### PR TITLE
Support React-style content rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ember-polaris Changelog
 
+### Unreleased
+- [#142](https://github.com/smile-io/ember-polaris/pull/142) [ENHANCEMENT] Support React-style child content.
+
 ### v1.6.0 (June 25, 2018)
 - [#133](https://github.com/smile-io/ember-polaris/pull/133) [FEATURE] Add [polaris-drop-zone](https://polaris.shopify.com/components/actions/drop-zone) component
 - [##140](https://github.com/smile-io/ember-polaris/pull/140) [INTERNAL] Update some dependencies and other minor tweaks

--- a/addon/components/render-content.js
+++ b/addon/components/render-content.js
@@ -1,0 +1,18 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import layout from '../templates/components/render-content';
+
+export default Component.extend({
+  tagName: '',
+
+  layout,
+
+  content: null,
+
+  contentIsComponent: computed('content', function() {
+    let contentConstructorName = this.get('content.constructor.name') || '';
+    return contentConstructorName.indexOf('ComponentDefinition') > -1;
+  }).readOnly(),
+}).reopenClass({
+  positionalParams: ['content'],
+});

--- a/addon/templates/components/render-content.hbs
+++ b/addon/templates/components/render-content.hbs
@@ -1,0 +1,5 @@
+{{#if contentIsComponent}}
+  {{component content}}
+{{else}}
+  {{content}}
+{{/if}}

--- a/app/components/render-content.js
+++ b/app/components/render-content.js
@@ -1,0 +1,1 @@
+export { default } from '@smile-io/ember-polaris/components/render-content';

--- a/tests/integration/components/render-content-test.js
+++ b/tests/integration/components/render-content-test.js
@@ -1,0 +1,36 @@
+import Component from '@ember/component';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { find } from 'ember-native-dom-helpers';
+
+module('Integration | Component | render-content', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    // Register a simple component to test `render-content` with.
+    this.owner.register('component:my-component', Component.extend({
+      classNames: ['my-test-component'],
+      layout: hbs`{{text}}`,
+    }));
+  });
+
+  test('it renders simple content correctly', async function(assert) {
+    await render(hbs`
+      <div id="render-content-test">
+        {{render-content "blah"}}
+      </div>
+    `);
+
+    assert.equal(find('#render-content-test').textContent.trim(), 'blah');
+  });
+
+  test('it renders component content correctly', async function(assert) {
+    await render(hbs`
+      {{render-content (component "my-component" text="component content here")}}
+    `);
+
+    assert.equal(find('.my-test-component').textContent.trim(), 'component content here');
+  });
+});


### PR DESCRIPTION
Quick little enhancement that allows us to render both "simple" values (e.g. `componentContent="some text"`) and component definitions (passed as e.g. `componentContent=(component "my-cool-component" color="pink")`) using the same one-liner, `{{render-content componentContent}}`.

This opens the door for us to be able to easily support passing child content to `ember-polaris` components without having to go down the route we've taken before of adding e.g. separate `label` and `labelComponent` properties to Polaris components.