### PR TITLE
Use `polaris-text-container` in `polaris-layout/annotation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ember-polaris Changelog
 
+### Unpublished
+
+- [#137](https://github.com/smile-io/ember-polaris/pull/137) [ENHANCEMENT] Replace hand-rolled `<div class="Polaris-TextContainer">` with `polaris-text-container` in `polaris-layout/annotation`.
+
 ### v1.5.4 (May 30, 2018)
 
 - [#135](https://github.com/smile-io/ember-polaris/pull/135) [FIX] Fix component documentation links on npm.

--- a/addon/templates/components/polaris-layout/annotation.hbs
+++ b/addon/templates/components/polaris-layout/annotation.hbs
@@ -1,4 +1,4 @@
-<div class="Polaris-TextContainer">
+{{#polaris-text-container}}
   {{polaris-heading text=title}}
 
   {{#if (or hasBlock description)}}
@@ -12,4 +12,4 @@
       {{/if}}
     {{/polaris-text-style}}
   {{/if}}
-</div>
+{{/polaris-text-container}}


### PR DESCRIPTION
@vladucu pointed out that we were still using `<div class="Polaris-TextContainer">` in `polaris-layout/annotation`, since that component pre-dates our implementation of `polaris-text-container`. Updating it to use the component instead of a simple `div` 👍 