### PR TITLE
Use didInsertElement instead of didRender for wrapping childs

### DIFF
--- a/addon/components/polaris-button-group.js
+++ b/addon/components/polaris-button-group.js
@@ -43,7 +43,7 @@ export default Component.extend({
   /**
    * Lifecycle hooks.
    */
-  didRender() {
+  didInsertElement() {
     this._super(...arguments);
 
     // Wrap each child element that isn't already a group item.

--- a/addon/components/polaris-form-layout.js
+++ b/addon/components/polaris-form-layout.js
@@ -29,7 +29,7 @@ const {
   /**
    * Lifecycle hooks.
    */
-  didRender() {
+  didInsertElement() {
     this._super(...arguments);
 
     // Wrap each child element that isn't already a group or an item.

--- a/addon/components/polaris-form-layout/group.js
+++ b/addon/components/polaris-form-layout/group.js
@@ -40,7 +40,7 @@ export default Component.extend({
    /**
     * Lifecycle hooks.
     */
-   didRender() {
+   didInsertElement() {
      this._super(...arguments);
 
      // Wrap each element that isn't already an item.

--- a/addon/components/polaris-stack.js
+++ b/addon/components/polaris-stack.js
@@ -108,7 +108,7 @@ const {
   /**
    * Lifecycle hooks.
    */
-  didRender() {
+  didInsertElement() {
     this._super(...arguments);
 
     // Wrap each child element that isn't already a stack item.

--- a/addon/components/polaris-subheading.js
+++ b/addon/components/polaris-subheading.js
@@ -50,7 +50,7 @@ export default Component.extend({
   /**
    * Lifecycle hooks.
    */
-  didRender() {
+  didInsertElement() {
     this._super(...arguments);
 
     // Update ariaLabel with the new content.


### PR DESCRIPTION
Using `didRender` is triggered on re-renders too, causing double-wrapping.
Run into this on admin while working on the forms.