### PR TITLE
Add data table component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # ember-polaris Changelog
 
 ### Unreleased
+
+- [#141](https://github.com/smile-io/ember-polaris/pull/141) [FEATURE] Add `polaris-data-table` component.
 - [#142](https://github.com/smile-io/ember-polaris/pull/142) [ENHANCEMENT] Support React-style child content.
 
 ### v1.6.0 (June 25, 2018)

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Below is a categorised list of the components available in `ember-polaris`. Clic
 - [Tag](./docs/tag.md#tag)
 
 #### Lists
+- [Data table](./docs/data-table.md#data-table)
 - [Description list](./docs/description-list.md#description-list)
 - [List](./docs/list.md#list)
 - [Resource list](./docs/resource-list.md#resource-list)

--- a/addon/components/polaris-data-table.js
+++ b/addon/components/polaris-data-table.js
@@ -375,6 +375,10 @@ export default Component.extend({
   },
 
   debouncedHandleResize() {
+    if (this.get('isDestroying') || this.get('isDestroyed')) {
+      return;
+    }
+
     let { footerContent, truncate } = this.getProperties('footerContent', 'truncate');
     let collapsed = this.get('table.scrollWidth') > this.get('dataTable.offsetWidth');
 
@@ -395,6 +399,10 @@ export default Component.extend({
   },
 
   scrollListener() {
+    if (this.get('isDestroying') || this.get('isDestroyed')) {
+      return;
+    }
+
     this.setProperties(this.calculateColumnVisibilityData(this.get('collapsed')));
   },
 
@@ -479,6 +487,10 @@ export default Component.extend({
 
       // TODO: use run loop instead of `requestAnimationFrame` here?
       requestAnimationFrame(() => {
+        if (this.get('isDestroying') || this.get('isDestroyed')) {
+          return;
+        }
+
         this.setProperties(this.calculateColumnVisibilityData(this.get('collapsed')));
       });
     },

--- a/addon/components/polaris-data-table.js
+++ b/addon/components/polaris-data-table.js
@@ -483,8 +483,39 @@ export default Component.extend({
       });
     },
 
-    defaultOnSort() {
-      // TODO: implement this.
+    defaultOnSort(headingIndex) {
+      let {
+        onSort,
+        truncate,
+        defaultSortDirection = 'ascending',
+        initialSortColumnIndex,
+        sortDirection,
+        sortedColumnIndex = initialSortColumnIndex,
+      } = this.getProperties('onSort', 'truncate', 'defaultSortDirection', 'initialSortColumnIndex', 'sortDirection', 'sortedColumnIndex');
+      let newSortDirection = defaultSortDirection;
+      if (sortedColumnIndex === headingIndex) {
+        newSortDirection = sortDirection === 'ascending' ? 'descending' : 'ascending';
+      }
+
+      this.setProperties({
+        sorted: true,
+        sortDirection: newSortDirection,
+        sortedColumnIndex: headingIndex,
+      });
+
+      scheduleOnce('afterRender', () => {
+        if (onSort) {
+          onSort(headingIndex, newSortDirection);
+          if (!truncate) {
+            let preservedScrollPosition = {
+              left: this.scrollContainer.scrollLeft,
+              top: window.scrollY,
+            };
+            this.set('preservedScrollPosition', preservedScrollPosition);
+            this.handleResize();
+          }
+        }
+      });
     },
   }
 });

--- a/addon/components/polaris-data-table.js
+++ b/addon/components/polaris-data-table.js
@@ -2,9 +2,10 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { isBlank, isPresent, isNone } from '@ember/utils';
 import { htmlSafe } from '@ember/string';
-import { scheduleOnce, debounce } from '@ember/runloop';
+import { scheduleOnce } from '@ember/runloop';
 import { assign } from '@ember/polyfills';
 import ContextBoundEventListenersMixin from 'ember-lifeline/mixins/dom';
+import ContextBoundTasksMixin from 'ember-lifeline/mixins/run';
 import layout from '../templates/components/polaris-data-table';
 
 function elementLookup(selector) {
@@ -78,7 +79,7 @@ function getPrevAndCurrentColumns(tableData, columnData) {
  * Polaris data table component.
  * See https://polaris.shopify.com/components/lists-and-tables/data-table
  */
-export default Component.extend(ContextBoundEventListenersMixin, {
+export default Component.extend(ContextBoundEventListenersMixin, ContextBoundTasksMixin, {
   classNameBindings: ['collapsed:Polaris-DataTable--collapsed'],
 
   layout,
@@ -359,14 +360,10 @@ export default Component.extend(ContextBoundEventListenersMixin, {
 
   handleResize() {
     // This is needed to replicate the React implementation's `@debounce` decorator.
-    debounce(this, 'debouncedHandleResize', 0);
+    this.debounceTask('debouncedHandleResize', 0);
   },
 
   debouncedHandleResize() {
-    if (this.get('isDestroying') || this.get('isDestroyed')) {
-      return;
-    }
-
     let { footerContent, truncate } = this.getProperties('footerContent', 'truncate');
     let collapsed = this.get('table.scrollWidth') > this.get('dataTable.offsetWidth');
 

--- a/addon/components/polaris-data-table.js
+++ b/addon/components/polaris-data-table.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { isBlank, isPresent } from '@ember/utils';
+import { isBlank, isPresent, isNone } from '@ember/utils';
 import { htmlSafe } from '@ember/string';
 import { scheduleOnce, debounce } from '@ember/runloop';
 import { assign } from '@ember/polyfills';
@@ -490,8 +490,9 @@ export default Component.extend({
         defaultSortDirection = 'ascending',
         initialSortColumnIndex,
         sortDirection,
-        sortedColumnIndex = initialSortColumnIndex,
+        sortedColumnIndex,
       } = this.getProperties('onSort', 'truncate', 'defaultSortDirection', 'initialSortColumnIndex', 'sortDirection', 'sortedColumnIndex');
+      sortedColumnIndex = isNone(sortedColumnIndex) ? initialSortColumnIndex : sortedColumnIndex;
       let newSortDirection = defaultSortDirection;
       if (sortedColumnIndex === headingIndex) {
         newSortDirection = sortDirection === 'ascending' ? 'descending' : 'ascending';
@@ -508,7 +509,7 @@ export default Component.extend({
           onSort(headingIndex, newSortDirection);
           if (!truncate) {
             let preservedScrollPosition = {
-              left: this.scrollContainer.scrollLeft,
+              left: this.get('scrollContainer').scrollLeft,
               top: window.scrollY,
             };
             this.set('preservedScrollPosition', preservedScrollPosition);

--- a/addon/components/polaris-data-table.js
+++ b/addon/components/polaris-data-table.js
@@ -4,12 +4,8 @@ import { isBlank, isPresent, isNone } from '@ember/utils';
 import { htmlSafe } from '@ember/string';
 import { scheduleOnce, debounce } from '@ember/runloop';
 import { assign } from '@ember/polyfills';
+import ContextBoundEventListenersMixin from 'ember-lifeline/mixins/dom';
 import layout from '../templates/components/polaris-data-table';
-
-const eventHandlerParams = [
-  [ window, 'resize', 'handleResize' ],
-  [ window, 'scroll', 'scrollListener', true ],
-];
 
 function volatileElementLookup(selector) {
   return computed(function() {
@@ -82,7 +78,7 @@ function getPrevAndCurrentColumns(tableData, columnData) {
  * Polaris data table component.
  * See https://polaris.shopify.com/components/lists-and-tables/data-table
  */
-export default Component.extend({
+export default Component.extend(ContextBoundEventListenersMixin, {
   classNameBindings: ['collapsed:Polaris-DataTable--collapsed'],
 
   layout,
@@ -266,13 +262,6 @@ export default Component.extend({
   totalsRowHeading: 'Totals',
 
   /**
-   * @property eventHandlerParams
-   * @type {Array[]}
-   * @private
-   */
-  eventHandlerParams,
-
-  /**
    * @property dataTable
    * @type {HTMLElement}
    * @private
@@ -427,15 +416,8 @@ export default Component.extend({
   },
 
   addEventHandlers() {
-    this.get('eventHandlerParams').forEach(([ target, eventName, callbackName, ...rest ]) => {
-      target.addEventListener(eventName, this[callbackName].bind(this), ...rest);
-    });
-  },
-
-  removeEventHandlers() {
-    this.get('eventHandlerParams').forEach(([ target, eventName, callbackName, ...rest ]) => {
-      target.removeEventListener(eventName, this[callbackName].bind(this), ...rest);
-    });
+    this.addEventListener(window, 'resize', this.handleResize);
+    this.addEventListener(window, 'scroll', this.scrollListener, { capture: true });
   },
 
   /*
@@ -458,10 +440,6 @@ export default Component.extend({
     this.handleResize();
 
     this.addEventHandlers();
-  },
-
-  willDestroyElement() {
-    this.removeEventHandlers();
   },
 
   didUpdateAttrs() {

--- a/addon/components/polaris-data-table.js
+++ b/addon/components/polaris-data-table.js
@@ -181,6 +181,7 @@ export default Component.extend({
    *
    * @property onSort
    * @type {function}
+   * @default no-op
    * @public
    */
   onSort(/* headingIndex, direction */) {},

--- a/addon/components/polaris-data-table.js
+++ b/addon/components/polaris-data-table.js
@@ -7,10 +7,10 @@ import { assign } from '@ember/polyfills';
 import ContextBoundEventListenersMixin from 'ember-lifeline/mixins/dom';
 import layout from '../templates/components/polaris-data-table';
 
-function volatileElementLookup(selector) {
+function elementLookup(selector) {
   return computed(function() {
     return this.element.querySelector(selector);
-  }).volatile();
+  });
 }
 
 function measureColumn(tableData) {
@@ -44,7 +44,7 @@ function measureColumn(tableData) {
         index,
       );
     }
-    return {leftEdge, rightEdge, isVisible};
+    return { leftEdge, rightEdge, isVisible };
   };
 }
 
@@ -71,7 +71,7 @@ function getPrevAndCurrentColumns(tableData, columnData) {
     },
     columnData[firstVisibleColumnIndex]
   );
-  return {previousColumn, currentColumn};
+  return { previousColumn, currentColumn };
 }
 
 /**
@@ -266,21 +266,21 @@ export default Component.extend(ContextBoundEventListenersMixin, {
    * @type {HTMLElement}
    * @private
    */
-  dataTable: volatileElementLookup('.Polaris-DataTable').readOnly(),
+  dataTable: elementLookup('.Polaris-DataTable').readOnly(),
 
   /**
    * @property scrollContainer
    * @type {HTMLElement}
    * @private
    */
-  scrollContainer: volatileElementLookup('.Polaris-DataTable__ScrollContainer').readOnly(),
+  scrollContainer: elementLookup('.Polaris-DataTable__ScrollContainer').readOnly(),
 
   /**
    * @property table
    * @type {HTMLElement}
    * @private
    */
-  table: volatileElementLookup('.Polaris-DataTable__Table').readOnly(),
+  table: elementLookup('.Polaris-DataTable__Table').readOnly(),
 
   /**
    * @property contentTypes
@@ -327,9 +327,7 @@ export default Component.extend(ContextBoundEventListenersMixin, {
 
   calculateColumnVisibilityData(collapsed) {
     if (collapsed) {
-      let headerCells = this.get('table').querySelectorAll(
-        '[class*=header]',
-      );
+      let headerCells = this.get('table').querySelectorAll('[class*=header]');
       let collapsedHeaderCells = Array.from(headerCells).slice(2);
       let fixedColumnWidth = headerCells[0].offsetWidth;
       let tableData = {

--- a/addon/components/polaris-data-table.js
+++ b/addon/components/polaris-data-table.js
@@ -1,0 +1,444 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { isBlank, isPresent } from '@ember/utils';
+import { htmlSafe } from '@ember/string';
+import { scheduleOnce, debounce } from '@ember/runloop';
+import { assign } from '@ember/polyfills';
+import layout from '../templates/components/polaris-data-table';
+
+function volatileElementLookup(selector) {
+  return computed(function() {
+    return this.element.querySelector(selector);
+  }).volatile();
+}
+
+function measureColumn(tableData) {
+  return function(column, index) {
+    let {
+      tableLeftVisibleEdge,
+      tableRightVisibleEdge,
+      firstVisibleColumnIndex,
+      fixedColumnWidth,
+    } = tableData;
+    let width = column.offsetWidth;
+    let leftEdge = column.offsetLeft - fixedColumnWidth;
+    let rightEdge = leftEdge + width;
+    let leftEdgeIsVisible = isEdgeVisible(
+      leftEdge,
+      tableLeftVisibleEdge,
+      tableRightVisibleEdge,
+    );
+    let rightEdgeIsVisible = isEdgeVisible(
+      rightEdge,
+      tableLeftVisibleEdge,
+      tableRightVisibleEdge,
+    );
+    let isCompletelyVisible =
+      leftEdge < tableLeftVisibleEdge && rightEdge > tableRightVisibleEdge;
+    let isVisible =
+      isCompletelyVisible || leftEdgeIsVisible || rightEdgeIsVisible;
+    if (isVisible) {
+      tableData.firstVisibleColumnIndex = Math.min(
+        firstVisibleColumnIndex,
+        index,
+      );
+    }
+    return {leftEdge, rightEdge, isVisible};
+  };
+}
+
+function isEdgeVisible(target, start, end) {
+  let minVisiblePixels = 30;
+  return target >= start + minVisiblePixels && target <= end - minVisiblePixels;
+}
+
+function getPrevAndCurrentColumns(tableData, columnData) {
+  let {
+    tableRightVisibleEdge,
+    tableLeftVisibleEdge,
+    firstVisibleColumnIndex,
+  } = tableData;
+  let previousColumnIndex = Math.max(firstVisibleColumnIndex - 1, 0);
+  let previousColumn = columnData[previousColumnIndex];
+  let lastColumnIndex = columnData.length - 1;
+  let lastColumn = columnData[lastColumnIndex];
+  let currentColumn = assign(
+    {
+      isScrolledFarthestLeft:
+        firstVisibleColumnIndex === 0 && tableLeftVisibleEdge === 0,
+      isScrolledFarthestRight: lastColumn.rightEdge <= tableRightVisibleEdge,
+    },
+    columnData[firstVisibleColumnIndex]
+  );
+  return {previousColumn, currentColumn};
+}
+
+/**
+ * Polaris data table component.
+ * See https://polaris.shopify.com/components/lists-and-tables/data-table
+ */
+export default Component.extend({
+  classNameBindings: ['collapsed:Polaris-DataTable--collapsed'],
+
+  layout,
+
+  /**
+   * List of data types, which determines content alignment for each column.
+   * Data types are "text," which aligns left, or "numeric," which aligns right.
+   *
+   * @property columnContentTypes
+   * @type {String[]}
+   * @public
+   */
+  columnContentTypes: null,
+
+  /**
+   * List of column headings.
+   *
+   * @property headings
+   * @type {String[]}
+   * @public
+   */
+  headings: null,
+
+  /**
+   * List of numeric column totals, highlighted in the table’s header below column headings.
+   * Use empty strings as placeholders for columns with no total.
+   *
+   * @property totals
+   * @type {Array}
+   * @public
+   */
+  totals: null,
+
+  /**
+   * Lists of data points which map to table body rows.
+   *
+   * @property rows
+   * @type {Array[]}
+   * @public
+   */
+  rows: null,
+
+  /**
+   * Truncate content in first column instead of wrapping.
+   *
+   * @property truncate
+   * @type {boolean}
+   * @default false
+   * @public
+   */
+  truncate: false,
+
+  /**
+   * Content centered in the full width cell of the table footer row.
+   *
+   * @property footerContent
+   * @type {String|Number|Component}
+   * @public
+   */
+  footerContent: null,
+
+  /**
+   * List of booleans, which maps to whether sorting is enabled or not for each column.
+   * Defaults to false for all columns.
+   *
+   * @property sortable
+   * @type {boolean[]}
+   * @public
+   */
+  sortable: null,
+
+  /**
+   * The direction to sort the table rows on first click or keypress of a sortable column heading.
+   * Defaults to ascending.
+   *
+   * @property defaultSortDirection
+   * @type {String}
+   * @default 'ascending'
+   * @public
+   */
+  defaultSortDirection: 'ascending',
+
+  /**
+   * The index of the heading that the table rows are initially sorted by.
+   * Defaults to the first column.
+   *
+   * @property initialSortColumnIndex
+   * @type {Number}
+   * @default 0
+   * @public
+   */
+  initialSortColumnIndex: 0,
+
+  /**
+   * Callback fired on click or keypress of a sortable column heading.
+   *
+   * @property onSort
+   * @type {function}
+   * @public
+   */
+  onSort(/* headingIndex, direction */) {},
+
+  /**
+   * @property collapsed
+   * @type {boolean}
+   * @default false
+   * @private
+   */
+  collapsed: false,
+
+  /**
+   * @property columnVisibilityData
+   * @type {Object[]}
+   * @private
+   */
+  columnVisibilityData: null,
+
+  /**
+   * @property previousColumn
+   * @type {Object}
+   * @private
+   */
+  previousColumn: null,
+
+  /**
+   * @property currentColumn
+   * @type {Object}
+   * @private
+   */
+  currentColumn: null,
+
+  /**
+   * @property sorted
+   * @type {boolean}
+   * @default false
+   * @private
+   */
+  sorted: false,
+
+  /**
+   * @property sortedColumnIndex
+   * @type {Number}
+   * @private
+   */
+  sortedColumnIndex: null,
+
+  /**
+   * @property sortDirection
+   * @type {String}
+   * @private
+   */
+  sortDirection: null,
+
+  /**
+   * @property heights
+   * @type {Number[]}
+   * @private
+   */
+  heights: null,
+
+  /**
+   * @property preservedScrollPosition
+   * @type {Object}
+   * @private
+   */
+  preservedScrollPosition: null,
+
+  /**
+   * @property previousTruncate
+   * @type {boolean}
+   * @private
+   */
+  previousTruncate: null,
+
+  /**
+   * @property dataTable
+   * @type {HTMLElement}
+   * @private
+   */
+  dataTable: volatileElementLookup('.Polaris-DataTable').readOnly(),
+
+  /**
+   * @property scrollContainer
+   * @type {HTMLElement}
+   * @private
+   */
+  scrollContainer: volatileElementLookup('.Polaris-DataTable__ScrollContainer').readOnly(),
+
+  /**
+   * @property table
+   * @type {HTMLElement}
+   * @private
+   */
+  table: volatileElementLookup('.Polaris-DataTable__Table').readOnly(),
+
+  /**
+   * @property totalsRowHeading
+   * @type {String}
+   * @private
+   */
+  totalsRowHeading: 'Totals',
+
+  /**
+   * @property contentTypes
+   * @type {String[]}
+   * @private
+   */
+  contentTypes: computed('columnContentTypes.[]', function() {
+    let columnContentTypes = this.get('columnContentTypes');
+    let fixedCellType = columnContentTypes[0];
+
+    return [ fixedCellType, ...columnContentTypes ];
+  }).readOnly(),
+
+  /**
+   * @property scrollContainerStyle
+   * @type {String}
+   * @private
+   */
+  scrollContainerStyle: computed('footerContent', 'heights.[]', function() {
+    if (isBlank(this.get('footerContent'))) {
+      return null;
+    }
+
+    return htmlSafe(`margin-bottom: ${ this.get('heights.lastObject') }px;`);
+  }).readOnly(),
+
+  resetScrollPosition() {
+    let { left, top } = this.get('preservedScrollPosition');
+
+    if (left) {
+      this.get('scrollContainer').scrollLeft = left;
+    }
+
+    if (top) {
+      window.scrollTo(0, top);
+    }
+  },
+
+  setHeightsAndScrollPosition() {
+    this.set('heights', this.tallestCellHeights());
+
+    scheduleOnce('afterRender', this, this.resetScrollPosition);
+  },
+
+  calculateColumnVisibilityData(collapsed) {
+    if (collapsed) {
+      let headerCells = this.get('table').querySelectorAll(
+        '[class*=header]',
+      );
+      let collapsedHeaderCells = Array.from(headerCells).slice(2);
+      let fixedColumnWidth = headerCells[0].offsetWidth;
+      let tableData = {
+        fixedColumnWidth,
+        firstVisibleColumnIndex: collapsedHeaderCells.length - 1,
+        tableLeftVisibleEdge: this.get('scrollContainer').scrollLeft,
+        tableRightVisibleEdge:
+          this.get('scrollContainer').scrollLeft +
+          (this.get('dataTable').offsetWidth - fixedColumnWidth),
+      };
+      let columnVisibilityData = collapsedHeaderCells.map(
+        measureColumn(tableData),
+      );
+
+      return assign(
+        {
+          columnVisibilityData,
+        },
+        getPrevAndCurrentColumns(tableData, columnVisibilityData)
+      );
+    }
+
+    return {
+      columnVisibilityData: [],
+      previousColumn: undefined,
+      currentColumn: undefined,
+    };
+  },
+
+  handleResize() {
+    // This is needed to replicate the React implementation's `@debounce` decorator.
+    debounce(this, 'debouncedHandleResize', 0);
+  },
+
+  debouncedHandleResize() {
+    let { footerContent, truncate } = this.getProperties('footerContent', 'truncate');
+    let collapsed = this.get('table.scrollWidth') > this.get('dataTable.offsetWidth');
+
+    this.get('scrollContainer').scrollLeft = 0;
+    this.setProperties(assign(
+      {
+        collapsed,
+        heights: [],
+      },
+      this.calculateColumnVisibilityData(collapsed),
+    ));
+
+    scheduleOnce('afterRender', () => {
+      if (footerContent || !truncate) {
+        this.setHeightsAndScrollPosition();
+      }
+    });
+  },
+
+  tallestCellHeights() {
+    let { footerContent, truncate, heights } = this.getProperties('footerContent', 'truncate', 'heights');
+    let rows = Array.from(this.get('table').getElementsByTagName('tr'));
+
+    if (!truncate) {
+      return (heights = rows.map((row) => {
+        let fixedCell = row.children[0];
+        return Math.max(row.clientHeight, fixedCell.clientHeight);
+      }));
+    }
+
+    if (footerContent) {
+      let footerCellHeight = rows[rows.length - 1].children[0].clientHeight;
+      heights = [footerCellHeight];
+    }
+
+    return heights;
+  },
+
+  /*
+   * Lifecycle hooks.
+   */
+  init() {
+    this._super(...arguments);
+
+    this.setProperties({
+      columnVisibilityData: [],
+      sorted: isPresent(this.get('sortable')),
+      heights: [],
+      preservedScrollPosition: {},
+    });
+  },
+
+  didInsertElement() {
+    this._super(...arguments);
+
+    this.handleResize();
+  },
+
+  didUpdateAttrs() {
+    this._super(...arguments);
+
+    let truncate = this.get('truncate');
+    if (!truncate && this.get('previousTruncate')) {
+      this.handleResize();
+    }
+
+    this.set('previousTruncate', truncate);
+  },
+
+  actions: {
+    navigateTable() {
+      // TODO: implement this.
+    },
+
+    defaultOnSort() {
+      // TODO: implement this.
+    },
+  }
+});

--- a/addon/components/polaris-data-table/cell.js
+++ b/addon/components/polaris-data-table/cell.js
@@ -182,17 +182,6 @@ export default Component.extend({
     return `caret-${ sortDirection === 'ascending' ? 'up' : 'down' }`;
   }).readOnly(),
 
-  /**
-   * Check if the `text` passed is actually a component.
-   * @property hasContentComponent
-   * @type {String}
-   * @private
-   */
-  hasContentComponent: computed('text', function() {
-    let className = this.get('text.constructor.name') || '';
-    return className.indexOf('ComponentDefinition') > -1;
-  }).readOnly(),
-
   actions: {
     onKeyDown(event) {
       let { keyCode } = event;

--- a/addon/components/polaris-data-table/cell.js
+++ b/addon/components/polaris-data-table/cell.js
@@ -211,7 +211,7 @@ export default Component.extend({
 
   updateAccessibilityLabel() {
     let cellElement = document.querySelector(`#${ this.get('cellElementId') }`);
-    this.set('sortAccessibilityLabel', `Sort by ${ cellElement.textContent.trim().toLowerCase() }`);
+    this.set('sortAccessibilityLabel', `sort by ${ cellElement.textContent.trim().toLowerCase() }`);
   },
 
   didRender() {

--- a/addon/components/polaris-data-table/cell.js
+++ b/addon/components/polaris-data-table/cell.js
@@ -211,7 +211,7 @@ export default Component.extend({
 
   updateAccessibilityLabel() {
     let cellElement = document.querySelector(`#${ this.get('cellElementId') }`);
-    this.set('sortAccessibilityLabel', `Sort by ${cellElement.textContent.trim().toLowerCase()}`);
+    this.set('sortAccessibilityLabel', `Sort by ${ cellElement.textContent.trim().toLowerCase() }`);
   },
 
   didRender() {

--- a/addon/components/polaris-data-table/cell.js
+++ b/addon/components/polaris-data-table/cell.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { htmlSafe } from '@ember/string';
+import { guidFor } from '@ember/object/internals';
 import layout from '../../templates/components/polaris-data-table/cell';
 
 export default Component.extend({
@@ -116,6 +117,26 @@ export default Component.extend({
   onSort() {},
 
   /**
+   * Accessibility label for the cell. This will get set dynamically after rendering.
+   *
+   * @property sortAccessibilityLabel
+   * @type {String}
+   * @private
+   */
+  sortAccessibilityLabel: null,
+
+  /**
+   * Generated unique ID to be set on the rendered SVG element.
+   *
+   * @property cellElementId
+   * @type {String}
+   * @private
+   */
+  cellElementId: computed(function() {
+    return guidFor(this);
+  }).readOnly(),
+
+  /**
    * @property cellClassNames
    * @type {String}
    * @private
@@ -187,6 +208,17 @@ export default Component.extend({
     let sortDirection = this.get('sorted') ? this.get('sortDirection') : this.get('defaultSortDirection');
     return `caret-${ sortDirection === 'ascending' ? 'up' : 'down' }`;
   }).readOnly(),
+
+  updateAccessibilityLabel() {
+    let cellElement = document.querySelector(`#${ this.get('cellElementId') }`);
+    this.set('sortAccessibilityLabel', `Sort by ${cellElement.textContent.trim().toLowerCase()}`);
+  },
+
+  didRender() {
+    this._super(...arguments);
+
+    this.updateAccessibilityLabel();
+  },
 
   actions: {
     onKeyDown(event) {

--- a/addon/components/polaris-data-table/cell.js
+++ b/addon/components/polaris-data-table/cell.js
@@ -182,6 +182,17 @@ export default Component.extend({
     return `caret-${ sortDirection === 'ascending' ? 'up' : 'down' }`;
   }).readOnly(),
 
+  /**
+   * Check if the `text` passed is actually a component.
+   * @property hasContentComponent
+   * @type {String}
+   * @private
+   */
+  hasContentComponent: computed('text', function() {
+    // TODO: use `ember-cli-is-component` here? This seems fragile...
+    return this.get('text.constructor.name') === 'CurriedComponentDefinition';
+  }).readOnly(),
+
   actions: {
     onKeyDown(event) {
       let { keyCode } = event;

--- a/addon/components/polaris-data-table/cell.js
+++ b/addon/components/polaris-data-table/cell.js
@@ -167,4 +167,28 @@ export default Component.extend({
     let height = this.get('height');
     return height ? htmlSafe(`height: ${ height }px`) : undefined;
   }).readOnly(),
+
+  /**
+   * @property sortIconSource
+   * @type {String}
+   * @private
+   */
+  sortIconSource: computed('sortable', 'sorted', 'sortDirection', 'defaultSortDirection', function() {
+    if (!this.get('sortable')) {
+      return null;
+    }
+
+    let sortDirection = this.get('sorted') ? this.get('sortDirection') : this.get('defaultSortDirection');
+    return `caret-${ sortDirection === 'ascending' ? 'up' : 'down' }`;
+  }).readOnly(),
+
+  actions: {
+    onKeyDown(event) {
+      let { keyCode } = event;
+      let sortFunc = this.get('onSort');
+      if (keyCode === 13 && sortFunc !== undefined) {
+        sortFunc();
+      }
+    },
+  }
 });

--- a/addon/components/polaris-data-table/cell.js
+++ b/addon/components/polaris-data-table/cell.js
@@ -1,0 +1,170 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { htmlSafe } from '@ember/string';
+import layout from '../../templates/components/polaris-data-table/cell';
+
+export default Component.extend({
+  tagName: '',
+
+  layout,
+
+  /**
+   * @property height
+   * @type {Number}
+   * @public
+   */
+  height: null,
+
+  /**
+   * TODO: support rendering a component here
+   *
+   * @property text
+   * @type {String|Component}
+   * @public
+   */
+  text: null,
+
+  /**
+   * @property contentType
+   * @type {String}
+   * @public
+   */
+  contentType: null,
+
+  /**
+   * @property fixed
+   * @type {boolean}
+   * @public
+   */
+  fixed: false,
+
+  /**
+   * @property truncate
+   * @type {boolean}
+   * @public
+   */
+  truncate: false,
+
+  /**
+   * @property presentational
+   * @type {boolean}
+   * @public
+   */
+  presentational: false,
+
+  /**
+   * @property header
+   * @type {boolean}
+   * @public
+   */
+  header: false,
+
+  /**
+   * @property total
+   * @type {boolean}
+   * @public
+   */
+  total: false,
+
+  /**
+   * @property footer
+   * @type {boolean}
+   * @public
+   */
+  footer: false,
+
+  /**
+   * @property sorted
+   * @type {boolean}
+   * @public
+   */
+  sorted: false,
+
+  /**
+   * @property sortable
+   * @type {boolean}
+   * @public
+   */
+  sortable: false,
+
+  /**
+   * @property sortDirection
+   * @type {String}
+   * @public
+   */
+  sortDirection: null,
+
+  /**
+   * @property defaultSortDirection
+   * @type {String}
+   * @public
+   */
+  defaultSortDirection: null,
+
+  /**
+   * @property onSort
+   * @type {function}
+   * @default no-op
+   * @public
+   */
+  onSort() {},
+
+  /**
+   * @property cellClassNames
+   * @type {String}
+   * @private
+   */
+  cellClassNames: computed('fixed', 'truncate', 'presentational', 'header', 'total', 'footer', 'contentType', 'sorted', 'sortable', function() {
+    let classNames = [ 'Polaris-DataTable__Cell' ];
+
+    let { fixed, truncate, presentational, header, total, footer, contentType, sorted, sortable } = this.getProperties('fixed', 'truncate', 'presentational', 'header', 'total', 'footer', 'contentType', 'sorted', 'sortable');
+
+    if (fixed) {
+      classNames.push('Polaris-DataTable__Cell--fixed');
+
+      if (truncate) {
+        classNames.push('Polaris-DataTable__Cell--truncated');
+      }
+    }
+
+    if (presentational) {
+      classNames.push('Polaris-DataTable__Cell--presentational');
+    }
+
+    if (header) {
+      classNames.push('Polaris-DataTable__Cell--header');
+    }
+
+    if (total) {
+      classNames.push('Polaris-DataTable__Cell--total');
+    }
+
+    if (footer) {
+      classNames.push('Polaris-DataTable__Cell--footer');
+    }
+
+    if (contentType === 'numeric') {
+      classNames.push('Polaris-DataTable__Cell--numeric');
+    }
+
+    if (sorted) {
+      classNames.push('Polaris-DataTable__Cell--sorted');
+    }
+
+    if (sortable) {
+      classNames.push('Polaris-DataTable__Cell--sortable');
+    }
+
+    return classNames.join(' ');
+  }).readOnly(),
+
+  /**
+   * @property style
+   * @type {String}
+   * @private
+   */
+  style: computed('height', function() {
+    let height = this.get('height');
+    return height ? htmlSafe(`height: ${ height }px`) : undefined;
+  }).readOnly(),
+});

--- a/addon/components/polaris-data-table/cell.js
+++ b/addon/components/polaris-data-table/cell.js
@@ -32,6 +32,7 @@ export default Component.extend({
   /**
    * @property fixed
    * @type {boolean}
+   * @default false
    * @public
    */
   fixed: false,
@@ -39,6 +40,7 @@ export default Component.extend({
   /**
    * @property truncate
    * @type {boolean}
+   * @default false
    * @public
    */
   truncate: false,
@@ -46,6 +48,7 @@ export default Component.extend({
   /**
    * @property presentational
    * @type {boolean}
+   * @default false
    * @public
    */
   presentational: false,
@@ -53,6 +56,7 @@ export default Component.extend({
   /**
    * @property header
    * @type {boolean}
+   * @default false
    * @public
    */
   header: false,
@@ -60,6 +64,7 @@ export default Component.extend({
   /**
    * @property total
    * @type {boolean}
+   * @default false
    * @public
    */
   total: false,
@@ -67,6 +72,7 @@ export default Component.extend({
   /**
    * @property footer
    * @type {boolean}
+   * @default false
    * @public
    */
   footer: false,
@@ -74,6 +80,7 @@ export default Component.extend({
   /**
    * @property sorted
    * @type {boolean}
+   * @default false
    * @public
    */
   sorted: false,
@@ -81,6 +88,7 @@ export default Component.extend({
   /**
    * @property sortable
    * @type {boolean}
+   * @default false
    * @public
    */
   sortable: false,

--- a/addon/components/polaris-data-table/cell.js
+++ b/addon/components/polaris-data-table/cell.js
@@ -189,8 +189,8 @@ export default Component.extend({
    * @private
    */
   hasContentComponent: computed('text', function() {
-    // TODO: use `ember-cli-is-component` here? This seems fragile...
-    return this.get('text.constructor.name') === 'CurriedComponentDefinition';
+    let className = this.get('text.constructor.name') || '';
+    return className.indexOf('ComponentDefinition') > -1;
   }).readOnly(),
 
   actions: {

--- a/addon/components/polaris-data-table/cell.js
+++ b/addon/components/polaris-data-table/cell.js
@@ -16,8 +16,6 @@ export default Component.extend({
   height: null,
 
   /**
-   * TODO: support rendering a component here
-   *
    * @property text
    * @type {String|Component}
    * @public

--- a/addon/components/polaris-data-table/heading.js
+++ b/addon/components/polaris-data-table/heading.js
@@ -25,6 +25,7 @@ export default Component.extend({
   /**
    * @property truncate
    * @type {boolean}
+   * @default false
    * @public
    */
   truncate: false,

--- a/addon/components/polaris-data-table/heading.js
+++ b/addon/components/polaris-data-table/heading.js
@@ -1,0 +1,146 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { equal } from '@ember/object/computed';
+import layout from '../../templates/components/polaris-data-table/heading';
+
+export default Component.extend({
+  tagName: '',
+
+  layout,
+
+  /**
+   * @property heading
+   * @type {String}
+   * @public
+   */
+  heading: null,
+
+  /**
+   * @property headingIndex
+   * @type {Number}
+   * @public
+   */
+  headingIndex: null,
+
+  /**
+   * @property truncate
+   * @type {boolean}
+   * @public
+   */
+  truncate: false,
+
+  /**
+   * @property heights
+   * @type {Number[]}
+   * @public
+   */
+  heights: null,
+
+  /**
+   * @property sortable
+   * @type {boolean[]}
+   * @public
+   */
+  sortable: null,
+
+  /**
+   * @property sortedColumnIndex
+   * @type {Number}
+   * @public
+   */
+  sortedColumnIndex: null,
+
+  /**
+   * @property sortDirection
+   * @type {String}
+   * @public
+   */
+  sortDirection: null,
+
+  /**
+   * @property contentTypes
+   * @type {String[]}
+   * @public
+   */
+  contentTypes: null,
+
+  /**
+   * @property defaultSortDirection
+   * @type {String}
+   * @public
+   */
+  defaultSortDirection: null,
+
+  /**
+   * @property defaultOnSort
+   * @type {function}
+   * @default no-op
+   * @public
+   */
+  defaultOnSort() {},
+
+  /**
+   * @property isFixed
+   * @type {boolean}
+   * @private
+   */
+  isFixed: equal('headingIndex', 0).readOnly(),
+
+  /**
+   * @property isPresentational
+   * @type {boolean}
+   * @private
+   */
+  isPresentational: equal('headingIndex', 1).readOnly(),
+
+  /**
+   * @property height
+   * @type {Number}
+   * @private
+   */
+  height: computed('truncate', 'heights.[]', function() {
+    return !this.get('truncate') ? this.get('heights.firstObject') : undefined;
+  }).readOnly(),
+
+  /**
+   * We account for the presentational heading cell’s index when
+   * accessing elements from arrays passed as props and when comparing
+   * a heading index with the sorted column’s index.
+   *
+   * @property index
+   * @type {Number}
+   * @private
+   */
+  index: computed('headingIndex', function() {
+    let headingIndex = this.get('headingIndex');
+    return headingIndex <= 1 ? headingIndex : headingIndex - 1;
+  }).readOnly(),
+
+  /**
+   * @property isSortable
+   * @type {boolean}
+   * @private
+   */
+  isSortable: computed('sortable.[]', 'index', function() {
+    return this.get('sortable')[this.get('index')];
+  }).readOnly(),
+
+  /**
+   * @property isSorted
+   * @type {boolean}
+   * @private
+   */
+  isSorted: computed('isSortable', 'sortedColumnIndex', 'index', function() {
+    let { isSortable, sortedColumnIndex, index } = this.getProperties('isSortable', 'sortedColumnIndex', 'index');
+    return isSortable && sortedColumnIndex === index;
+  }).readOnly(),
+
+  /**
+   * @property direction
+   * @type {String}
+   * @private
+   */
+  direction: computed('isSorted', 'sortDirection', function() {
+    return this.get('isSorted') ? this.get('sortDirection') : 'none';
+  }).readOnly(),
+});

--- a/addon/components/polaris-data-table/navigation.js
+++ b/addon/components/polaris-data-table/navigation.js
@@ -1,0 +1,38 @@
+import Component from '@ember/component';
+import layout from '../../templates/components/polaris-data-table/navigation';
+
+export default Component.extend({
+  classNames: ['Polaris-DataTable__Navigation'],
+
+  layout,
+
+  /**
+   * @property currentColumn
+   * @type {Object}
+   * @public
+   */
+  currentColumn: null,
+
+  /**
+   * @property columnVisibilityData
+   * @type {Object[]}
+   * @public
+   */
+  columnVisibilityData: null,
+
+  /**
+   * @property navigateTableLeft
+   * @type {function}
+   * @default no-op
+   * @public
+   */
+  navigateTableLeft() {},
+
+  /**
+   * @property navigateTableRight
+   * @type {function}
+   * @default no-op
+   * @public
+   */
+  navigateTableRight() {},
+});

--- a/addon/components/polaris-data-table/row.js
+++ b/addon/components/polaris-data-table/row.js
@@ -1,0 +1,77 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { isPresent } from '@ember/utils';
+import layout from '../../templates/components/polaris-data-table/row';
+
+export default Component.extend({
+  tagName: 'tr',
+  classNames: ['Polaris-DataTable__TableRow'],
+
+  layout,
+
+  /**
+   * @property row
+   * @type {Array}
+   * @public
+   */
+  row: null,
+
+  /**
+   * @property index
+   * @type {Number}
+   * @public
+   */
+  index: null,
+
+  /**
+   * @property totals
+   * @type {Number[]}
+   * @public
+   */
+  totals: null,
+
+  /**
+   * @property heights
+   * @type {Number[]}
+   * @public
+   */
+  heights: null,
+
+  /**
+   * @property footerContent
+   * @type {String|Number|Component}
+   * @public
+   */
+  footerContent: null,
+
+  /**
+   * @property contentTypes
+   * @type {String[]}
+   * @public
+   */
+  contentTypes: null,
+
+  /**
+   * @property truncate
+   * @type {boolean}
+   * @default false
+   * @public
+   */
+  truncate: false,
+
+  /**
+   * @property bodyCellHeights
+   * @type {Number[]}
+   * @private
+   */
+  bodyCellHeights: computed('totals.[]', 'heights.[]', 'footerContent', function() {
+    let { totals, heights, footerContent } = this.getProperties('totals', 'heights', 'footerContent');
+    let bodyCellHeights = isPresent(totals) ? heights.slice(2) : heights.slice(1);
+
+    if (footerContent) {
+      bodyCellHeights.pop();
+    }
+
+    return bodyCellHeights;
+  }).readOnly(),
+});

--- a/addon/components/polaris-data-table/total.js
+++ b/addon/components/polaris-data-table/total.js
@@ -1,0 +1,56 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import layout from '../../templates/components/polaris-data-table/total';
+
+export default Component.extend({
+  tagName: '',
+
+  layout,
+
+  /**
+   * TODO: make this support passing a component to render instead of just text/numbers.
+   *
+   * @property total
+   * @type {String|Number}
+   * @public
+   */
+  total: null,
+
+  /**
+   * @property index
+   * @type {Number}
+   * @public
+   */
+  index: null,
+
+  /**
+   * @property heights
+   * @type {Number[]}
+   * @public
+   */
+  heights: null,
+
+  /**
+   * @property truncate
+   * @type {boolean}
+   * @public
+   */
+  truncate: false,
+
+  /**
+   * @property totalsRowHeading
+   * @type {String}
+   * @public
+   */
+  totalsRowHeading: null,
+
+  /**
+   * @property height
+   * @type {Number}
+   * @private
+   */
+  height: computed('heights.[]', 'truncate', function() {
+    let { heights, truncate } = this.getProperties('heights', 'truncate');
+    return !truncate ? heights[1] : undefined;
+  }).readOnly(),
+});

--- a/addon/components/polaris-data-table/total.js
+++ b/addon/components/polaris-data-table/total.js
@@ -8,10 +8,8 @@ export default Component.extend({
   layout,
 
   /**
-   * TODO: make this support passing a component to render instead of just text/numbers.
-   *
    * @property total
-   * @type {String|Number}
+   * @type {String|Number|Component}
    * @public
    */
   total: null,
@@ -33,6 +31,7 @@ export default Component.extend({
   /**
    * @property truncate
    * @type {boolean}
+   * @default false
    * @public
    */
   truncate: false,

--- a/addon/helpers/get-array-item.js
+++ b/addon/helpers/get-array-item.js
@@ -1,0 +1,14 @@
+import { helper } from '@ember/component/helper';
+
+// Helper to allow array access from templates.
+// This is only needed to support Ember 2.12,
+// which doesn't allow passing non-string keys
+// to the `get` helper. If we stop supporting
+// Ember 2.12, we can remove this helper and
+// replace its usages with the existing `get`
+// helper.
+export function getArrayItem([ array, index ]) {
+  return array[index];
+}
+
+export default helper(getArrayItem);

--- a/addon/helpers/polaris-data-table/insert-presentational-cell.js
+++ b/addon/helpers/polaris-data-table/insert-presentational-cell.js
@@ -1,0 +1,8 @@
+import { helper } from '@ember/component/helper';
+
+export function polarisDataTableInsertPresentationalCell([ cells ]) {
+  let [ fixedCell, ...rest ] = cells;
+  return [ fixedCell, '', ...rest ];
+}
+
+export default helper(polarisDataTableInsertPresentationalCell);

--- a/addon/mixins/components/svg-handling.js
+++ b/addon/mixins/components/svg-handling.js
@@ -2,6 +2,7 @@ import Mixin from '@ember/object/mixin';
 import { computed } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { isNone } from '@ember/utils';
+import { scheduleOnce } from '@ember/runloop';
 
 /*
  * This mixin is intended for use with components that render an SVG icon
@@ -49,6 +50,10 @@ export default Mixin.create({
     return document.querySelector(`#${ this.get('svgElementId') }`);
   }).volatile(),
 
+  removeFillsFromSvgElement() {
+    this.removeSvgFills(this.get('svgElement'));
+  },
+
   /*
    * Helper method to process the `fill` attribute
    * on a given SVG element and its children.
@@ -79,6 +84,12 @@ export default Mixin.create({
   didInsertElement() {
     this._super(...arguments);
 
-    this.removeSvgFills(this.get('svgElement'));
+    this.removeFillsFromSvgElement();
+  },
+
+  didUpdateAttrs() {
+    this._super(...arguments);
+
+    scheduleOnce('afterRender', this, this.removeFillsFromSvgElement);
   },
 });

--- a/addon/templates/components/polaris-data-table.hbs
+++ b/addon/templates/components/polaris-data-table.hbs
@@ -7,12 +7,6 @@
 
 <div class="Polaris-DataTable {{if collapsed "Polaris-DataTable--collapsed"}} {{if footerContent "Polaris-DataTable--hasFooter"}}">
   <div class="Polaris-DataTable__ScrollContainer" style={{scrollContainerStyle}}>
-    {{!-- TODO: add these event listeners --}}
-{{!--
-    <EventListener event="resize" handler={this.handleResize} />
-    <EventListener capture event="scroll" handler={this.scrollListener} />
---}}
-
     <table class="Polaris-DataTable__Table">
       <thead>
         <tr>

--- a/addon/templates/components/polaris-data-table.hbs
+++ b/addon/templates/components/polaris-data-table.hbs
@@ -17,7 +17,7 @@
               truncate=truncate
               heights=heights
               sortable=sortable
-              sortedColumnIndex=sortedColumnIndex
+              sortedColumnIndex=(or sortedColumnIndex initialSortColumnIndex)
               sortDirection=sortDirection
               contentTypes=contentTypes
               defaultSortDirection=defaultSortDirection

--- a/addon/templates/components/polaris-data-table.hbs
+++ b/addon/templates/components/polaris-data-table.hbs
@@ -1,0 +1,78 @@
+{{polaris-data-table/navigation
+  currentColumn=currentColumn
+  columnVisibilityData=columnVisibilityData
+  navigateTableLeft=(action "navigateTable" "left")
+  navigateTableRight=(action "navigateTable" "right")
+}}
+
+<div class="Polaris-DataTable {{if collapsed "Polaris-DataTable--collapsed"}} {{if footerContent "Polaris-DataTable--hasFooter"}}">
+  <div class="Polaris-DataTable__ScrollContainer" style={{scrollContainerStyle}}>
+    {{!-- TODO: add these event listeners --}}
+{{!--
+    <EventListener event="resize" handler={this.handleResize} />
+    <EventListener capture event="scroll" handler={this.scrollListener} />
+--}}
+
+    <table class="Polaris-DataTable__Table">
+      <thead>
+        <tr>
+          {{#each (polaris-data-table/insert-presentational-cell headings) as |heading headingIndex|}}
+            {{polaris-data-table/heading
+              heading=heading
+              headingIndex=headingIndex
+              truncate=truncate
+              heights=heights
+              sortable=sortable
+              sortedColumnIndex=sortedColumnIndex
+              sortDirection=sortDirection
+              contentTypes=contentTypes
+              defaultSortDirection=defaultSortDirection
+              defaultOnSort=(action "defaultOnSort")
+            }}
+          {{/each}}
+        </tr>
+
+        {{#if totals}}
+          <tr>
+            {{#each (polaris-data-table/insert-presentational-cell totals) as |total index|}}
+              {{polaris-data-table/total
+                total=total
+                index=index
+                heights=heights
+                truncate=truncate
+                totalsRowHeading=totalsRowHeading
+              }}
+            {{/each}}
+          </tr>
+        {{/if}}
+      </thead>
+
+      <tbody>
+        {{#each rows as |row index|}}
+          {{polaris-data-table/row
+            row=row
+            index=index
+            totals=totals
+            heights=heights
+            footerContent=footerContent
+            contentTypes=contentTypes
+            truncate=truncate
+          }}
+        {{/each}}
+      </tbody>
+
+      {{#if footerContent}}
+        <tfoot class="Polaris-DataTable__TableFoot">
+          <tr>
+            {{polaris-data-table/cell
+              footer=true
+              height=heights.lastObject
+              text=footerContent
+              truncate=truncate
+            }}
+          </tr>
+        </tfoot>
+      {{/if}}
+    </table>
+  </div>
+</div>

--- a/addon/templates/components/polaris-data-table/cell.hbs
+++ b/addon/templates/components/polaris-data-table/cell.hbs
@@ -21,7 +21,11 @@
         >
           {{#if (eq contentType "text")}}
             <span class="Polaris-DataTable__Heading {{if (eq contentType "text") "Polaris-DataTable__Heading--left"}}">
-              {{text}}
+              {{#if hasContentComponent}}
+                {{component text}}
+              {{else}}
+                {{text}}
+              {{/if}}
               <span class="Polaris-DataTable__Heading--sortable">
                 {{#unless sorted}}
                   {{polaris-icon source=sortIconSource}}
@@ -45,7 +49,11 @@
                   {{polaris-icon source=sortIconSource}}
                 {{/if}}
               </span>
-              {{text}}
+              {{#if hasContentComponent}}
+                {{component text}}
+              {{else}}
+                {{text}}
+              {{/if}}
             </span>
           {{/if}}
         </th>
@@ -56,17 +64,29 @@
           style={{style}}
           aria-disabled="true"
         >
-          {{text}}
+          {{#if hasContentComponent}}
+            {{component text}}
+          {{else}}
+            {{text}}
+          {{/if}}
         </th>
       {{/if}}
     {{else}}
       <th class={{cellClassNames}} scope="row" style={{style}}>
-        {{text}}
+        {{#if hasContentComponent}}
+          {{component text}}
+        {{else}}
+          {{text}}
+        {{/if}}
       </th>
     {{/if}}
   {{else}}
     <td class={{cellClassNames}} style={{style}}>
-      {{text}}
+      {{#if hasContentComponent}}
+        {{component text}}
+      {{else}}
+        {{text}}
+      {{/if}}
     </td>
   {{/if}}
 {{/if}}

--- a/addon/templates/components/polaris-data-table/cell.hbs
+++ b/addon/templates/components/polaris-data-table/cell.hbs
@@ -7,41 +7,58 @@
 {{else}}
   {{#if (or header fixed)}}
     {{#if header}}
-      {{#with (component "wrapper-element"
-        tagName="th"
-        scope="col"
-        class=cellClassNames
-        style=style
-      ) as |headerComponent|}}
-        {{#if sortable}}
-          {{#component headerComponent
-            role=button
-            aria-sort=sortDirection
-            aria-label=sortAccessibilityLabel
-            click=(action onSort)
-            keyDown=(action onKeyDown)
-          }}
-            {{#if (eq contentType "text")}}
-              {{!-- TODO: add headerClassName, iconClassName, sortableIconMarkup and sortedIconMarkup --}}
-              <span class={headerClassName}>
-                {{text}}
-                <span class={iconClassName}>{sortableIconMarkup}</span>
-                <span>{sortedIconMarkup}</span>
-              </span>
-            {{else}}
-              <span class={headerClassName}>
-              <span class={iconClassName}>{sortableIconMarkup}</span>
-              <span>{sortedIconMarkup}</span>
+      {{#if sortable}}
+        <th
+          scope="col"
+          class={{cellClassNames}}
+          style={{style}}
+          role="button"
+          aria-sort={{sortDirection}}
+          aria-label={{sortAccessibilityLabel}}
+          tabindex="0"
+          {{action onSort}}
+          onkeydown={{action "onKeyDown"}}
+        >
+          {{#if (eq contentType "text")}}
+            <span class="Polaris-DataTable__Heading {{if (eq contentType "text") "Polaris-DataTable__Heading--left"}}">
               {{text}}
-             </span>
-            {{/if}}
-          {{/component}}
-        {{else}}
-          {{#component headerComponent aria-disabled=true}}
-            {{text}}
-          {{/component}}
-        {{/if}}
-      {{/with}}
+              <span class="Polaris-DataTable__Heading--sortable">
+                {{#unless sorted}}
+                  {{polaris-icon source=sortIconSource}}
+                {{/unless}}
+              </span>
+              <span>
+                {{#if sorted}}
+                  {{polaris-icon source=sortIconSource}}
+                {{/if}}
+              </span>
+            </span>
+          {{else}}
+            <span class="Polaris-DataTable__Heading {{if (eq contentType "text") "Polaris-DataTable__Heading--left"}}">
+              <span class="Polaris-DataTable__Heading--sortable">
+                {{#unless sorted}}
+                  {{polaris-icon source=sortIconSource}}
+                {{/unless}}
+              </span>
+              <span>
+                {{#if sorted}}
+                  {{polaris-icon source=sortIconSource}}
+                {{/if}}
+              </span>
+              {{text}}
+            </span>
+          {{/if}}
+        </th>
+      {{else}}
+        <th
+          scope="col"
+          class={{cellClassNames}}
+          style={{style}}
+          aria-disabled="true"
+        >
+          {{text}}
+        </th>
+      {{/if}}
     {{else}}
       <th class={{cellClassNames}} scope="row" style={{style}}>
         {{text}}

--- a/addon/templates/components/polaris-data-table/cell.hbs
+++ b/addon/templates/components/polaris-data-table/cell.hbs
@@ -21,11 +21,7 @@
         >
           {{#if (eq contentType "text")}}
             <span class="Polaris-DataTable__Heading {{if (eq contentType "text") "Polaris-DataTable__Heading--left"}}">
-              {{#if hasContentComponent}}
-                {{component text}}
-              {{else}}
-                {{text}}
-              {{/if}}
+              {{render-content text}}
               <span class="Polaris-DataTable__Heading--sortable">
                 {{#unless sorted}}
                   {{polaris-icon source=sortIconSource}}
@@ -49,11 +45,7 @@
                   {{polaris-icon source=sortIconSource}}
                 {{/if}}
               </span>
-              {{#if hasContentComponent}}
-                {{component text}}
-              {{else}}
-                {{text}}
-              {{/if}}
+              {{render-content text}}
             </span>
           {{/if}}
         </th>
@@ -64,29 +56,17 @@
           style={{style}}
           aria-disabled="true"
         >
-          {{#if hasContentComponent}}
-            {{component text}}
-          {{else}}
-            {{text}}
-          {{/if}}
+          {{render-content text}}
         </th>
       {{/if}}
     {{else}}
       <th class={{cellClassNames}} scope="row" style={{style}}>
-        {{#if hasContentComponent}}
-          {{component text}}
-        {{else}}
-          {{text}}
-        {{/if}}
+        {{render-content text}}
       </th>
     {{/if}}
   {{else}}
     <td class={{cellClassNames}} style={{style}}>
-      {{#if hasContentComponent}}
-        {{component text}}
-      {{else}}
-        {{text}}
-      {{/if}}
+      {{render-content text}}
     </td>
   {{/if}}
 {{/if}}

--- a/addon/templates/components/polaris-data-table/cell.hbs
+++ b/addon/templates/components/polaris-data-table/cell.hbs
@@ -1,14 +1,15 @@
 {{#if presentational}}
   {{#if header}}
-    <th aria-hidden="true" role="presentation" class={{cellClassNames}} style={{style}}></th>
+    <th aria-hidden="true" role="presentation" id={{cellElementId}} class={{cellClassNames}} style={{style}}></th>
   {{else}}
-    <td aria-hidden="true" role="presentation" class={{cellClassNames}} style={{style}}></td>
+    <td aria-hidden="true" role="presentation" id={{cellElementId}} class={{cellClassNames}} style={{style}}></td>
   {{/if}}
 {{else}}
   {{#if (or header fixed)}}
     {{#if header}}
       {{#if sortable}}
         <th
+          id={{cellElementId}}
           scope="col"
           class={{cellClassNames}}
           style={{style}}
@@ -52,6 +53,7 @@
       {{else}}
         <th
           scope="col"
+          id={{cellElementId}}
           class={{cellClassNames}}
           style={{style}}
           aria-disabled="true"
@@ -60,12 +62,12 @@
         </th>
       {{/if}}
     {{else}}
-      <th class={{cellClassNames}} scope="row" style={{style}}>
+      <th id={{cellElementId}} class={{cellClassNames}} scope="row" style={{style}}>
         {{render-content text}}
       </th>
     {{/if}}
   {{else}}
-    <td class={{cellClassNames}} style={{style}}>
+    <td id={{cellElementId}} class={{cellClassNames}} style={{style}}>
       {{render-content text}}
     </td>
   {{/if}}

--- a/addon/templates/components/polaris-data-table/cell.hbs
+++ b/addon/templates/components/polaris-data-table/cell.hbs
@@ -21,7 +21,7 @@
           onkeydown={{action "onKeyDown"}}
         >
           {{#if (eq contentType "text")}}
-            <span class="Polaris-DataTable__Heading {{if (eq contentType "text") "Polaris-DataTable__Heading--left"}}">
+            <span class="Polaris-DataTable__Heading Polaris-DataTable__Heading--left">
               {{render-content text}}
               <span class="Polaris-DataTable__Heading--sortable">
                 {{#unless sorted}}
@@ -35,7 +35,7 @@
               </span>
             </span>
           {{else}}
-            <span class="Polaris-DataTable__Heading {{if (eq contentType "text") "Polaris-DataTable__Heading--left"}}">
+            <span class="Polaris-DataTable__Heading">
               <span class="Polaris-DataTable__Heading--sortable">
                 {{#unless sorted}}
                   {{polaris-icon source=sortIconSource}}

--- a/addon/templates/components/polaris-data-table/cell.hbs
+++ b/addon/templates/components/polaris-data-table/cell.hbs
@@ -1,0 +1,55 @@
+{{#if presentational}}
+  {{#if header}}
+    <th aria-hidden="true" role="presentation" class={{cellClassNames}} style={{style}}></th>
+  {{else}}
+    <td aria-hidden="true" role="presentation" class={{cellClassNames}} style={{style}}></td>
+  {{/if}}
+{{else}}
+  {{#if (or header fixed)}}
+    {{#if header}}
+      {{#with (component "wrapper-element"
+        tagName="th"
+        scope="col"
+        class=cellClassNames
+        style=style
+      ) as |headerComponent|}}
+        {{#if sortable}}
+          {{#component headerComponent
+            role=button
+            aria-sort=sortDirection
+            aria-label=sortAccessibilityLabel
+            click=(action onSort)
+            keyDown=(action onKeyDown)
+          }}
+            {{#if (eq contentType "text")}}
+              {{!-- TODO: add headerClassName, iconClassName, sortableIconMarkup and sortedIconMarkup --}}
+              <span class={headerClassName}>
+                {{text}}
+                <span class={iconClassName}>{sortableIconMarkup}</span>
+                <span>{sortedIconMarkup}</span>
+              </span>
+            {{else}}
+              <span class={headerClassName}>
+              <span class={iconClassName}>{sortableIconMarkup}</span>
+              <span>{sortedIconMarkup}</span>
+              {{text}}
+             </span>
+            {{/if}}
+          {{/component}}
+        {{else}}
+          {{#component headerComponent aria-disabled=true}}
+            {{text}}
+          {{/component}}
+        {{/if}}
+      {{/with}}
+    {{else}}
+      <th class={{cellClassNames}} scope="row" style={{style}}>
+        {{text}}
+      </th>
+    {{/if}}
+  {{else}}
+    <td class={{cellClassNames}} style={{style}}>
+      {{text}}
+    </td>
+  {{/if}}
+{{/if}}

--- a/addon/templates/components/polaris-data-table/heading.hbs
+++ b/addon/templates/components/polaris-data-table/heading.hbs
@@ -2,7 +2,7 @@
   header=true
   height=height
   text=heading
-  contentType=(get contentTypes headingIndex)
+  contentType=(get-array-item contentTypes headingIndex)
   fixed=isFixed
   truncate=truncate
   presentational=isPresentational

--- a/addon/templates/components/polaris-data-table/heading.hbs
+++ b/addon/templates/components/polaris-data-table/heading.hbs
@@ -1,0 +1,14 @@
+{{polaris-data-table/cell
+  header=true
+  height=height
+  text=heading
+  contentType=(get contentTypes headingIndex)
+  fixed=isFixed
+  truncate=truncate
+  presentational=isPresentational
+  defaultSortDirection=(if sortable defaultSortDirection)
+  sorted=(if sortable isSorted)
+  sortable=(if sortable isSortable)
+  sortDirection=(if sortable direction)
+  onSort=(if sortable (action defaultOnSort index))
+}}

--- a/addon/templates/components/polaris-data-table/navigation.hbs
+++ b/addon/templates/components/polaris-data-table/navigation.hbs
@@ -1,0 +1,19 @@
+{{polaris-button
+  plain=true
+  icon="chevron-left"
+  disabled=currentColumn.isScrolledFarthestLeft
+  accessibilityLabel="Scroll table left one column"
+  onClick=(action navigateTableLeft)
+}}
+
+{{#each columnVisibilityData as |column|}}
+  <div class="Polaris-DataTable__Pip {{if column.isVisible "Polaris-DataTable__Pip--visible"}}"></div>
+{{/each}}
+
+{{polaris-button
+  plain=true
+  icon="chevron-right"
+  disabled=currentColumn.isScrolledFarthestRight
+  accessibilityLabel="Scroll table right one column"
+  onClick=(action navigateTableRight)
+}}

--- a/addon/templates/components/polaris-data-table/navigation.hbs
+++ b/addon/templates/components/polaris-data-table/navigation.hbs
@@ -7,7 +7,7 @@
 }}
 
 {{#each columnVisibilityData as |column|}}
-  <div class="Polaris-DataTable__Pip {{if column.isVisible "Polaris-DataTable__Pip--visible"}}"></div>
+  <div class="Polaris-DataTable__Pip {{if column.isVisible 'Polaris-DataTable__Pip--visible'}}"></div>
 {{/each}}
 
 {{polaris-button

--- a/addon/templates/components/polaris-data-table/row.hbs
+++ b/addon/templates/components/polaris-data-table/row.hbs
@@ -1,8 +1,8 @@
 {{#each (polaris-data-table/insert-presentational-cell row) as |cellText cellIndex|}}
   {{polaris-data-table/cell
-    height=(get bodyCellHeights index)
+    height=(get-array-item bodyCellHeights index)
     text=cellText
-    contentType=(get contentTypes cellIndex)
+    contentType=(get-array-item contentTypes cellIndex)
     fixed=(eq cellIndex 0)
     truncate=truncate
     presentational=(eq cellIndex 1)

--- a/addon/templates/components/polaris-data-table/row.hbs
+++ b/addon/templates/components/polaris-data-table/row.hbs
@@ -1,0 +1,10 @@
+{{#each (polaris-data-table/insert-presentational-cell row) as |cellText cellIndex|}}
+  {{polaris-data-table/cell
+    height=(get bodyCellHeights index)
+    text=cellText
+    contentType=(get contentTypes cellIndex)
+    fixed=(eq cellIndex 0)
+    truncate=truncate
+    presentational=(eq cellIndex 1)
+  }}
+{{/each}}

--- a/addon/templates/components/polaris-data-table/total.hbs
+++ b/addon/templates/components/polaris-data-table/total.hbs
@@ -1,0 +1,22 @@
+{{#if (eq total "")}}
+  {{#if (eq index 0)}}
+    {{polaris-data-table/cell
+      fixed=true
+      total=true
+      height=height
+      text=totalsRowHeading
+      truncate=truncate
+    }}
+  {{else if (eq index 1)}}
+    {{polaris-data-table/cell presentational=true height=height}}
+  {{else}}
+    {{polaris-data-table/cell total=true contentType="numeric" height=height}}
+  {{/if}}
+{{else}}
+  {{polaris-data-table/cell
+    total=true
+    height=height
+    contentType="numeric"
+    text=total
+  }}
+{{/if}}

--- a/app/components/polaris-data-table.js
+++ b/app/components/polaris-data-table.js
@@ -1,0 +1,1 @@
+export { default } from '@smile-io/ember-polaris/components/polaris-data-table';

--- a/app/components/polaris-data-table/cell.js
+++ b/app/components/polaris-data-table/cell.js
@@ -1,0 +1,1 @@
+export { default } from '@smile-io/ember-polaris/components/polaris-data-table/cell';

--- a/app/components/polaris-data-table/heading.js
+++ b/app/components/polaris-data-table/heading.js
@@ -1,0 +1,1 @@
+export { default } from '@smile-io/ember-polaris/components/polaris-data-table/heading';

--- a/app/components/polaris-data-table/navigation.js
+++ b/app/components/polaris-data-table/navigation.js
@@ -1,0 +1,1 @@
+export { default } from '@smile-io/ember-polaris/components/polaris-data-table/navigation';

--- a/app/components/polaris-data-table/row.js
+++ b/app/components/polaris-data-table/row.js
@@ -1,0 +1,1 @@
+export { default } from '@smile-io/ember-polaris/components/polaris-data-table/row';

--- a/app/components/polaris-data-table/total.js
+++ b/app/components/polaris-data-table/total.js
@@ -1,0 +1,1 @@
+export { default } from '@smile-io/ember-polaris/components/polaris-data-table/total';

--- a/app/helpers/get-array-item.js
+++ b/app/helpers/get-array-item.js
@@ -1,0 +1,1 @@
+export { default, getArrayItem } from '@smile-io/ember-polaris/helpers/get-array-item';

--- a/app/helpers/polaris-data-table/insert-presentational-cell.js
+++ b/app/helpers/polaris-data-table/insert-presentational-cell.js
@@ -1,0 +1,1 @@
+export { default, polarisDataTableInsertPresentationalCell } from '@smile-io/ember-polaris/helpers/polaris-data-table/insert-presentational-cell';

--- a/docs/data-table.md
+++ b/docs/data-table.md
@@ -1,0 +1,73 @@
+[< Back to Components List](../README.md#components)
+
+## Data table
+
+`polaris-data-table` implements the [Polaris Data table component](https://polaris.shopify.com/components/lists-and-tables/data-table).
+
+### Example
+
+Basic data table (using [ember-array-helper](https://github.com/kellyselden/ember-array-helper)):
+
+```hbs
+{{polaris-data-table
+  columnContentTypes=(array "text" "numeric")
+  headings=(array "Product" "Remaining stock")
+  rows=(array
+    (array "Kitten" 5)
+    (array "Puppy" 3)
+  )
+}}
+```
+
+Sortable data table (you are responsible for sorting the `rows` in the action passed into `onSort`):
+
+```hbs
+{{polaris-data-table
+  columnContentTypes=(array "text" "numeric")
+  headings=(array "Product" "Remaining stock")
+  rows=rows
+  sortable=(array false true)
+  defaultSortDirection="descending"
+  initialSortColumnIndex=1
+  onSort=(action "sortData")
+}}
+```
+
+Data table with totals and footer:
+
+```hbs
+{{polaris-data-table
+  columnContentTypes=(array "text" "numeric" "numeric")
+  headings=(array "Product" "Remaining stock" "Net sales")
+  rows=(array
+    (array "Kitten" 5 "$12,345")
+    (array "Puppy" 3 "$6,789")
+  )
+  totals=(array "" 8 "$19,134")
+  footerContent="Showing 2 of 2 results"
+}}
+```
+
+You can also pass component definitions to render in heading, total, row and footer cells:
+
+```hbs
+{{polaris-data-table
+  columnContentTypes=(array "text" "numeric")
+  headings=(array "Product" "Remaining stock")
+  rows=(array
+    (array "Kitten" 5)
+    (array
+      "Puppy"
+      (component "polaris-text-style"
+        variation="negative"
+        text="3"
+      )
+    )
+  )
+  footerContent=(component "polaris-button"
+    plain=true
+    text="Refresh stock statuses"
+    onClick=(action "refreshStockStatuses")
+  )
+}}
+```

--- a/tests/integration/components/polaris-data-table-test.js
+++ b/tests/integration/components/polaris-data-table-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { findAll } from 'ember-native-dom-helpers';
+import { findAll, find } from 'ember-native-dom-helpers';
 
 const sortable = [false, true, false, false, true, false];
 const columnContentTypes = [
@@ -24,7 +24,7 @@ const rows = [
   ['Emerald Silk Gown', '$230.00', 124689, 32, '$19,090.00'],
   ['Mauve Cashmere Scarf', '$445.00', 124533, 140, '$14,240.00'],
 ];
-const summary = ['', '', '', 255, '$155,830.00'];
+const footerContent = ['', '', '', 255, '$155,830.00'];
 
 module('Integration | Component | polaris-data-table', function(hooks) {
   setupRenderingTest(hooks);
@@ -35,7 +35,7 @@ module('Integration | Component | polaris-data-table', function(hooks) {
       columnContentTypes,
       headings,
       rows,
-      summary,
+      footerContent,
     });
   });
 
@@ -45,7 +45,7 @@ module('Integration | Component | polaris-data-table', function(hooks) {
         columnContentTypes=columnContentTypes
         headings=headings
         rows=rows
-        summary=summary
+        footerContent=footerContent
       }}
     `);
 
@@ -58,7 +58,7 @@ module('Integration | Component | polaris-data-table', function(hooks) {
         columnContentTypes=columnContentTypes
         headings=headings
         rows=rows
-        summary=summary
+        footerContent=footerContent
       }}
     `);
     const sortableHeadings = findAll('Polaris-DataTable__Heading--sortable');
@@ -73,7 +73,7 @@ module('Integration | Component | polaris-data-table', function(hooks) {
         columnContentTypes=columnContentTypes
         headings=headings
         rows=rows
-        summary=summary
+        footerContent=footerContent
         sortable=firstColumnSortable
       }}
     `);
@@ -88,7 +88,7 @@ module('Integration | Component | polaris-data-table', function(hooks) {
         columnContentTypes=columnContentTypes
         headings=headings
         rows=rows
-        summary=summary
+        footerContent=footerContent
         sortable=sortable
         initialSortColumnIndex=4
       }}
@@ -96,5 +96,47 @@ module('Integration | Component | polaris-data-table', function(hooks) {
     const fifthHeadingCell = findAll('th.Polaris-DataTable__Cell')[5];
 
     assert.ok(fifthHeadingCell.classList.contains('Polaris-DataTable__Cell--sorted'));
+  });
+
+  test('it accepts both text and component definitions as cell contents', async function(assert) {
+    await render(hbs`
+      {{polaris-data-table
+        columnContentTypes=(array
+          "text"
+          "numeric"
+        )
+        headings=(array
+          "Product"
+          (component "polaris-badge" text="Status")
+        )
+        rows=(array
+          (array
+            (component "polaris-link" text="Emerald Silk Gown")
+            "In stock"
+          )
+        )
+        footerContent=(component "polaris-button" text="Refresh stock statuses")
+      }}
+    `);
+
+    const headingCells = findAll('thead th');
+    const firstHeadingCell = headingCells[0];
+    assert.equal(firstHeadingCell.textContent.trim(), 'Product', 'first heading cell renders correct text');
+
+    const lastHeadingCell = headingCells[headingCells.length - 1];
+    assert.ok(lastHeadingCell.firstElementChild.classList.contains('Polaris-Badge'), 'last heading cell renders badge component');
+    assert.equal(lastHeadingCell.textContent.trim(), 'Status', 'last heading cell renders correct text');
+
+    const rowCells = find('tbody tr.Polaris-DataTable__TableRow').children;
+    const firstRowCell = rowCells[0];
+    assert.ok(firstRowCell.firstElementChild.classList.contains('Polaris-Link'), 'first row cell renders link component');
+    assert.equal(firstRowCell.textContent.trim(), 'Emerald Silk Gown', 'first row cell renders correct text');
+
+    const lastRowCell = rowCells[rowCells.length - 1];
+    assert.equal(lastRowCell.textContent.trim(), 'In stock', 'last row cell renders correct text');
+
+    const footerCell = find('tfoot td.Polaris-DataTable__Cell--footer');
+    assert.ok(footerCell.firstElementChild.classList.contains('Polaris-Button'), 'footer cell renders button component');
+    assert.equal(footerCell.textContent.trim(), 'Refresh stock statuses', 'footer cell renders correct text');
   });
 });

--- a/tests/integration/components/polaris-data-table-test.js
+++ b/tests/integration/components/polaris-data-table-test.js
@@ -1,3 +1,4 @@
+import { helper } from '@ember/component/helper';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
@@ -37,6 +38,12 @@ module('Integration | Component | polaris-data-table', function(hooks) {
       rows,
       footerContent,
     });
+
+    // Register a simple array helper to avoid "object is not extensible"
+    // errors in some versions of Ember.
+    this.owner.register('helper:array', helper(function array(items) {
+      return [ ...items ];
+    }));
   });
 
   test('it renders all table body rows', async function(assert) {

--- a/tests/integration/components/polaris-data-table-test.js
+++ b/tests/integration/components/polaris-data-table-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('polaris-data-table', 'Integration | Component | polaris-data-table', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{polaris-data-table}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#polaris-data-table}}
+      template block text
+    {{/polaris-data-table}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/integration/components/polaris-data-table-test.js
+++ b/tests/integration/components/polaris-data-table-test.js
@@ -1,24 +1,100 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { findAll, find } from 'ember-native-dom-helpers';
 
-moduleForComponent('polaris-data-table', 'Integration | Component | polaris-data-table', {
-  integration: true
-});
+const sortable = [false, true, false, false, true, false];
+const columnContentTypes = [
+  'text',
+  'numeric',
+  'numeric',
+  'numeric',
+  'numeric',
+];
+const headings = ['Product', 'Price', 'Order Number', 'Quantity', 'Subtotal'];
+const rows = [
+  [
+    'Navy Merino Wool Blazer with khaki chinos and yellow belt',
+    '$875.00',
+    124518,
+    83,
+    '$122,500.00',
+  ],
+  ['Emerald Silk Gown', '$230.00', 124689, 32, '$19,090.00'],
+  ['Mauve Cashmere Scarf', '$445.00', 124533, 140, '$14,240.00'],
+];
+const summary = ['', '', '', 255, '$155,830.00'];
 
-test('it renders', function(assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+module('Integration | Component | polaris-data-table', function(hooks) {
+  setupRenderingTest(hooks);
 
-  this.render(hbs`{{polaris-data-table}}`);
+  hooks.beforeEach(function() {
+    this.setProperties({
+      sortable,
+      columnContentTypes,
+      headings,
+      rows,
+      summary,
+    });
+  });
 
-  assert.equal(this.$().text().trim(), '');
+  test('it renders all table body rows', async function(assert) {
+    await render(hbs`
+      {{polaris-data-table
+        columnContentTypes=columnContentTypes
+        headings=headings
+        rows=rows
+        summary=summary
+      }}
+    `);
 
-  // Template block usage:
-  this.render(hbs`
-    {{#polaris-data-table}}
-      template block text
-    {{/polaris-data-table}}
-  `);
+    assert.equal(findAll('tbody tr').length, 3);
+  });
 
-  assert.equal(this.$().text().trim(), 'template block text');
+  test('it defaults to non-sorting column headings', async function(assert) {
+    await render(hbs`
+      {{polaris-data-table
+        columnContentTypes=columnContentTypes
+        headings=headings
+        rows=rows
+        summary=summary
+      }}
+    `);
+    const sortableHeadings = findAll('Polaris-DataTable__Heading--sortable');
+
+    assert.equal(sortableHeadings.length, 0);
+  });
+
+  test('initial sort column defaults to first column if not specified', async function(assert) {
+    this.set('firstColumnSortable', [true, true, false, false, true, false]);
+    await render(hbs`
+      {{polaris-data-table
+        columnContentTypes=columnContentTypes
+        headings=headings
+        rows=rows
+        summary=summary
+        sortable=firstColumnSortable
+      }}
+    `);
+    const firstHeadingCell = findAll('th.Polaris-DataTable__Cell')[0];
+
+    assert.ok(firstHeadingCell.classList.contains('Polaris-DataTable__Cell--sorted'));
+  });
+
+  test('it sets specified initial sort column', async function(assert) {
+    await render(hbs`
+      {{polaris-data-table
+        columnContentTypes=columnContentTypes
+        headings=headings
+        rows=rows
+        summary=summary
+        sortable=true
+        initialSortColumnIndex=4
+      }}
+    `);
+    const fifthHeadingCell = findAll('th.Polaris-DataTable__Cell')[5];
+
+    assert.ok(fifthHeadingCell.classList.contains('Polaris-DataTable__Cell--sorted'));
+  });
 });

--- a/tests/integration/components/polaris-data-table-test.js
+++ b/tests/integration/components/polaris-data-table-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { findAll, find } from 'ember-native-dom-helpers';
+import { findAll } from 'ember-native-dom-helpers';
 
 const sortable = [false, true, false, false, true, false];
 const columnContentTypes = [
@@ -89,7 +89,7 @@ module('Integration | Component | polaris-data-table', function(hooks) {
         headings=headings
         rows=rows
         summary=summary
-        sortable=true
+        sortable=sortable
         initialSortColumnIndex=4
       }}
     `);

--- a/tests/integration/components/polaris-data-table-test.js
+++ b/tests/integration/components/polaris-data-table-test.js
@@ -1,9 +1,8 @@
 import { helper } from '@ember/component/helper';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, findAll, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { findAll, find } from 'ember-native-dom-helpers';
 
 const sortable = [false, true, false, false, true, false];
 const columnContentTypes = [


### PR DESCRIPTION
Depends on #142 in order to be able to render arbitrary components in table cells.

Adds full implementation of the Polaris [data table](https://polaris.shopify.com/components/lists-and-tables/data-table) component:

Reproducing the demos on the Shopify component documentation page:

Data table with footer:
![polaris-data-table-footer](https://user-images.githubusercontent.com/5737342/41783574-d0929ade-7645-11e8-9b84-d8ceb2814399.gif)

Data table with sortable columns (when the sorting updates without clicking it's because I pressed `Enter` while the column heading was focussed):
![polaris-data-table-sortable](https://user-images.githubusercontent.com/5737342/41783582-d8aa8772-7645-11e8-82bc-ac8163061f57.gif)
