### PR TITLE
Add titleHidden support to polaris-page

### DIFF
--- a/addon/components/polaris-page.js
+++ b/addon/components/polaris-page.js
@@ -26,6 +26,16 @@ export default Component.extend({
   title: null,
 
   /**
+   * Visually hide the title
+   *
+   * @property titleHidden
+   * @public
+   * @type {boolean}
+   * @default false
+   */
+  titleHidden: false,
+
+  /**
    * App icon, for pages that are part of Shopify apps
    *
    * @property icon

--- a/addon/components/polaris-page/header.js
+++ b/addon/components/polaris-page/header.js
@@ -5,6 +5,7 @@ import { gt, or } from '@ember/object/computed';
 export default Component.extend({
   classNames: [ 'Polaris-Page__Header' ],
   classNameBindings: [
+    'titleHidden:Polaris-Page__Title--hidden',
     'hasBreadcrumbs:Polaris-Page__Header--hasBreadcrumbs',
     'hasRollup:Polaris-Page__Header--hasRollup',
     'separator:Polaris-Page__Header--hasSeparator',
@@ -22,6 +23,16 @@ export default Component.extend({
    * @default null
    */
   title: null,
+
+  /**
+   * Visually hide the title
+   *
+   * @property titleHidden
+   * @public
+   * @type {boolean}
+   * @default false
+   */
+  titleHidden: false,
 
   /**
    * App icon, for pages that are part of Shopify apps

--- a/addon/templates/components/polaris-page.hbs
+++ b/addon/templates/components/polaris-page.hbs
@@ -1,6 +1,7 @@
 {{#if hasHeaderContent}}
   {{polaris-page/header
     title=title
+    titleHidden=titleHidden
     icon=icon
     breadcrumbs=breadcrumbs
     separator=separator

--- a/tests/integration/components/polaris-page-test.js
+++ b/tests/integration/components/polaris-page-test.js
@@ -34,6 +34,7 @@ test('it renders the page correctly', function(assert) {
       title="This is the title"
       fullWidth=fullWidth
       singleColumn=singleColumn
+      titleHidden=titleHidden
     }}
       <div class="test-page-content">This is some test content</div>
     {{/polaris-page}}`
@@ -71,11 +72,18 @@ test('it renders the page correctly', function(assert) {
   const contentText = contents[0].textContent.trim();
   assert.equal(contentText, 'This is some test content', 'renders correct content');
 
+  assert.notOk(page.classList.contains('Polaris-Page--fullWidth'), 'fullWidth unset - does not apply fullWidth class');
   this.set('fullWidth', true);
-  assert.ok(page.classList.contains('Polaris-Page--fullWidth'), 'honours fullWidth flag');
+  assert.ok(page.classList.contains('Polaris-Page--fullWidth'), 'fullWidth set - applies fullWidth class');
 
+  assert.notOk(page.classList.contains('Polaris-Page--singleColumn'), 'singleColumn unset - does not apply singleColumn class');
   this.set('singleColumn', true);
-  assert.ok(page.classList.contains('Polaris-Page--singleColumn'), 'honours singleColumn flag');
+  assert.ok(page.classList.contains('Polaris-Page--singleColumn'), 'singleColumn set - applies singleColumn class');
+
+  let header = headers[0];
+  assert.notOk(header.classList.contains('Polaris-Page__Title--hidden'), 'titleHidden unset - does not apply titleHidden class');
+  this.set('titleHidden', true);
+  assert.ok(header.classList.contains('Polaris-Page__Title--hidden'), 'titleHidden set - applies titleHidden class');
 });
 
 test('it handles primary action correctly when supplied', function(assert) {


### PR DESCRIPTION
Adds the `titleHidden` behaviour introduced in Polaris v1.12.0.