### PR TITLE
Update color picker component to match v1.10.2

### DIFF
--- a/addon/components/polaris-color-picker.js
+++ b/addon/components/polaris-color-picker.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { typeOf } from '@ember/utils';
+import { typeOf, isNone } from '@ember/utils';
 import { htmlSafe } from '@ember/string';
 import layout from '../templates/components/polaris-color-picker';
 import { clamp } from '../utils/math';
@@ -80,6 +80,10 @@ export default Component.extend({
 
     // Grab the size of the picker for positioning the draggable markers.
     const mainColorElement = this.$('div.Polaris-ColorPicker__MainColor')[0];
+    if (isNone(mainColorElement)) {
+      return;
+    }
+
     this.set('pickerSize', mainColorElement.clientWidth);
   },
 

--- a/addon/components/polaris-color-picker/slidable.js
+++ b/addon/components/polaris-color-picker/slidable.js
@@ -131,6 +131,9 @@ export default Component.extend({
     if (typeOf(onDraggerHeightChanged) === 'function') {
       // Publish the height of our dragger.
       const draggerElement = this.$('div.Polaris-ColorPicker__Dragger')[0];
+      if (isNone(draggerElement)) {
+        return;
+      }
 
       // Yes, for some strange reason this is width not height in the shopify code...
       onDraggerHeightChanged(draggerElement.clientWidth);

--- a/addon/utils/color.js
+++ b/addon/utils/color.js
@@ -97,8 +97,8 @@ export function rgbaToHsb(color) {
   let huePercentage = 0;
   switch (largestComponent) {
     case r:
-      huePercentage = (g - b) / delta % 6;
-     break;
+      huePercentage = (g - b) / delta + (g < b ? 6 : 0);
+      break;
     case g:
       huePercentage = (b - r) / delta + 2;
       break;


### PR DESCRIPTION
Brings `polaris-color-picker` and a couple of dependent files in line with the latest Polaris release. Basically adds a couple of `null` checks before using elements, and tweaks the hue calculation in the RGBA to HSB utility function (all updates that appeared in Shopify's Polaris source after we built `polaris-color-picker`).