### PR TITLE
Allow using text attr on card section

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Slim external link:
 **NOTE:** _the `actions`, `primaryFooterAction` and `secondaryFooterAction` properties are currently unimplemented._
 
 ###### Examples
+Each of `{{polaris-card}}` and `{{polaris-card/section}}` can be used in both inline or block form as described above, with the `text` attribute being used for their content when used inline. These examples will only show them in block form, since that is the most common use case.
 
 Basic usage:
 ```

--- a/addon/components/polaris-card/section.js
+++ b/addon/components/polaris-card/section.js
@@ -15,4 +15,5 @@ export default Component.extend({
 
   title: null,
   subdued: false,
+  text: null,
 });

--- a/addon/templates/components/polaris-card/section.hbs
+++ b/addon/templates/components/polaris-card/section.hbs
@@ -6,4 +6,8 @@
   </div>
 {{/if}}
 
-{{yield}}
+{{#if hasBlock}}
+  {{yield}}
+{{else}}
+  {{text}}
+{{/if}}


### PR DESCRIPTION
Quick little addition to let developers do this:

```
{{#polaris-card as |card|}}
  {{card.section text="whatever"}}
{{/polaris-card}}
```

instead of this:

```
{{#polaris-card as |card|}}
  {{#card.section}}
    whatever
  {{/card.section}}
{{/polaris-card}}
```