### PR TITLE
Make `polaris-spinner` respect the `color` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ember-polaris Changelog
 
+### Unreleased
+
+- [#139](https://github.com/smile-io/ember-polaris/pull/139) [FIX] Make `polaris-spinner` respect the `color` property.
+
 ### v1.5.5 (May 31, 2018)
 
 - [#137](https://github.com/smile-io/ember-polaris/pull/137) [ENHANCEMENT] Replace hand-rolled `<div class="Polaris-TextContainer">` with `polaris-text-container` in `polaris-layout/annotation`.

--- a/addon/components/polaris-icon.js
+++ b/addon/components/polaris-icon.js
@@ -1,12 +1,13 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { equal } from '@ember/object/computed';
-import { isNone, isEmpty } from '@ember/utils';
+import { isEmpty } from '@ember/utils';
 import { classify } from '@ember/string';
 import layout from '../templates/components/polaris-icon';
+import SvgHandling from '../mixins/components/svg-handling';
 
 // TODO: look into importing icons properly.
-export default Component.extend({
+export default Component.extend(SvgHandling, {
   tagName: 'span',
   classNames: ['Polaris-Icon'],
   classNameBindings: [
@@ -128,36 +129,4 @@ export default Component.extend({
 
     return source;
   }).readOnly(),
-
-  removeSvgFills(elem) {
-    if (isNone(elem)) {
-      return;
-    }
-
-    if (!elem.hasChildNodes) {
-        return;
-    }
-
-    let children = elem.childNodes;
-    for (let i = 0, len = children.length; i < len; i++) {
-      let child = children[i];
-      if (child.tagName === 'g') {
-        child.removeAttribute('fill');
-        this.removeSvgFills(child);
-      } else {
-        let fill = child.getAttribute('fill');
-        // This is what Shopify does too in @shopify/images/icon-loader.js
-        let newFill = fill && fill.indexOf('#FFF') !== -1 ? 'currentColor' : '';
-        child.setAttribute('fill', newFill);
-      }
-    }
-  },
-
-  /*
-   * Lifecycle hooks.
-   */
-  didInsertElement() {
-    this._super(...arguments);
-    this.removeSvgFills(this.$('svg')[0]);
-  }
 });

--- a/addon/components/polaris-spinner.js
+++ b/addon/components/polaris-spinner.js
@@ -2,6 +2,7 @@ import Component from '@ember/component';
 import layout from '../templates/components/polaris-spinner';
 import { computed } from '@ember/object';
 import { classify } from '@ember/string';
+import SvgHandling from '../mixins/components/svg-handling';
 
 const allowedColors = [
   'white',
@@ -20,7 +21,7 @@ const allowedSizes = [
 ];
 const defaultSize = 'large';
 
-export default Component.extend({
+export default Component.extend(SvgHandling, {
   tagName: '',
 
   layout,

--- a/addon/mixins/components/svg-handling.js
+++ b/addon/mixins/components/svg-handling.js
@@ -35,6 +35,12 @@ export default Mixin.create({
 
   /**
    * Volatile CP to find the SVG element for this component.
+   * This is marked as `volatile` so that `this.get('svgElement')`
+   * essentially becomes an alias for the `document.querySelector`
+   * call, meaning that each time we try to access it, we'll get
+   * an up-to-date indication of whether the element is still
+   * in the DOM. Without the `volatile` modifier, we could for
+   * example end up using a cached element that's no longer in the DOM.
    *
    * @property svgElement
    * @type {DOMNode}

--- a/addon/mixins/components/svg-handling.js
+++ b/addon/mixins/components/svg-handling.js
@@ -1,0 +1,78 @@
+import Mixin from '@ember/object/mixin';
+import { computed } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import { isNone } from '@ember/utils';
+
+/*
+ * This mixin is intended for use with components that render an SVG icon
+ * via the `svg-jar` helper.
+ *
+ * The Polaris React implementation checks the
+ * `fill` attribute on SVG elements and their children to ensure SVGs
+ * always respect whatever `color` they're passed.
+ *
+ * In this mixin, we automate that process - all that's needed is to
+ * include this mixin in the component that renders the SVG, and pass
+ * `id=svgElementId` to the `svg-jar` invocation.
+ *
+ * TODO: this currently only supports having a single SVG per component.
+ * This should be fine for now though since this mixin only gets used
+ * in components whose sole responsibility is to render a single SVG.
+ */
+export default Mixin.create({
+  /**
+   * Generated unique ID to be set on the rendered SVG element.
+   *
+   * @property svgElementId
+   * @type {string}
+   */
+  svgElementId: computed(function() {
+    // We append '-svg' to the component's Ember-generated GUID,
+    // because Ember will automatically use that GUID as the ID
+    // for the root element of non-tagless components.
+    return `${ guidFor(this) }-svg`;
+  }).readOnly(),
+
+  /**
+   * Volatile CP to find the SVG element for this component.
+   *
+   * @property svgElement
+   * @type {DOMNode}
+   */
+  svgElement: computed(function() {
+    return document.querySelector(`#${ this.get('svgElementId') }`);
+  }).volatile(),
+
+  /*
+   * Helper method to process the `fill` attribute
+   * on a given SVG element and its children.
+   */
+  removeSvgFills(elem) {
+    if (isNone(elem) || !elem.hasChildNodes()) {
+      return;
+    }
+
+    let children = elem.childNodes;
+    for (let i = 0, len = children.length; i < len; i++) {
+      let child = children[i];
+      if (child.tagName === 'g') {
+        child.removeAttribute('fill');
+        this.removeSvgFills(child);
+      } else {
+        let fill = child.getAttribute('fill');
+        // This is what Shopify does too in @shopify/images/icon-loader.js
+        let newFill = fill && fill.indexOf('#FFF') !== -1 ? 'currentColor' : '';
+        child.setAttribute('fill', newFill);
+      }
+    }
+  },
+
+  /*
+   * Lifecycle hooks.
+   */
+  didInsertElement() {
+    this._super(...arguments);
+
+    this.removeSvgFills(this.get('svgElement'));
+  },
+});

--- a/addon/templates/components/polaris-icon.hbs
+++ b/addon/templates/components/polaris-icon.hbs
@@ -6,5 +6,6 @@
     class="Polaris-Icon__Svg"
     focusable="false"
     aria-hidden="true"
+    id=svgElementId
   }}
 {{/if}}

--- a/addon/templates/components/polaris-spinner.hbs
+++ b/addon/templates/components/polaris-spinner.hbs
@@ -1,5 +1,6 @@
 {{svg-jar spinnerSource
   role="status"
+  id=svgElementId
   class=spinnerClass
   aria-label=accessibilityLabel
 }}


### PR DESCRIPTION
Fixes #116 by abstracting out the SVG `fill` attribute processing from `polaris-icon` into a mixin and applying it to the SVG rendered by `polaris-spinner` as well.