### PR TITLE
Update layout annotated section to v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 
 - [#123](https://github.com/smile-io/ember-polaris/pull/123) [UPDATE] Add new `isColored` class, `aria-hidden` and `focusable` attributes to `polaris-icon`.
+- [#126](https://github.com/smile-io/ember-polaris/pull/126) [UPDATE] Add subdued text style to polaris-layout's annotated section description.
 
 ### v1.3.2 (May 14, 2018)
 

--- a/addon/templates/components/polaris-layout/annotation.hbs
+++ b/addon/templates/components/polaris-layout/annotation.hbs
@@ -2,12 +2,14 @@
   {{polaris-heading text=title}}
 
   {{#if (or hasBlock description)}}
-    {{#if hasBlock}}
-      {{yield}}
-    {{else}}
-      <p>
-        {{description}}
-      </p>
-    {{/if}}
+    {{#polaris-text-style variation="subdued"}}
+      {{#if hasBlock}}
+        {{yield}}
+      {{else}}
+        <p>
+          {{description}}
+        </p>
+      {{/if}}
+    {{/polaris-text-style}}
   {{/if}}
 </div>

--- a/tests/integration/components/polaris-layout-test.js
+++ b/tests/integration/components/polaris-layout-test.js
@@ -134,7 +134,7 @@ test('it renders the correct HTML when using annotated sections in inline form',
 
   const textContainerSelector = buildNestedSelector('div.Polaris-Layout__Annotation', 'div.Polaris-TextContainer');
   const headerSelector = buildNestedSelector(textContainerSelector, 'h2.Polaris-Heading');
-  const descriptionSelector = buildNestedSelector(textContainerSelector, 'p');
+  const descriptionSelector = buildNestedSelector(textContainerSelector, 'span.Polaris-TextStyle--variationSubdued', 'p');
   const contentSelector = 'div.Polaris-Layout__AnnotationContent';
 
   // Check the first annotation.
@@ -245,7 +245,7 @@ test('it renders the correct HTML when using annotated sections in block form', 
 
   const textContainerSelector = buildNestedSelector('div.Polaris-Layout__Annotation', 'div.Polaris-TextContainer');
   const headerSelector = buildNestedSelector(textContainerSelector, 'h2.Polaris-Heading');
-  const descriptionSelector = buildNestedSelector(textContainerSelector, 'p');
+  const descriptionSelector = buildNestedSelector(textContainerSelector, 'span.Polaris-TextStyle--variationSubdued', 'p');
   const contentSelector = 'div.Polaris-Layout__AnnotationContent';
 
   // Check the first annotation.


### PR DESCRIPTION
Adds the [new-to-v2.0.0 subdued text style](https://github.com/Shopify/polaris/compare/v1.12.4...v2?diff=split#diff-7fd5adef3605c29a5ce32bc357cdf5ef) to `polaris-layout/annotated-section`'s description text.