### PR TITLE
Remove fill attribute from SVG groups

### DIFF
--- a/addon/components/polaris-icon.js
+++ b/addon/components/polaris-icon.js
@@ -84,8 +84,9 @@ export default Component.extend({
   didInsertElement() {
     this._super(...arguments);
 
-    // The SVG path rendered seems to have a greyish fill applied by default
-    // which prevents the color attribute working. This works around that...
+    // Some of the Polaris SVG files have a greyish fill applied by default which
+    // prevents the color attribute working. These steps work around the known issues...
+    this.$('g').removeAttr('fill');
     this.$('path').css({
       fill: 'inherit'
     });


### PR DESCRIPTION
Some of the Polaris SVG files (e.g. the Checkbox's `checkmark` icon) have a `fill` attribute set on their wrapping `g` element which prevents the icon from inheriting its colour via styling. This quick fix removes that attribute to allow the icons to assume the intended colour.