### PR TITLE
Fix failing breadcrumb test on Travis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ember-polaris Changelog
 
+### v1.3.2 (May 14, 2018)
+
+- [#124](https://github.com/smile-io/ember-polaris/pull/124) [FIX] Fix polaris-page breadcrumb test failure caused by URL mismatch on Travis.
+
 ### v1.3.0 (April 24, 2018)
 
 - [#117](https://github.com/smile-io/ember-polaris/pull/117) [FEATURE] Add `preferredPosition` attribute to polaris-popover.

--- a/tests/integration/components/polaris-page-test.js
+++ b/tests/integration/components/polaris-page-test.js
@@ -295,7 +295,7 @@ test('it handles breadcrumbs correctly', function(assert) {
   const contentSelector = 'span.Polaris-Breadcrumbs__Content';
 
   let breadcrumbLink = breadcrumbLinks[0];
-  assert.equal(breadcrumbLink.href, `${window.location.origin}/home/the-beginning/13/27`, 'breadcrumb has href of last breadcrumb in list');
+  assert.ok(breadcrumbLink.href.indexOf('/home/the-beginning/13/27') > -1, 'breadcrumb has href of last breadcrumb in list');
   assert.equal(breadcrumbLink.dataset.polarisUnstyled, 'true', 'breadcrumb has data-polaris-unstyled attribute');
 
   let contents = findAll(contentSelector, breadcrumbLink);


### PR DESCRIPTION
Fixes [this breadcrumb test failure](https://travis-ci.org/smile-io/ember-polaris/jobs/378581532#L926) that seems to be due to URL configuration on Travis...