### PR TITLE
Add IDs to `Ember.warn` calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ember-polaris Changelog
 
+### v1.3.2 (May 14, 2018)
+
+- [#125](https://github.com/smile-io/ember-polaris/pull/125) [FIX] Fix test failures caused by deprecation warnings from `Ember.warn`.
+
 ### v1.3.0 (April 24, 2018)
 
 - [#117](https://github.com/smile-io/ember-polaris/pull/117) [FEATURE] Add `preferredPosition` attribute to polaris-popover.

--- a/addon/components/polaris-popover.js
+++ b/addon/components/polaris-popover.js
@@ -148,7 +148,11 @@ export default Component.extend({
     let activators = component.querySelectorAll('.ember-basic-dropdown-trigger');
 
     if (activators.length > 1) {
-      warn('Multiple popover activators found. Defaulting to `preferredPosition` of `below`');
+      warn(
+        'Multiple popover activators found. Defaulting to `preferredPosition` of `below`',
+        { id: 'ember-polaris.polaris-popover.multiple-popover-activators' }
+      );
+
       return BELOW;
     }
 

--- a/addon/components/polaris-thumbnail.js
+++ b/addon/components/polaris-thumbnail.js
@@ -59,7 +59,10 @@ export default Component.extend({
     let size = this.get('size');
     if (allowedSizes.indexOf(size) === -1) {
       size = defaultSize;
-      warn(`Unsupported 'size' attribute for 'polaris-thumbnail'. Supported values: ${ allowedSizes.join(' ') }.`);
+      warn(
+        `Unsupported 'size' attribute for 'polaris-thumbnail'. Supported values: ${ allowedSizes.join(', ') }.`,
+        { id: 'ember-polaris.polaris-thumbnail.unsupported-size' }
+      );
     }
 
     return `Polaris-Thumbnail--size${ classify(size) }`;


### PR DESCRIPTION
Fixes [this deprecation warning](https://travis-ci.org/smile-io/ember-polaris/jobs/378581532#L996) on Travis, caused by calling `Ember.warn` without passing an ID for the warning.