### PR TITLE
Update polaris-badge status attribute to match Polaris

### DIFF
--- a/addon/components/polaris-badge.js
+++ b/addon/components/polaris-badge.js
@@ -11,6 +11,13 @@ const PROGRESS_LABELS = {
   complete: 'Complete',
 };
 
+const STATUS_LABELS = {
+  info: 'Info',
+  success: 'Success',
+  warning: 'Warning',
+  attention: 'Attention',
+};
+
 /**
  * Polaris badge component.
  * See https://polaris.shopify.com/components/images-and-icons/badge
@@ -86,15 +93,15 @@ export default Component.extend({
       return null;
     }
 
-    return classify(status);
+    return STATUS_LABELS[status];
   }).readOnly(),
 
-  statusClass: computed('statusDescription', function() {
-    const statusDescription = this.get('statusDescription');
-    if (isBlank(statusDescription)) {
+  statusClass: computed('status', function() {
+    const status = this.get('status');
+    if (isBlank(status) || status === 'default') {
       return null;
     }
 
-    return `Polaris-Badge--status${statusDescription}`;
+    return `Polaris-Badge--status${classify(status)}`;
   }).readOnly()
 });

--- a/addon/templates/components/polaris-badge.hbs
+++ b/addon/templates/components/polaris-badge.hbs
@@ -1,7 +1,5 @@
-{{#if hasStatus}}
-  {{#polaris-visually-hidden}}
-    {{statusDescription}}
-  {{/polaris-visually-hidden}}
+{{#if statusDescription}}
+  {{polaris-visually-hidden text=statusDescription}}
 {{/if}}
 
 {{#if progressDescription}}

--- a/tests/integration/components/polaris-badge-test.js
+++ b/tests/integration/components/polaris-badge-test.js
@@ -55,8 +55,7 @@ test('it renders the correct HTML when status is set', function(assert) {
   assert.equal(badge.className.indexOf('Polaris-Badge--status'), -1, 'status set to default - does not apply status classes');
 
   visuallyHiddenComponents = findAll(visuallyHiddenSelector);
-  assert.equal(visuallyHiddenComponents.length, 1, 'status set to default - renders one visually hidden component');
-  assert.equal(visuallyHiddenComponents[0].textContent.trim(), '', 'status set to default - renders correct visually hidden content');
+  assert.equal(visuallyHiddenComponents.length, 0, 'status not set - does not render any visually hidden components');
 
   // With status set to success:
   //  - should apply success status class


### PR DESCRIPTION
## Overview

The `status` attribute of `polaris-badge` did not exactly match what [Shopify's implementation](https://polaris.shopify.com/components/images-and-icons/badge) does.

Behavior Changes:

- A `status=default` value will _no longer_ render a `polaris-visually-hidden` component.

Notable Codez Changes:

- Using lookup tables to find the label values, since other badge attributes (for example, `progress`) have values that differ from their keys, so `classify(key)` will not always work for everything.