### PR TITLE
Update polaris-radio-button and polaris-checkbox to v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#123](https://github.com/smile-io/ember-polaris/pull/123) [UPDATE] Add new `isColored` class, `aria-hidden` and `focusable` attributes to `polaris-icon`.
 - [#126](https://github.com/smile-io/ember-polaris/pull/126) [UPDATE] Add subdued text style to polaris-layout's annotated section description.
+- [#127](https://github.com/smile-io/ember-polaris/pull/127) [UPDATE] Change `div`s to `span`s in `polaris-checkbox` and `polaris-radio-button`.
 
 ### v1.3.2 (May 14, 2018)
 

--- a/addon/templates/components/polaris-checkbox.hbs
+++ b/addon/templates/components/polaris-checkbox.hbs
@@ -6,7 +6,7 @@
   helpText=helpText
   error=error
 }}
-  <div class="Polaris-Checkbox {{if error "Polaris-Checkbox--error"}}">
+  <span class="Polaris-Checkbox {{if error "Polaris-Checkbox--error"}}">
     <input
       type="checkbox"
       role="checkbox"
@@ -25,10 +25,10 @@
       onblur={{action onBlur}}
     >
 
-    <div class="Polaris-Checkbox__Backdrop"></div>
+    <span class="Polaris-Checkbox__Backdrop"></span>
 
-    <div class="Polaris-Checkbox__Icon">
+    <span class="Polaris-Checkbox__Icon">
       {{polaris-icon source=(if isIndeterminate "subtract" "checkmark")}}
-    </div>
-  </div>
+    </span>
+  </span>
 {{/polaris-choice}}

--- a/addon/templates/components/polaris-radio-button.hbs
+++ b/addon/templates/components/polaris-radio-button.hbs
@@ -4,7 +4,7 @@
   labelHidden=labelHidden
   helpText=helpText
 }}
-  <div class="Polaris-RadioButton">
+  <span class="Polaris-RadioButton">
     <input
       type="radio"
       class="Polaris-RadioButton__Input"
@@ -19,7 +19,7 @@
       onblur={{action onBlur}}
     >
 
-    <div class="Polaris-RadioButton__Backdrop"></div>
-    <div class="Polaris-RadioButton__Icon"></div>
-  </div>
+    <span class="Polaris-RadioButton__Backdrop"></span>
+    <span class="Polaris-RadioButton__Icon"></span>
+  </span>
 {{/polaris-choice}}

--- a/tests/integration/components/polaris-checkbox-test.js
+++ b/tests/integration/components/polaris-checkbox-test.js
@@ -33,15 +33,15 @@ moduleForComponent('polaris-checkbox', 'Integration | Component | polaris checkb
 });
 
 const choiceSelector = 'label.Polaris-Choice';
-const checkboxSelector = buildNestedSelector(choiceSelector, 'div.Polaris-Checkbox');
+const checkboxSelector = buildNestedSelector(choiceSelector, 'span.Polaris-Checkbox');
 const checkboxInputSelector = buildNestedSelector(
   checkboxSelector,
   'input.Polaris-Checkbox__Input[type="checkbox"]'
 );
-const checkboxBackdropSelector = buildNestedSelector(checkboxSelector, 'div.Polaris-Checkbox__Backdrop');
+const checkboxBackdropSelector = buildNestedSelector(checkboxSelector, 'span.Polaris-Checkbox__Backdrop');
 const checkboxIconSelector = buildNestedSelector(
   checkboxSelector,
-  'div.Polaris-Checkbox__Icon',
+  'span.Polaris-Checkbox__Icon',
   'span.Polaris-Icon',
   'svg'
 );
@@ -70,9 +70,9 @@ test('it renders the correct HTML', function(assert) {
   assert.equal(choiceData.helpText, 'Help!', 'passes helpText through to `polaris-choice` component');
   assert.equal(choiceData.error, 'I\'ve got an error', 'passes error through to `polaris-choice` component');
 
-  // Check the wrapper div and its class handling.
+  // Check the wrapper element and its class handling.
   const checkboxes = findAll(checkboxSelector);
-  assert.equal(checkboxes.length, 1, 'renders one checkbox div');
+  assert.equal(checkboxes.length, 1, 'renders one checkbox wrapper');
   assert.ok(checkboxes[0].classList.contains('Polaris-Checkbox--error'), 'applies error class when error present');
 
   this.set('error', null);

--- a/tests/integration/components/polaris-choice-list-test.js
+++ b/tests/integration/components/polaris-choice-list-test.js
@@ -15,8 +15,8 @@ moduleForComponent('polaris-choice-list', 'Integration | Component | polaris cho
 const choiceListSelector = 'fieldset.Polaris-ChoiceList';
 const choicesWrapperSelector = buildNestedSelector(choiceListSelector, 'ul.Polaris-ChoiceList__Choices');
 const choiceSelector = buildNestedSelector(choicesWrapperSelector, 'li', 'label.Polaris-Choice');
-const radioInputSelector = buildNestedSelector('div.Polaris-RadioButton', 'input[type="radio"]');
-const checkboxInputSelector = buildNestedSelector('div.Polaris-Checkbox', 'input[type="checkbox"]');
+const radioInputSelector = buildNestedSelector('span.Polaris-RadioButton', 'input[type="radio"]');
+const checkboxInputSelector = buildNestedSelector('span.Polaris-Checkbox', 'input[type="checkbox"]');
 const titleSelector = buildNestedSelector(choiceListSelector, 'legend.Polaris-ChoiceList__Title');
 
 const choiceWithDescriptionWrapperSelector = buildNestedSelector(

--- a/tests/integration/components/polaris-radio-button-test.js
+++ b/tests/integration/components/polaris-radio-button-test.js
@@ -31,15 +31,15 @@ moduleForComponent('polaris-radio-button', 'Integration | Component | polaris ra
 });
 
 const choiceSelector = 'label.Polaris-Choice';
-const radioButtonSelector = buildNestedSelector(choiceSelector, 'div.Polaris-RadioButton');
+const radioButtonSelector = buildNestedSelector(choiceSelector, 'span.Polaris-RadioButton');
 const radioButtonInputSelector = buildNestedSelector(
   radioButtonSelector,
   'input.Polaris-RadioButton__Input[type="radio"]'
 );
-const radioButtonBackdropSelector = buildNestedSelector(radioButtonSelector, 'div.Polaris-RadioButton__Backdrop');
+const radioButtonBackdropSelector = buildNestedSelector(radioButtonSelector, 'span.Polaris-RadioButton__Backdrop');
 const radioButtonIconSelector = buildNestedSelector(
   radioButtonSelector,
-  'div.Polaris-RadioButton__Icon'
+  'span.Polaris-RadioButton__Icon'
 );
 
 test('it renders the correct HTML', function(assert) {
@@ -63,9 +63,9 @@ test('it renders the correct HTML', function(assert) {
   assert.equal(choiceData.labelHidden, 'Label is hidden, yes', 'passes labelHidden through to `polaris-choice` component');
   assert.equal(choiceData.helpText, 'Help!', 'passes helpText through to `polaris-choice` component');
 
-  // Check the wrapper div.
+  // Check the wrapper element.
   const radioButtons = findAll(radioButtonSelector);
-  assert.equal(radioButtons.length, 1, 'renders one radio button div');
+  assert.equal(radioButtons.length, 1, 'renders one radio button wrapper');
 
   // Check the input.
   const inputs = findAll(radioButtonInputSelector);


### PR DESCRIPTION
Switches the `div`s inside [`polaris-radio-button`](https://github.com/Shopify/polaris/compare/v1.12.4...v2?diff=split#diff-c8fd35a0b10ec3c24926318011c0ae40) and [`polaris-checkbox`](https://github.com/Shopify/polaris/compare/v1.12.4...v2?diff=split#diff-07693469831f3bf8790b8c358d194d7c) for `span`s, as per the v2.0.0 React components.