### PR TITLE
Fix focused button group item z-index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ember-polaris Changelog
 
+### v1.3.2 (May 14, 2018)
+
+- [#121](https://github.com/smile-io/ember-polaris/pull/121) [FIX] Fix z-index of focused `polaris-button-group` items to prevent border rendering bug.
+
 ### v1.3.0 (April 24, 2018)
 
 - [#117](https://github.com/smile-io/ember-polaris/pull/117) [FEATURE] Add `preferredPosition` attribute to polaris-popover.

--- a/addon/components/polaris-button-group/item.js
+++ b/addon/components/polaris-button-group/item.js
@@ -3,17 +3,18 @@ import layout from '../../templates/components/polaris-button-group/item';
 
 export default Component.extend({
   classNames: ['Polaris-ButtonGroup__Item'],
-  classNameBindings: ['plain:Polaris-ButtonGroup__Item--plain'],
+  classNameBindings: [
+    'plain:Polaris-ButtonGroup__Item--plain',
+    'focused:Polaris-ButtonGroup__Item--focused'
+  ],
 
   layout,
 
-  /*
-   * Public attributes.
-   */
   /**
    * Elements to display inside group item
    *
    * @property text
+   * @public
    * @type {string}
    * @default null
    */
@@ -23,8 +24,30 @@ export default Component.extend({
    * Use a plain style for the group item
    *
    * @property plain
+   * @public
    * @type {boolean}
    * @default false
    */
   plain: false,
+
+  /**
+   * Whether the group item is focused
+   *
+   * @property focused
+   * @private
+   * @type {boolean}
+   * @default false
+   */
+  focused: false,
+
+  /**
+   * Events.
+   */
+  focusIn() {
+    this.set('focused', true);
+  },
+
+  focusOut() {
+    this.set('focused', false);
+  },
 });

--- a/docs/button-group.md
+++ b/docs/button-group.md
@@ -17,12 +17,17 @@ Basic usage:
 {{/polaris-button-group}}
 ```
 
-Buttons joined as segmented group:
+Buttons joined as segmented group (*N.B.* when using segmented button groups, you must explicitly add group item wrappers around each item to handle focused styling correctly):
 
 ```hbs
-{{#polaris-button-group segmented=true}}
-  {{polaris-button text="Button 1" onClick=(action "doSomething")}}
-  {{polaris-button text="Button 2" onClick=(action (mut button2Clicked) true)}}
+{{#polaris-button-group segmented=true as |group|}}
+  {{#group.item}}
+    {{polaris-button text="Button 1" onClick=(action "doSomething")}}
+  {{/group.item}}
+
+  {{#group.item}}
+    {{polaris-button text="Button 2" onClick=(action (mut button2Clicked) true)}}
+  {{/group.item}}
 {{/polaris-button-group}}
 ```
 

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,13 +1,35 @@
 {{#polaris-page
   title="This is the application route"
+  primaryAction=(hash
+    text="Primary"
+    onAction=(action (mut primaryClicked) true)
+  )
+  secondaryActions=(array
+    (hash
+      text="Secondary 1"
+      onAction=(action (mut secondary1Clicked) true)
+    )
+    (hash
+      text="Secondary 2"
+      onAction=(action (mut secondary2Clicked) true)
+    )
+  )
 }}
-  {{#polaris-button-group segmented=true as |buttonGroup|}}
-    {{#buttonGroup.item}}
-      {{polaris-button text="Button 1"}}
-    {{/buttonGroup.item}}
+  <div>
+    {{#link-to "test"}}
+      Go to test route
+    {{/link-to}}
+  </div>
 
-    {{#buttonGroup.item}}
-      {{polaris-button text="Button 2"}}
-    {{/buttonGroup.item}}
-  {{/polaris-button-group}}
+  <div>
+    {{#link-to "test.child"}}
+      Go to child route
+    {{/link-to}}
+  </div>
+
+  {{polaris-link
+    url="https://github.com/smile-io/ember-polaris"
+    external=true
+    text="Ember Polaris on GitHub"
+  }}
 {{/polaris-page}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,45 +1,13 @@
 {{#polaris-page
   title="This is the application route"
-  primaryAction=(hash
-    text="Primary"
-    action=(action (mut primaryClicked) true)
-  )
-  secondaryActions=(array
-    (hash
-      text="Secondary 1"
-      action=(action (mut secondary1Clicked) true)
-    )
-    (hash
-      text="Secondary 2"
-      action=(action (mut secondary2Clicked) true)
-    )
-  )
 }}
-  {{polaris-color-picker
-    color=color
-    allowAlpha=true
-    onChange=(action (mut color))
-  }}
-  <div>Hue: {{color.hue}}</div>
-  <div>Saturation: {{color.saturation}}</div>
-  <div>Brightness: {{color.brightness}}</div>
-  <div>Alpha: {{color.alpha}}</div>
-  <hr>
-  <div>
-    {{#link-to "test"}}
-      Go to test route
-    {{/link-to}}
-  </div>
+  {{#polaris-button-group segmented=true as |buttonGroup|}}
+    {{#buttonGroup.item}}
+      {{polaris-button text="Button 1"}}
+    {{/buttonGroup.item}}
 
-  <div>
-    {{#link-to "test.child"}}
-      Go to child route
-    {{/link-to}}
-  </div>
-
-  {{polaris-link
-    url="https://github.com/smile-io/ember-polaris"
-    external=true
-    text="Ember Polaris on GitHub"
-  }}
+    {{#buttonGroup.item}}
+      {{polaris-button text="Button 2"}}
+    {{/buttonGroup.item}}
+  {{/polaris-button-group}}
 {{/polaris-page}}

--- a/tests/integration/components/polaris-button-group-test.js
+++ b/tests/integration/components/polaris-button-group-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { findAll, find } from 'ember-native-dom-helpers';
+import { findAll, find, focus, blur } from 'ember-native-dom-helpers';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
 moduleForComponent('polaris-button-group', 'Integration | Component | polaris button group', {
@@ -73,4 +73,25 @@ test('it renders the correct HTML in block usage', function(assert) {
   buttonGroupItem = buttonGroupItems[2];
   assert.notOk(buttonGroupItem.classList.contains('Polaris-ButtonGroup__Item--plain'), 'third group item - does not have plain class');
   assert.equal(buttonGroupItem.textContent.trim(), 'Magically wrapped button', 'third group item - renders the correct content');
+});
+
+test('it handles focused buttons correctly', function(assert) {
+  this.render(hbs`
+    {{#polaris-button-group as |buttonGroup|}}
+      {{#buttonGroup.item}}
+        {{polaris-button text="Focus me please!"}}
+      {{/buttonGroup.item}}
+    {{/polaris-button-group}}
+  `);
+
+  const buttonGroupItem = find(buttonGroupItemSelector);
+  assert.ok(buttonGroupItem, 'renders the button group item');
+
+  assert.notOk(buttonGroupItem.classList.contains('Polaris-ButtonGroup__Item--focused'), 'before focus - group item does not have focused class');
+
+  focus('.Polaris-Button');
+  assert.ok(buttonGroupItem.classList.contains('Polaris-ButtonGroup__Item--focused'), 'after focus - group item has focused class');
+
+  blur('.Polaris-Button');
+  assert.notOk(buttonGroupItem.classList.contains('Polaris-ButtonGroup__Item--focused'), 'after blur - group item does not have focused class');
 });


### PR DESCRIPTION
Fixes #120:

![button-group-focus](https://user-images.githubusercontent.com/5737342/39910752-5ff8c722-5501-11e8-8399-00473b8d824a.gif)

Found that the reason I couldn't get this working yesterday was that when the code doesn't explicitly add the item wrapper component around each button in the group, we can't handle the focus/blur events on the [auto-added wrapper `div`s](https://github.com/smile-io/ember-polaris/blob/b91554f944ac2c3a44815de50571c7e30bf0f213/addon/components/polaris-button-group.js#L48). Once the user explicitly adds the item wrapper component around each button, this works fine; I've added a note to the documentation about this.

I guess we could also hack something together on the auto-wrapper system to handle focus/blur on the wrapper `div`s, but that'd be pretty dirty and probs not worth doing...