### PR TITLE
Update polaris-tag to v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#123](https://github.com/smile-io/ember-polaris/pull/123) [UPDATE] Add new `isColored` class, `aria-hidden` and `focusable` attributes to `polaris-icon`.
 - [#126](https://github.com/smile-io/ember-polaris/pull/126) [UPDATE] Add subdued text style to polaris-layout's annotated section description.
+- [#129](https://github.com/smile-io/ember-polaris/pull/129) [UPDATE] Add `disabled` property to `polaris-tag`.
 
 ### v1.3.2 (May 14, 2018)
 

--- a/addon/components/polaris-tag.js
+++ b/addon/components/polaris-tag.js
@@ -9,6 +9,7 @@ import { handleMouseUpByBlurring } from '../utils/focus';
 export default Component.extend({
   tagName: 'span',
   classNames: ['Polaris-Tag'],
+  classNameBindings: ['disabled:Polaris-Tag--disabled'],
 
   layout,
 
@@ -25,6 +26,16 @@ export default Component.extend({
    * @default: null
    */
   text: null,
+
+  /**
+   * Disables the tag.
+   *
+   * @public
+   * @property disabled
+   * @type {boolean}
+   * @default: false
+   */
+  disabled: false,
 
   /**
    *  Callback when tag is removed

--- a/addon/templates/components/polaris-tag.hbs
+++ b/addon/templates/components/polaris-tag.hbs
@@ -10,9 +10,8 @@
   type="button"
   aria-label="Remove"
   class="Polaris-Tag__Button"
+  disabled={{disabled}}
   onclick={{action onRemove}}
 >
-
   {{polaris-icon source="cancel"}}
-
 </button>

--- a/docs/tag.md
+++ b/docs/tag.md
@@ -24,3 +24,12 @@ Tag block usage:
   Wholesale
 {{/polaris-tag}}
 ```
+
+Disabled tag:
+
+```hbs
+{{polaris-tag
+  text="Disabled"
+  disabled=true
+}}
+```

--- a/tests/integration/components/polaris-tag-test.js
+++ b/tests/integration/components/polaris-tag-test.js
@@ -75,6 +75,25 @@ test('it renders the correct HTML in block usage', function(assert) {
   assert.equal(iconSource, 'polaris/cancel', 'it uses the correct polaris/cancel icon as the icon source');
 });
 
+test('it handles the disabled attribute correctly', function(assert) {
+  this.render(hbs`{{polaris-tag disabled=disabled}}`);
+
+  const tagComponent = find(componentSelector);
+  assert.ok(tagComponent, 'it renders the tag component');
+
+  const button = find(buttonSelector, tagComponent);
+  assert.ok(tagComponent, 'it renders the remove button');
+
+  // Check the component when no value for `disabled` is given.
+  assert.notOk(tagComponent.classList.contains('Polaris-Tag--disabled'), 'when disabled is not specified - does not apply disabled class to tag');
+  assert.notOk(button.disabled, 'when disabled is not specified - does not disable the remove button');
+
+  // Specify that the tag's disabled and check the component again.
+  this.set('disabled', true);
+  assert.ok(tagComponent.classList.contains('Polaris-Tag--disabled'), 'when disabled is specified - applies disabled class to tag');
+  assert.ok(button.disabled, 'when disabled is specified - disables the remove button');
+});
+
 test('it calls an `onRemove` action when the button is clicked', function(assert) {
   this.set('onRemoveActionFired', false);
 


### PR DESCRIPTION
Adds the [new `disabled` property](https://github.com/Shopify/polaris/blob/fcb570f9e3664642fded60f4943b375032cf8271/src/components/Tag/Tag.tsx#L15) to `polaris-tag`.