### PR TITLE
Use default z-index for positioned overlay

### DIFF
--- a/app/styles/components/polaris-popover.scss
+++ b/app/styles/components/polaris-popover.scss
@@ -1,6 +1,5 @@
 .Polaris-PositionedOverlay {
   &.ember-basic-dropdown-content {
     background: transparent;
-    z-index: 2147483647;
   }
 }


### PR DESCRIPTION
Remove massively high `z-index` override for Polaris positioned overlay