### PR TITLE
Update text container component to match v1.10.2

### DIFF
--- a/addon/components/polaris-text-container.js
+++ b/addon/components/polaris-text-container.js
@@ -1,11 +1,19 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { classify } from '@ember/string';
 import layout from '../templates/components/polaris-text-container';
+
+const allowedSpacings = [
+  'tight',
+  'loose'
+];
 
 /**
  * Undocumented Polaris text container component.
  */
 export default Component.extend({
   classNames: ['Polaris-TextContainer'],
+  classNameBindings: ['spacingClass'],
 
   layout,
 
@@ -24,4 +32,25 @@ export default Component.extend({
    * @default null
    */
   text: null,
+
+  /**
+   * The amount of vertical spacing children will get between them.
+   *
+   * @property spacing
+   * @type {string}
+   * @default null
+   */
+  spacing: null,
+
+  /*
+   * Internal properties.
+   */
+  spacingClass: computed('spacing', function() {
+    let spacing = this.get('spacing');
+    if (allowedSpacings.indexOf(spacing) > -1) {
+      return `Polaris-TextContainer--spacing${ classify(spacing) }`;
+    }
+
+    return null;
+  }).readOnly(),
 });

--- a/tests/integration/components/polaris-text-container-test.js
+++ b/tests/integration/components/polaris-text-container-test.js
@@ -23,3 +23,26 @@ test('it renders the correct HTML in block form', function(assert) {
   assert.equal(textContainers.length, 1, 'renders one text container');
   assert.equal(textContainers[0].textContent.trim(), 'This is some block text', 'renders the correct content');
 });
+
+test('it handles spacing correctly', function(assert) {
+  this.render(hbs`{{polaris-text-container spacing=spacing}}`);
+
+  const textContainers = findAll(textContainerSelector);
+  assert.equal(textContainers.length, 1, 'renders one text container');
+
+  const textContainer = textContainers[0];
+  assert.notOk(textContainer.classList.contains('Polaris-TextContainer--spacingLoose'), 'unset spacing - does not apply loose spacing class');
+  assert.notOk(textContainer.classList.contains('Polaris-TextContainer--spacingTight'), 'unset spacing - does not apply tight spacing class');
+
+  this.set('spacing', 'loose');
+  assert.ok(textContainer.classList.contains('Polaris-TextContainer--spacingLoose'), 'loose spacing - applies loose spacing class');
+  assert.notOk(textContainer.classList.contains('Polaris-TextContainer--spacingTight'), 'loose spacing - does not apply tight spacing class');
+
+  this.set('spacing', 'tight');
+  assert.notOk(textContainer.classList.contains('Polaris-TextContainer--spacingLoose'), 'tight spacing - does not apply loose spacing class');
+  assert.ok(textContainer.classList.contains('Polaris-TextContainer--spacingTight'), 'tight spacing - applies tight spacing class');
+
+  this.set('spacing', 'unsupported');
+  assert.notOk(textContainer.classList.contains('Polaris-TextContainer--spacingLoose'), 'unsupported spacing - does not apply loose spacing class');
+  assert.notOk(textContainer.classList.contains('Polaris-TextContainer--spacingTight'), 'unsupported spacing - does not apply tight spacing class');
+});


### PR DESCRIPTION
Adds support for the `spacing` property that controls the top margin between elements inside a `polaris-text-container`.