### PR TITLE
Add support for disabled and destructive flags and icon on page secondary actions

### DIFF
--- a/addon/templates/components/polaris-page-actions.hbs
+++ b/addon/templates/components/polaris-page-actions.hbs
@@ -7,6 +7,9 @@
       {{#each secondaryActions as |secondaryAction|}}
         {{polaris-button
           text=secondaryAction.content
+          disabled=secondaryAction.disabled
+          destructive=secondaryAction.destructive
+          icon=secondaryAction.icon
           onClick=(action "fireAction" secondaryAction)
         }}
       {{/each}}


### PR DESCRIPTION
The Polaris `PageActions` component specifies that the `secondaryActions` are of type `ComplexAction`. This means they support `disabled`, `destructive` and `icon` properties, which are added in this PR.