### PR TITLE
Update link component to match v1.10.2

### DIFF
--- a/addon/components/polaris-unstyled-link.js
+++ b/addon/components/polaris-unstyled-link.js
@@ -1,6 +1,7 @@
 import { computed } from '@ember/object';
 import Component from '@ember/component';
 import layout from '../templates/components/polaris-unstyled-link';
+import mapEventToAction from '../utils/map-event-to-action';
 
 export default Component.extend({
   tagName: 'a',
@@ -43,6 +44,15 @@ export default Component.extend({
    */
   external: false,
 
+  /**
+   * Callback when a link is clicked
+   *
+   * @property onClick
+   * @type {function}
+   * @default noop
+   */
+  onClick() {},
+
   /*
    * Internal properties.
    */
@@ -59,8 +69,5 @@ export default Component.extend({
   /**
    * Action handlers.
    */
-  click(event) {
-    //  Allow clicking the link to perform its default action without bubbling.
-    event.stopPropagation();
-  },
+  click: mapEventToAction('onClick', { preventDefault: false, stopPropagation: true }),
 });

--- a/addon/templates/components/polaris-link.hbs
+++ b/addon/templates/components/polaris-link.hbs
@@ -3,6 +3,7 @@
     url=url
     class=linkClass
     external=external
+    onClick=(action onClick)
   }}
     {{#if hasBlock}}
       {{yield}}

--- a/addon/utils/map-event-to-action.js
+++ b/addon/utils/map-event-to-action.js
@@ -1,9 +1,20 @@
 import { invokeAction } from 'ember-invoke-action';
+import { assign } from '@ember/polyfills';
 
-export default function mapEventToAction(actionName, options = { preventDefault: true }, ...args) {
+const defaultOptions = {
+  preventDefault: true,
+  stopPropagation: false,
+};
+
+export default function mapEventToAction(actionName, options, ...args) {
+  options = assign({}, defaultOptions, options);
   return function(event) {
     if (options.preventDefault) {
       event.preventDefault();
+    }
+
+    if (options.stopPropagation) {
+      event.stopPropagation();
     }
 
     return invokeAction(this, actionName, ...args);

--- a/tests/integration/components/polaris-link-test.js
+++ b/tests/integration/components/polaris-link-test.js
@@ -120,6 +120,34 @@ test('clicking a link navigates but does not bubble to the parent', function(ass
   assert.notOk(parentHandlerCalled, 'parent click handler is not fired');
 });
 
+test('clicking a link fires the onClick handler if present', function(assert) {
+  // Reset the hash part of the browser URL to keep this test valid on reruns.
+  window.location.hash = 'linkNotClicked';
+
+  this.set('clickHandlerCalled', false);
+  let parentHandlerCalled = false;
+  this.on('parentClicked', () => {
+    parentHandlerCalled = true;
+  });
+
+  this.render(hbs`
+    <div {{action (action "parentClicked")}}>
+      {{polaris-link
+        url="#linkClicked"
+        onClick=(action (mut clickHandlerCalled) true)
+      }}
+    </div>
+  `);
+
+  const links = findAll(linkSelector);
+  assert.equal(links.length, 1, 'renders one link');
+
+  click(linkSelector);
+  assert.equal(location.hash, '#linkClicked', 'app navigates to specified URL');
+  assert.ok(this.get('clickHandlerCalled'), 'link click handler is fired');
+  assert.notOk(parentHandlerCalled, 'parent click handler is not fired');
+});
+
 test('clicking a link button performs the button action but does not bubble to the parent', function(assert) {
   let parentHandlerCalled = false;
   this.on('parentClicked', () => {


### PR DESCRIPTION
Brings `polaris-link` in line with the latest Polaris release by adding `onClick` handling to it.