### PR TITLE
Move to npm org tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "4"
+  - "6"
 
 sudo: false
 dist: trusty

--- a/app/components/polaris-action-list.js
+++ b/app/components/polaris-action-list.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-action-list';
+export { default } from '@smile-io/ember-polaris/components/polaris-action-list';

--- a/app/components/polaris-action-list/image.js
+++ b/app/components/polaris-action-list/image.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-action-list/image';
+export { default } from '@smile-io/ember-polaris/components/polaris-action-list/image';

--- a/app/components/polaris-action-list/item.js
+++ b/app/components/polaris-action-list/item.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-action-list/item';
+export { default } from '@smile-io/ember-polaris/components/polaris-action-list/item';

--- a/app/components/polaris-action-list/section.js
+++ b/app/components/polaris-action-list/section.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-action-list/section';
+export { default } from '@smile-io/ember-polaris/components/polaris-action-list/section';

--- a/app/components/polaris-avatar.js
+++ b/app/components/polaris-avatar.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-avatar';
+export { default } from '@smile-io/ember-polaris/components/polaris-avatar';

--- a/app/components/polaris-badge.js
+++ b/app/components/polaris-badge.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-badge';
+export { default } from '@smile-io/ember-polaris/components/polaris-badge';

--- a/app/components/polaris-banner.js
+++ b/app/components/polaris-banner.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-banner';
+export { default } from '@smile-io/ember-polaris/components/polaris-banner';

--- a/app/components/polaris-breadcrumbs.js
+++ b/app/components/polaris-breadcrumbs.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-breadcrumbs';
+export { default } from '@smile-io/ember-polaris/components/polaris-breadcrumbs';

--- a/app/components/polaris-breadcrumbs/breadcrumb.js
+++ b/app/components/polaris-breadcrumbs/breadcrumb.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-breadcrumbs/breadcrumb';
+export { default } from '@smile-io/ember-polaris/components/polaris-breadcrumbs/breadcrumb';

--- a/app/components/polaris-button-group.js
+++ b/app/components/polaris-button-group.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-button-group';
+export { default } from '@smile-io/ember-polaris/components/polaris-button-group';

--- a/app/components/polaris-button-group/item.js
+++ b/app/components/polaris-button-group/item.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-button-group/item';
+export { default } from '@smile-io/ember-polaris/components/polaris-button-group/item';

--- a/app/components/polaris-button.js
+++ b/app/components/polaris-button.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-button';
+export { default } from '@smile-io/ember-polaris/components/polaris-button';

--- a/app/components/polaris-button/button.js
+++ b/app/components/polaris-button/button.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-button/button';
+export { default } from '@smile-io/ember-polaris/components/polaris-button/button';

--- a/app/components/polaris-button/link.js
+++ b/app/components/polaris-button/link.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-button/link';
+export { default } from '@smile-io/ember-polaris/components/polaris-button/link';

--- a/app/components/polaris-callout-card.js
+++ b/app/components/polaris-callout-card.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-callout-card';
+export { default } from '@smile-io/ember-polaris/components/polaris-callout-card';

--- a/app/components/polaris-caption.js
+++ b/app/components/polaris-caption.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-caption';
+export { default } from '@smile-io/ember-polaris/components/polaris-caption';

--- a/app/components/polaris-card.js
+++ b/app/components/polaris-card.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-card';
+export { default } from '@smile-io/ember-polaris/components/polaris-card';

--- a/app/components/polaris-card/section-header.js
+++ b/app/components/polaris-card/section-header.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-card/section-header';
+export { default } from '@smile-io/ember-polaris/components/polaris-card/section-header';

--- a/app/components/polaris-card/section.js
+++ b/app/components/polaris-card/section.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-card/section';
+export { default } from '@smile-io/ember-polaris/components/polaris-card/section';

--- a/app/components/polaris-checkbox.js
+++ b/app/components/polaris-checkbox.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-checkbox';
+export { default } from '@smile-io/ember-polaris/components/polaris-checkbox';

--- a/app/components/polaris-choice-list.js
+++ b/app/components/polaris-choice-list.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-choice-list';
+export { default } from '@smile-io/ember-polaris/components/polaris-choice-list';

--- a/app/components/polaris-choice.js
+++ b/app/components/polaris-choice.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-choice';
+export { default } from '@smile-io/ember-polaris/components/polaris-choice';

--- a/app/components/polaris-choice/label.js
+++ b/app/components/polaris-choice/label.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-choice/label';
+export { default } from '@smile-io/ember-polaris/components/polaris-choice/label';

--- a/app/components/polaris-color-picker.js
+++ b/app/components/polaris-color-picker.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-color-picker';
+export { default } from '@smile-io/ember-polaris/components/polaris-color-picker';

--- a/app/components/polaris-color-picker/alpha-picker.js
+++ b/app/components/polaris-color-picker/alpha-picker.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-color-picker/alpha-picker';
+export { default } from '@smile-io/ember-polaris/components/polaris-color-picker/alpha-picker';

--- a/app/components/polaris-color-picker/hue-picker.js
+++ b/app/components/polaris-color-picker/hue-picker.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-color-picker/hue-picker';
+export { default } from '@smile-io/ember-polaris/components/polaris-color-picker/hue-picker';

--- a/app/components/polaris-color-picker/slidable.js
+++ b/app/components/polaris-color-picker/slidable.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-color-picker/slidable';
+export { default } from '@smile-io/ember-polaris/components/polaris-color-picker/slidable';

--- a/app/components/polaris-date-picker.js
+++ b/app/components/polaris-date-picker.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-date-picker';
+export { default } from '@smile-io/ember-polaris/components/polaris-date-picker';

--- a/app/components/polaris-date-picker/day.js
+++ b/app/components/polaris-date-picker/day.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-date-picker/day';
+export { default } from '@smile-io/ember-polaris/components/polaris-date-picker/day';

--- a/app/components/polaris-date-picker/month.js
+++ b/app/components/polaris-date-picker/month.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-date-picker/month';
+export { default } from '@smile-io/ember-polaris/components/polaris-date-picker/month';

--- a/app/components/polaris-date-picker/weekday.js
+++ b/app/components/polaris-date-picker/weekday.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-date-picker/weekday';
+export { default } from '@smile-io/ember-polaris/components/polaris-date-picker/weekday';

--- a/app/components/polaris-description-list.js
+++ b/app/components/polaris-description-list.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-description-list';
+export { default } from '@smile-io/ember-polaris/components/polaris-description-list';

--- a/app/components/polaris-display-text.js
+++ b/app/components/polaris-display-text.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-display-text';
+export { default } from '@smile-io/ember-polaris/components/polaris-display-text';

--- a/app/components/polaris-empty-state.js
+++ b/app/components/polaris-empty-state.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-empty-state';
+export { default } from '@smile-io/ember-polaris/components/polaris-empty-state';

--- a/app/components/polaris-empty-state/details.js
+++ b/app/components/polaris-empty-state/details.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-empty-state/details';
+export { default } from '@smile-io/ember-polaris/components/polaris-empty-state/details';

--- a/app/components/polaris-footer-help.js
+++ b/app/components/polaris-footer-help.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-footer-help';
+export { default } from '@smile-io/ember-polaris/components/polaris-footer-help';

--- a/app/components/polaris-form-layout.js
+++ b/app/components/polaris-form-layout.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-form-layout';
+export { default } from '@smile-io/ember-polaris/components/polaris-form-layout';

--- a/app/components/polaris-form-layout/group.js
+++ b/app/components/polaris-form-layout/group.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-form-layout/group';
+export { default } from '@smile-io/ember-polaris/components/polaris-form-layout/group';

--- a/app/components/polaris-heading.js
+++ b/app/components/polaris-heading.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-heading';
+export { default } from '@smile-io/ember-polaris/components/polaris-heading';

--- a/app/components/polaris-icon.js
+++ b/app/components/polaris-icon.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-icon';
+export { default } from '@smile-io/ember-polaris/components/polaris-icon';

--- a/app/components/polaris-layout.js
+++ b/app/components/polaris-layout.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-layout';
+export { default } from '@smile-io/ember-polaris/components/polaris-layout';

--- a/app/components/polaris-layout/annotated-section.js
+++ b/app/components/polaris-layout/annotated-section.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-layout/annotated-section';
+export { default } from '@smile-io/ember-polaris/components/polaris-layout/annotated-section';

--- a/app/components/polaris-layout/annotation-content.js
+++ b/app/components/polaris-layout/annotation-content.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-layout/annotation-content';
+export { default } from '@smile-io/ember-polaris/components/polaris-layout/annotation-content';

--- a/app/components/polaris-layout/annotation.js
+++ b/app/components/polaris-layout/annotation.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-layout/annotation';
+export { default } from '@smile-io/ember-polaris/components/polaris-layout/annotation';

--- a/app/components/polaris-layout/section.js
+++ b/app/components/polaris-layout/section.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-layout/section';
+export { default } from '@smile-io/ember-polaris/components/polaris-layout/section';

--- a/app/components/polaris-link.js
+++ b/app/components/polaris-link.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-link';
+export { default } from '@smile-io/ember-polaris/components/polaris-link';

--- a/app/components/polaris-list.js
+++ b/app/components/polaris-list.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-list';
+export { default } from '@smile-io/ember-polaris/components/polaris-list';

--- a/app/components/polaris-list/item.js
+++ b/app/components/polaris-list/item.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-list/item';
+export { default } from '@smile-io/ember-polaris/components/polaris-list/item';

--- a/app/components/polaris-page-actions.js
+++ b/app/components/polaris-page-actions.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-page-actions';
+export { default } from '@smile-io/ember-polaris/components/polaris-page-actions';

--- a/app/components/polaris-page.js
+++ b/app/components/polaris-page.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-page';
+export { default } from '@smile-io/ember-polaris/components/polaris-page';

--- a/app/components/polaris-page/action-icon.js
+++ b/app/components/polaris-page/action-icon.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-page/action-icon';
+export { default } from '@smile-io/ember-polaris/components/polaris-page/action-icon';

--- a/app/components/polaris-page/action.js
+++ b/app/components/polaris-page/action.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-page/action';
+export { default } from '@smile-io/ember-polaris/components/polaris-page/action';

--- a/app/components/polaris-page/header.js
+++ b/app/components/polaris-page/header.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-page/header';
+export { default } from '@smile-io/ember-polaris/components/polaris-page/header';

--- a/app/components/polaris-pagination.js
+++ b/app/components/polaris-pagination.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-pagination';
+export { default } from '@smile-io/ember-polaris/components/polaris-pagination';

--- a/app/components/polaris-popover.js
+++ b/app/components/polaris-popover.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-popover';
+export { default } from '@smile-io/ember-polaris/components/polaris-popover';

--- a/app/components/polaris-popover/content.js
+++ b/app/components/polaris-popover/content.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-popover/content';
+export { default } from '@smile-io/ember-polaris/components/polaris-popover/content';

--- a/app/components/polaris-progress-bar.js
+++ b/app/components/polaris-progress-bar.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-progress-bar';
+export { default } from '@smile-io/ember-polaris/components/polaris-progress-bar';

--- a/app/components/polaris-radio-button.js
+++ b/app/components/polaris-radio-button.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-radio-button';
+export { default } from '@smile-io/ember-polaris/components/polaris-radio-button';

--- a/app/components/polaris-resource-list.js
+++ b/app/components/polaris-resource-list.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-resource-list';
+export { default } from '@smile-io/ember-polaris/components/polaris-resource-list';

--- a/app/components/polaris-resource-list/item.js
+++ b/app/components/polaris-resource-list/item.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-resource-list/item';
+export { default } from '@smile-io/ember-polaris/components/polaris-resource-list/item';

--- a/app/components/polaris-setting-toggle.js
+++ b/app/components/polaris-setting-toggle.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-setting-toggle';
+export { default } from '@smile-io/ember-polaris/components/polaris-setting-toggle';

--- a/app/components/polaris-skeleton-body-text.js
+++ b/app/components/polaris-skeleton-body-text.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-skeleton-body-text';
+export { default } from '@smile-io/ember-polaris/components/polaris-skeleton-body-text';

--- a/app/components/polaris-skeleton-display-text.js
+++ b/app/components/polaris-skeleton-display-text.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-skeleton-display-text';
+export { default } from '@smile-io/ember-polaris/components/polaris-skeleton-display-text';

--- a/app/components/polaris-skeleton-page.js
+++ b/app/components/polaris-skeleton-page.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-skeleton-page';
+export { default } from '@smile-io/ember-polaris/components/polaris-skeleton-page';

--- a/app/components/polaris-skeleton-page/action.js
+++ b/app/components/polaris-skeleton-page/action.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-skeleton-page/action';
+export { default } from '@smile-io/ember-polaris/components/polaris-skeleton-page/action';

--- a/app/components/polaris-spinner.js
+++ b/app/components/polaris-spinner.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-spinner';
+export { default } from '@smile-io/ember-polaris/components/polaris-spinner';

--- a/app/components/polaris-stack.js
+++ b/app/components/polaris-stack.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-stack';
+export { default } from '@smile-io/ember-polaris/components/polaris-stack';

--- a/app/components/polaris-stack/item.js
+++ b/app/components/polaris-stack/item.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-stack/item';
+export { default } from '@smile-io/ember-polaris/components/polaris-stack/item';

--- a/app/components/polaris-subheading.js
+++ b/app/components/polaris-subheading.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-subheading';
+export { default } from '@smile-io/ember-polaris/components/polaris-subheading';

--- a/app/components/polaris-tag.js
+++ b/app/components/polaris-tag.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-tag';
+export { default } from '@smile-io/ember-polaris/components/polaris-tag';

--- a/app/components/polaris-text-container.js
+++ b/app/components/polaris-text-container.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-text-container';
+export { default } from '@smile-io/ember-polaris/components/polaris-text-container';

--- a/app/components/polaris-text-style.js
+++ b/app/components/polaris-text-style.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-text-style';
+export { default } from '@smile-io/ember-polaris/components/polaris-text-style';

--- a/app/components/polaris-thumbnail.js
+++ b/app/components/polaris-thumbnail.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-thumbnail';
+export { default } from '@smile-io/ember-polaris/components/polaris-thumbnail';

--- a/app/components/polaris-unstyled-link.js
+++ b/app/components/polaris-unstyled-link.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-unstyled-link';
+export { default } from '@smile-io/ember-polaris/components/polaris-unstyled-link';

--- a/app/components/polaris-visually-hidden.js
+++ b/app/components/polaris-visually-hidden.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/polaris-visually-hidden';
+export { default } from '@smile-io/ember-polaris/components/polaris-visually-hidden';

--- a/app/components/wrapper-element.js
+++ b/app/components/wrapper-element.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/components/wrapper-element';
+export { default } from '@smile-io/ember-polaris/components/wrapper-element';

--- a/app/utils/focus.js
+++ b/app/utils/focus.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-polaris/utils/focus';
+export { default } from '@smile-io/ember-polaris/utils/focus';

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var Funnel = require('broccoli-funnel');
 var mergeTrees = require('broccoli-merge-trees');
 
 module.exports = {
-  name: 'ember-polaris',
+  name: '@smile-io/ember-polaris',
 
   treeForStyles(tree) {
     var packageRoot = path.dirname(resolve.sync('@shopify/polaris/package.json', { basedir: __dirname }));

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ember-polaris",
+  "name": "@smile-io/ember-polaris",
   "version": "1.4.1",
   "description": "Ember components for Shopify's Polaris design system.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "loader.js": "^4.2.3"
   },
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "6.* || >= 7.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/unit/utils/color-test.js
+++ b/tests/unit/utils/color-test.js
@@ -5,7 +5,7 @@ import {
   rgbaToHsb,
   rgbaToHex,
   hexToRgb,
-} from 'ember-polaris/utils/color';
+} from '@smile-io/ember-polaris/utils/color';
 
 module('Unit | Utility | color');
 


### PR DESCRIPTION
### What's here

- updates to use scoped package in both `package.json` and `index.js`
- updates exports/imports to use scoped package

NOTE: Until now everything worked because we didn't changed `index.js` name, with this we will break imports and stuff....however we need to do this, since otherwise newly generated stuff will use scoped name, but import won't resolve because it will still use un-scoped name 