### PR TITLE
Update polaris-icon to v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ember-polaris Changelog
 
+### Unreleased
+- [#123](https://github.com/smile-io/ember-polaris/pull/123) [UPDATE] Add new `isColored` class, `aria-hidden` and `focusable` attributes to polaris-icon.
+
 ### v1.3.0 (April 24, 2018)
 
 - [#117](https://github.com/smile-io/ember-polaris/pull/117) [FEATURE] Add `preferredPosition` attribute to polaris-popover.

--- a/addon/components/polaris-icon.js
+++ b/addon/components/polaris-icon.js
@@ -11,6 +11,7 @@ export default Component.extend({
   classNames: ['Polaris-Icon'],
   classNameBindings: [
     'colorClass',
+    'isColored:Polaris-Icon--isColored',
     'backdrop:Polaris-Icon--hasBackdrop'
   ],
   attributeBindings: [
@@ -19,15 +20,13 @@ export default Component.extend({
 
   layout,
 
-  /*
-   * Public attributes.
-   */
   /**
    * The SVG contents to display in the icon
    * If the source doesn't have a slash in the name, it will look for Polaris
    * icons in the namespace specified by `sourcePath` property.
    *
    * @property source
+   * @public
    * @type {string}
    * @default null
    */
@@ -37,6 +36,7 @@ export default Component.extend({
    * Sets the color for the SVG fill
    *
    * @property color
+   * @public
    * @type {string}
    * @default null
    */
@@ -46,6 +46,7 @@ export default Component.extend({
    * Show a backdrop behind the icon
    *
    * @property backdrop
+   * @public
    * @type {boolean}
    * @default false
    */
@@ -55,6 +56,7 @@ export default Component.extend({
    * Descriptive text to be read to screenreaders
    *
    * @property accessibilityLabel
+   * @public
    * @type {string}
    * @default null
    */
@@ -62,16 +64,32 @@ export default Component.extend({
 
   /**
    * Path under which `ember-svg-jar` serves the Polaris SVG icons
+   *
+   * @property sourcePath
+   * @public
+   * @type {string}
+   * @default 'polaris'
    */
   sourcePath: 'polaris',
 
-  /*
-   * Internal properties.
+  /**
+   * Whether the component should leave space for an icon
+   *
+   * @property showPlaceholder
+   * @private
+   * @type {boolean}
    */
   showPlaceholder: equal('source', 'placeholder').readOnly(),
 
+  /**
+   * Class to apply to color the icon
+   *
+   * @property colorClass
+   * @private
+   * @type {string}
+   */
   colorClass: computed('color', function() {
-    const color = this.get('color');
+    let color = this.get('color');
 
     if (isEmpty(color)) {
       return null;
@@ -80,6 +98,30 @@ export default Component.extend({
     return `Polaris-Icon--color${classify(color)}`;
   }).readOnly(),
 
+  /**
+   * Whether a color has been specified for the icon
+   *
+   * @property isColored
+   * @private
+   * @type {boolean}
+   */
+  isColored: computed('color', function() {
+    let color = this.get('color');
+
+    if (isEmpty(color)) {
+      return false;
+    }
+
+    return color !== 'white';
+  }).readOnly(),
+
+  /**
+   * Final source for the icon SVG
+   *
+   * @property iconSource
+   * @private
+   * @type {string}
+   */
   iconSource: computed('sourcePath', 'source', function() {
     let source = this.get('source');
     source = source.indexOf('/') === -1 ? `${ this.get('sourcePath') }/${ source }` : source;

--- a/addon/templates/components/polaris-icon.hbs
+++ b/addon/templates/components/polaris-icon.hbs
@@ -1,5 +1,10 @@
 {{#if showPlaceholder}}
   <div class="Polaris-Icon__Placeholder"></div>
 {{else}}
-  {{svg-jar iconSource class="Polaris-Icon__Svg"}}
+  {{svg-jar
+    iconSource
+    class="Polaris-Icon__Svg"
+    focusable="false"
+    aria-hidden="true"
+  }}
 {{/if}}

--- a/tests/integration/components/polaris-icon-test.js
+++ b/tests/integration/components/polaris-icon-test.js
@@ -64,7 +64,9 @@ test('it applies colors correctly', function(assert) {
     const colorClass = `Polaris-Icon--color${classify(color)}`;
     assert.ok(icon.classList.contains(colorClass), `icon with ${color} color applies ${colorClass} class`);
 
-    const colorClassNames = [...icon.classList].filter((className) => className.indexOf('Polaris-Icon--color') === 0);
+    const colorClassNames = [...icon.classList].filter((className) => {
+      return className.indexOf('Polaris-Icon--color') === 0;
+    });
     assert.equal(colorClassNames.length, 1, `icon with ${color} color does not add other color classes`);
 
     if (color === 'white') {

--- a/tests/integration/components/polaris-icon-test.js
+++ b/tests/integration/components/polaris-icon-test.js
@@ -24,7 +24,11 @@ test('it renders the specified icon correctly', function(assert) {
   const svgSelector = buildNestedSelector(iconSelector, 'svg.Polaris-Icon__Svg');
   const svgs = findAll(svgSelector);
   assert.equal(svgs.length, 1, 'renders one SVG element');
-  assert.equal(svgs[0].dataset.iconSource, 'polaris/notes', 'uses the correct SVG source');
+
+  const svg = svgs[0];
+  assert.equal(svg.dataset.iconSource, 'polaris/notes', 'uses the correct SVG source');
+  assert.equal(svg.getAttribute('focusable'), 'false', 'applies focusable:false to the SVG element');
+  assert.equal(svg.getAttribute('aria-hidden'), 'true', 'applies aria-hidden to the SVG element');
 });
 
 test('it applies colors correctly', function(assert) {

--- a/tests/integration/components/polaris-icon-test.js
+++ b/tests/integration/components/polaris-icon-test.js
@@ -44,19 +44,30 @@ test('it applies colors correctly', function(assert) {
     'purple'
   ];
 
+  assert.expect(2 + colors.length * 3);
+
   this.render(hbs`{{polaris-icon source="add" color=color}}`);
 
   // Check without any color set first.
   const icon = find(iconSelector);
-  assert.equal(icon.classList.length, 2, 'icon without color does not add color class');
+  assert.ok(icon.className.indexOf('Polaris-Icon--color') === -1, 'icon without color does not add color class');
+  assert.notOk(icon.classList.contains('Polaris-Icon--isColored'), 'icon without color does not add isColored class');
 
-  // Check all the available colors.
+  // Check all the available colors are handled correctly.
   for (const color of colors) {
     this.set('color', color);
 
     const colorClass = `Polaris-Icon--color${classify(color)}`;
     assert.ok(icon.classList.contains(colorClass), `icon with ${color} color applies ${colorClass} class`);
-    assert.equal(icon.classList.length, 3, `icon with ${color} color does not add other color classes`);
+
+    const colorClassNames = [...icon.classList].filter((className) => className.indexOf('Polaris-Icon--color') === 0);
+    assert.equal(colorClassNames.length, 1, `icon with ${color} color does not add other color classes`);
+
+    if (color === 'white') {
+      assert.notOk(icon.classList.contains('Polaris-Icon--isColored'), `icon with ${color} color does not add isColored class`);
+    } else {
+      assert.ok(icon.classList.contains('Polaris-Icon--isColored'), `icon with ${color} color adds isColored class`);
+    }
   }
 });
 

--- a/tests/mocks/components/svg-jar.js
+++ b/tests/mocks/components/svg-jar.js
@@ -7,7 +7,9 @@ const SvgJar = Component.extend({
   // Bind attributes to the element's dataset for testing.
   attributeBindings: [
     'source:data-icon-source',
-    'aria-label'
+    'aria-label',
+    'aria-hidden',
+    'focusable'
   ],
 
   source: null,


### PR DESCRIPTION
Updates `polaris-icon` to match the [v2.0.0 React component](https://github.com/Shopify/polaris/compare/v1.12.4...v2?diff=split#diff-ac192d85916a4a5bf777ae9cb10c1a08) by adding the internal `isColored` class (required for proper icon rendering now), and setting the new `focusable` and `aria-hidden` attributes on the icon's SVG element.