### PR TITLE
Add missing class name on `polaris-action-list` section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ember-polaris Changelog
 
+### v1.3.2 (May 14, 2018)
+
+- [#119](https://github.com/smile-io/ember-polaris/pull/119) [FIX] Add missing class to polaris-action-list section.
+
 ### v1.3.0 (April 24, 2018)
 
 - [#117](https://github.com/smile-io/ember-polaris/pull/117) [FEATURE] Add `preferredPosition` attribute to polaris-popover.

--- a/addon/templates/components/polaris-action-list/section.hbs
+++ b/addon/templates/components/polaris-action-list/section.hbs
@@ -1,4 +1,7 @@
-{{#wrapper-element tagName=(if hasMultipleSections "li" "")}}
+{{#wrapper-element
+  tagName=(if hasMultipleSections "li" "")
+  class=(if hasMultipleSections "Polaris-ActionList__Section" "")
+}}
   <div class={{unless section.title "Polaris-ActionList__Section--withoutTitle"}}>
     {{#if section.title}}
       <p class="Polaris-ActionList__Title">

--- a/tests/integration/components/polaris-action-list-test.js
+++ b/tests/integration/components/polaris-action-list-test.js
@@ -217,30 +217,30 @@ test('it handles the "any item" action correctly', function(assert) {
 });
 
 test('it renders the correct HTML when using sections', function(assert) {
+  this.set('sections', [
+    {
+      title: 'Section 2',
+      items: [
+        {
+          text: 'Section 2 item 1',
+          icon: 'notes',
+        }, {
+          text: 'Section 2 item 2',
+        }
+      ]
+    }, {
+      items: [
+        {
+          text: 'Section 3 item',
+        }
+      ]
+    }
+  ]);
+
   this.render(hbs`
     {{polaris-action-list
       items=items
-      sections=(array
-        (hash
-          title="Section 2"
-          items=(array
-            (hash
-              text="Section 2 item 1"
-              icon="notes"
-            )
-            (hash
-              text="Section 2 item 2"
-            )
-          )
-        )
-        (hash
-          items=(array
-            (hash
-              text="Section 3 item"
-            )
-          )
-        )
-      )
+      sections=sections
     }}
   `);
 

--- a/tests/integration/components/polaris-action-list-test.js
+++ b/tests/integration/components/polaris-action-list-test.js
@@ -43,7 +43,7 @@ const actionListItemContentTextSelector = buildNestedSelector(
 const sectionedActionListSelector = 'ul.Polaris-ActionList';
 const sectionedActionListSectionSelector = buildNestedSelector(
   sectionedActionListSelector,
-  'li',
+  'li.Polaris-ActionList__Section',
   'div'
 );
 const actionListSectionTitleSelector = 'p.Polaris-ActionList__Title';


### PR DESCRIPTION
Just noticed that we had a missing class on one of the elements in `polaris-action-list` which was breaking some styling.