### PR TITLE
Allow stack spacing of 'none'

### DIFF
--- a/addon/components/polaris-stack.js
+++ b/addon/components/polaris-stack.js
@@ -53,9 +53,9 @@ const {
    *
    * @property spacing
    * @type {enum}
-   * @default none
+   * @default null
    */
-  spacing: 'none',
+  spacing: null,
 
   /**
    * Adjust alignment of elements
@@ -80,7 +80,7 @@ const {
    */
   spacingClassName: computed('spacing', function() {
     const spacing = this.get('spacing');
-    if (isBlank(spacing) || spacing === 'none') {
+    if (isBlank(spacing)) {
       return null;
     }
 

--- a/tests/integration/components/polaris-stack-test.js
+++ b/tests/integration/components/polaris-stack-test.js
@@ -57,11 +57,14 @@ test('it renders the correct HTML with vertical attribute', function(assert) {
 });
 
 test('it renders the correct HTML with spacing attribute', function(assert) {
-  this.set('spacing', 'none');
+  this.set('spacing', null);
   this.render(hbs`{{polaris-stack spacing=spacing}}`);
 
   const stack = find(stackSelector);
-  assert.equal(stack.className.indexOf('Polaris-Stack--spacing'), -1, 'spacing=none - does not add any spacing class');
+  assert.equal(stack.className.indexOf('Polaris-Stack--spacing'), -1, 'spacing=null - does not add any spacing class');
+
+  this.set('spacing', 'none');
+  assert.ok(stack.classList.contains('Polaris-Stack--spacingNone'), 'spacing=none - adds the correct spacing class');
 
   this.set('spacing', 'loose');
   assert.ok(stack.classList.contains('Polaris-Stack--spacingLoose'), 'spacing=loose - adds the correct spacing class');


### PR DESCRIPTION
For some reason when I built the `polaris-stack` component I didn't allow the `spacing="none"` attribute to do its thing - this PR fixes that.