### PR TITLE
Remove focus from buttons on mouseup

### DIFF
--- a/addon/components/polaris-breadcrumbs/breadcrumb.js
+++ b/addon/components/polaris-breadcrumbs/breadcrumb.js
@@ -1,6 +1,7 @@
 import { computed } from '@ember/object';
 import { isArray } from '@ember/array';
 import LinkComponent from '@ember/routing/link-component';
+import { handleMouseUpByBlurring } from '../../utils/focus';
 import layout from '../../templates/components/polaris-breadcrumbs/breadcrumb';
 
 export default LinkComponent.extend({
@@ -27,4 +28,6 @@ export default LinkComponent.extend({
 
     return params;
   }).readOnly(),
+
+  mouseUp: handleMouseUpByBlurring,
 });

--- a/addon/components/polaris-button.js
+++ b/addon/components/polaris-button.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { isPresent, isBlank, isNone } from '@ember/utils';
+import { handleMouseUpByBlurring } from '../utils/focus';
 import layout from '../templates/components/polaris-button';
 
 /**
@@ -187,4 +188,6 @@ export default Component.extend({
   iconOnly: computed('icon', 'text', function() {
     return isBlank(this.get('text')) && isPresent(this.get('icon'));
   }).readOnly(),
+
+  handleMouseUpByBlurring,
 });

--- a/addon/components/polaris-button/button.js
+++ b/addon/components/polaris-button/button.js
@@ -5,7 +5,13 @@ export default BaseComponent.extend({
   tagName: 'button',
   attributeBindings: [
     'type',
+    'accessibilityLabel:aria-label',
+    'disabled',
   ],
+
+  accessibilityLabel: null,
+
+  disabled: null,
 
   type: computed('submit', function() {
     return this.get('submit') === true ? 'submit' : 'button';

--- a/addon/components/polaris-page/action.js
+++ b/addon/components/polaris-page/action.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import layout from '../../templates/components/polaris-page/action';
+import { handleMouseUpByBlurring } from '../../utils/focus';
 import mapEventToAction from '../../utils/map-event-to-action';
 
 export default Component.extend({
@@ -23,5 +24,6 @@ export default Component.extend({
   /*
    * Action handlers.
    */
+  mouseUp: handleMouseUpByBlurring,
   click: mapEventToAction('action.action'),
 });

--- a/addon/components/polaris-pagination.js
+++ b/addon/components/polaris-pagination.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import { not } from '@ember/object/computed';
+import { handleMouseUpByBlurring } from '../utils/focus';
 import layout from '../templates/components/polaris-pagination';
 
 export default Component.extend({
@@ -21,7 +22,7 @@ export default Component.extend({
   /**
    * The URL of the next page
    *
-   * @propety nextUrl
+   * @property nextUrl
    * @type {String}
    * @default null
    * TODO not implemented
@@ -31,7 +32,7 @@ export default Component.extend({
   /**
    * The URL of the previous page
    *
-   * @propety previousUrl
+   * @property previousUrl
    * @type {String}
    * @default null
    * TODO not implemented
@@ -76,4 +77,6 @@ export default Component.extend({
 
   isPreviousDisabled: not('hasPrevious').readOnly(),
   isNextDisabled: not('hasNext').readOnly(),
+
+  handleMouseUpByBlurring,
 });

--- a/addon/templates/components/polaris-button.hbs
+++ b/addon/templates/components/polaris-button.hbs
@@ -15,6 +15,7 @@
   onClick=onClick
   onFocus=onFocus
   onBlur=onBlur
+  mouseUp=handleMouseUpByBlurring
 }}
   <span class="Polaris-Button__Content">
     {{#if icon}}

--- a/addon/templates/components/polaris-pagination.hbs
+++ b/addon/templates/components/polaris-pagination.hbs
@@ -1,7 +1,19 @@
-<button class="Polaris-Pagination__Button" aria-label="Previous" disabled={{isPreviousDisabled}} {{action (action onPrevious)}}>
+{{#polaris-button/button
+  class="Polaris-Pagination__Button"
+  accessibilityLabel="Previous"
+  disabled=isPreviousDisabled
+  mouseUp=handleMouseUpByBlurring
+  onClick=(action onPrevious)
+}}
   {{polaris-icon source="arrow-left"}}
-</button>
+{{/polaris-button/button}}
 
-<button class="Polaris-Pagination__Button" aria-label="Next" disabled={{isNextDisabled}} {{action (action onNext)}}>
+{{#polaris-button/button
+  class="Polaris-Pagination__Button"
+  accessibilityLabel="Next"
+  disabled=isNextDisabled
+  mouseUp=handleMouseUpByBlurring
+  onClick=(action onNext)
+}}
   {{polaris-icon source="arrow-right"}}
-</button>
+{{/polaris-button/button}}

--- a/addon/utils/focus.js
+++ b/addon/utils/focus.js
@@ -1,0 +1,3 @@
+export function handleMouseUpByBlurring({ currentTarget }) {
+  currentTarget.blur();
+}

--- a/app/utils/focus.js
+++ b/app/utils/focus.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-polaris/utils/focus';

--- a/tests/integration/components/polaris-button-test.js
+++ b/tests/integration/components/polaris-button-test.js
@@ -273,6 +273,9 @@ test('handles events correctly', function(assert) {
   })
   .then(() => {
     assert.ok(clickHandlerCalled, 'after click, click handler fired');
+
+    const focussedButton = find(`${ buttonSelector }:focus`);
+    assert.notOk(focussedButton, 'after click, button is not focussed');
   });
 });
 

--- a/tests/integration/components/polaris-page-test.js
+++ b/tests/integration/components/polaris-page-test.js
@@ -157,8 +157,12 @@ test('it handles secondary actions correctly when supplied', function(assert) {
   assert.ok(secondaryAction1Fired, 'first secondary action - fired after clicking button');
   assert.notOk(secondaryAction2Fired, 'second secondary action - not fired after clicking first button');
 
+  const focussedSecondaryButtonSelector = `${ secondaryActionsButtonSelector }:focus`;
+  assert.notOk(find(focussedSecondaryButtonSelector), 'no focussed buttons after clicking first secondary action');
+
   click('button:last-child', secondaryActionsWrapperSelector);
   assert.ok(secondaryAction2Fired, 'second secondary action - fired after clicking button');
+  assert.notOk(find(focussedSecondaryButtonSelector), 'no focussed buttons after clicking second secondary action');
 });
 
 test('it renders action icons correctly', function(assert) {

--- a/tests/integration/components/polaris-pagination-test.js
+++ b/tests/integration/components/polaris-pagination-test.js
@@ -47,23 +47,32 @@ test('it renders correctly', function(assert) {
  });
 
 test('it fires events correctly', function(assert) {
-  assert.expect(2);
+  assert.expect(5);
 
-  // TODO should we test explicitly these actions
-  this.on('clickPrevious', () => {
-    assert.ok(true, 'clicking previous button fires `onPrevious` callback');
-  });
-  this.on('clickNext', () => {
-    assert.ok(true, 'clicking next button fires `onNext` callback');
+  this.setProperties({
+    previousClicked: false,
+    nextClicked: false,
   });
 
   this.render(hbs`{{polaris-pagination
     hasPrevious=true
     hasNext=true
-    onPrevious=(action "clickPrevious")
-    onNext=(action "clickNext")
+    onPrevious=(action (mut previousClicked) true)
+    onNext=(action (mut nextClicked) true)
   }}`);
 
-  click('button[aria-label="Previous"]');
-  click('button[aria-label="Next"]');
+  const previousButtonSelector = 'button[aria-label="Previous"]';
+  click(previousButtonSelector);
+  assert.ok(this.get('previousClicked'), 'clicking previous button fires `onPrevious` callback');
+  assert.notOk(this.get('nextClicked'), 'clicking previous button does not fire `onNext` callback');
+
+  let focussedButton = find(`${ previousButtonSelector }:focus`);
+  assert.notOk(focussedButton, 'after clicking previous button, button is not focussed');
+
+  const nextButtonSelector = 'button[aria-label="Next"]';
+  click(nextButtonSelector);
+  assert.ok(this.get('nextClicked'), 'clicking next button fires `onNext` callback');
+
+  focussedButton = find(`${ nextButtonSelector }:focus`);
+  assert.notOk(focussedButton, 'after clicking next button, button is not focussed');
 });

--- a/tests/unit/utils/focus-test.js
+++ b/tests/unit/utils/focus-test.js
@@ -1,0 +1,19 @@
+import focus from 'dummy/utils/focus';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | focus');
+
+test('handleMouseUpByBlurring calls blur on the passed in event\'s currentTarget', function(assert) {
+  let blurCalled = false;
+  let mockEvent = {
+    currentTarget: {
+      blur() {
+        blurCalled = true;
+      }
+    }
+  };
+
+  focus.handleMouseUpByBlurring(mockEvent);
+
+  assert.ok(blurCalled, 'blur called on event\'s currentTarget');
+});


### PR DESCRIPTION
A number of Polaris React components (breadcrumbs, button, page header secondary actions, pagination, tab and tag) remove focus from themselves on mouseup, which makes the appearance look better in a number of use cases. This PR adds that behaviour to the Ember implementations we currently have in the addon.

Some before/after examples:
Buttons (before):
![remove-focus-buttons-before](https://user-images.githubusercontent.com/5737342/32830239-365be05a-c9fd-11e7-9767-1bff1d0322a8.gif)

Buttons (after):
![remove-focus-buttons-after](https://user-images.githubusercontent.com/5737342/32830258-432a6f90-c9fd-11e7-948d-128b4c79d673.gif)

Page secondary actions (before):
![remove-focus-page-secondary-actions-before](https://user-images.githubusercontent.com/5737342/32830291-586264c6-c9fd-11e7-86a2-d21f0acf316b.gif)

Page secondary actions (after):
![remove-focus-page-secondary-actions-after](https://user-images.githubusercontent.com/5737342/32830290-5839a8ba-c9fd-11e7-9f02-08079ea337d2.gif)

Pagination controls (before):
![remove-focus-pagination-before](https://user-images.githubusercontent.com/5737342/32830307-694cdcc6-c9fd-11e7-9927-e08194366968.gif)

Pagination controls (after):
![remove-focus-pagination-after](https://user-images.githubusercontent.com/5737342/32830306-69243dac-c9fd-11e7-8737-489a96cefdf4.gif)
