### PR TITLE
Add onClose attribute to polaris-popover

### DIFF
--- a/addon/components/polaris-popover.js
+++ b/addon/components/polaris-popover.js
@@ -87,10 +87,9 @@ export default Component.extend({
    *
    * @property onClose
    * @type {function(source: React.ReactElement)}
-   * @default null
-   * TODO: not implemented
+   * @default noop
    */
-  onClose: null,
+  onClose() {},
 
   /*
    * Internal properties.

--- a/addon/components/polaris-popover.js
+++ b/addon/components/polaris-popover.js
@@ -86,7 +86,7 @@ export default Component.extend({
    * Callback when popover is closed
    *
    * @property onClose
-   * @type {function(source: React.ReactElement)}
+   * @type {function}
    * @default noop
    */
   onClose() {},

--- a/addon/templates/components/polaris-popover.hbs
+++ b/addon/templates/components/polaris-popover.hbs
@@ -1,7 +1,7 @@
 {{#basic-dropdown
   verticalPosition=verticalPosition
   onOpen=(action "onOpen")
-  onClose=onClose
+  onClose=(action onClose)
   as |dd|
 }}
   {{yield (hash

--- a/addon/templates/components/polaris-popover.hbs
+++ b/addon/templates/components/polaris-popover.hbs
@@ -1,6 +1,7 @@
 {{#basic-dropdown
   verticalPosition=verticalPosition
   onOpen=(action "onOpen")
+  onClose=onClose
   as |dd|
 }}
   {{yield (hash

--- a/docs/popover.md
+++ b/docs/popover.md
@@ -6,7 +6,7 @@
 component](https://polaris.shopify.com/components/overlays/popover). This component uses [`ember-basic-dropdown`](https://github.com/cibernox/ember-basic-dropdown) to implement popover functionality. Note that the usage is slightly different from the React implementation so please pay attention to the examples below.
 
 
-**NOTE:** _the `active`, `activatorWrapper`, `preventAutofocus` and `onClose` properties are currently unimplemented._
+**NOTE:** _the `active`, `activatorWrapper`, and `preventAutofocus` properties are currently unimplemented._
 
 ### Examples
 

--- a/docs/popover.md
+++ b/docs/popover.md
@@ -24,10 +24,14 @@ Basic usage:
 {{/polaris-popover}}
 ```
 
-Sectioned popover:
+Sectioned popover with `onClose` action:
 
 ```hbs
-{{#polaris-popover sectioned=true as |popover|}}
+{{#polaris-popover
+  sectioned=true
+  onClose=(action "myCloseAction")
+  as |popover|
+}}
   {{#popover.activator}}
     {{polaris-button text="Toggle popover"}}
   {{/popover.activator}}

--- a/tests/integration/components/polaris-popover-test.js
+++ b/tests/integration/components/polaris-popover-test.js
@@ -167,6 +167,8 @@ test('it calls a passed-in onClose action when closed', function(assert) {
   // open the popover
   click(activatorSelector);
 
+  assert.notOk(this.get('onCloseCalled'), 'the passed-in onClose action has not been called');
+
   // close the popover
   click(activatorSelector);
 

--- a/tests/integration/components/polaris-popover-test.js
+++ b/tests/integration/components/polaris-popover-test.js
@@ -140,3 +140,35 @@ test('it renders the correct HTML with preferredPosition attribute', function(as
   const contentBelow = document.querySelector(popoverContentBelowSelector);
   assert.ok(contentBelow, 'renders popover content below the trigger');
 });
+
+test('it calls a passed-in onClose action when closed', function(assert) {
+  this.set('onCloseCalled', false);
+
+  this.on('close', () => {
+    this.set('onCloseCalled', true);
+  });
+
+  this.render(hbs`
+    {{#polaris-popover
+      sectioned=true
+      onClose=(action "close")
+      as |popover|
+    }}
+      {{#popover.activator}}
+        {{polaris-button text="Toggle popover"}}
+      {{/popover.activator}}
+
+      {{#popover.content}}
+        This is some sectioned popover content
+      {{/popover.content}}
+    {{/polaris-popover}}
+  `);
+
+  // open the popover
+  click(activatorSelector);
+
+  // close the popover
+  click(activatorSelector);
+
+  assert.ok(this.get('onCloseCalled'), 'the passed-in onClose action is called when popover is closed');
+});


### PR DESCRIPTION
Adds the [`onClose`](https://polaris.shopify.com/components/overlays/popover/onClose) property to the popover component