### PR TITLE
Use `render-component` to align component interfaces with React implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 - [#142](https://github.com/smile-io/ember-polaris/pull/142) [ENHANCEMENT] Support React-style child content.
+- [#143](https://github.com/smile-io/ember-polaris/pull/143) [ENHANCEMENT] Remove need for separate `label` and `labelComponent` properties for `polaris-checkbox`, and `termComponent`/`term` and `descriptionComponent`/`description` properties for `polaris-description-list` `items`.
 
 ### v1.6.0 (June 25, 2018)
 - [#133](https://github.com/smile-io/ember-polaris/pull/133) [FEATURE] Add [polaris-drop-zone](https://polaris.shopify.com/components/actions/drop-zone) component

--- a/addon/components/polaris-checkbox.js
+++ b/addon/components/polaris-checkbox.js
@@ -3,6 +3,7 @@ import { computed } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { typeOf } from '@ember/utils';
 import { equal } from '@ember/object/computed';
+import { deprecate } from '@ember/debug';
 import layout from '../templates/components/polaris-checkbox';
 
 /**
@@ -19,7 +20,7 @@ export default Component.extend({
    * Label for the checkbox
    *
    * @property label
-   * @type {String}
+   * @type {String|Component}
    * @default null
    * @public
    */
@@ -27,6 +28,8 @@ export default Component.extend({
 
   /**
    * Component to render for the checkbox's label
+   *
+   * DEPRECATED: pass the component as `label` instead.
    *
    * @property labelComponent
    * @type {String | Component}
@@ -186,4 +189,20 @@ export default Component.extend({
 
     return describedBy.join(' ');
   }).readOnly(),
+
+  /**
+   * Lifecycle hooks.
+   */
+  didReceiveAttrs() {
+    this._super(...arguments);
+
+    deprecate(
+      'Passing an explicit `labelComponent` to `polaris-checkbox` is deprecated - pass the component as `label` instead',
+      !this.get('labelComponent'),
+      {
+        id: 'ember-polaris.polaris-checkbox.label-component',
+        until: '2.0.0',
+      }
+    );
+  },
 });

--- a/addon/components/polaris-choice.js
+++ b/addon/components/polaris-choice.js
@@ -27,7 +27,7 @@ export default Component.extend({
    * Label content for the choice
    *
    * @property label
-   * @type {String}
+   * @type {String|Component}
    * @default: null
    * @public
    */
@@ -35,6 +35,8 @@ export default Component.extend({
 
   /**
    * Component to render for the choice's label
+   *
+   * DEPRECATED: pass the component as `label` instead.
    *
    * @property labelComponent
    * @type {String | Component}

--- a/addon/components/polaris-choice/label.js
+++ b/addon/components/polaris-choice/label.js
@@ -23,7 +23,7 @@ export default Component.extend({
    * Label content for the choice this label belongs to.
    *
    * @property label
-   * @type {String}
+   * @type {String|Component}
    * @default: null
    * @public
    */
@@ -31,6 +31,8 @@ export default Component.extend({
 
   /**
    * Component to render for the label
+   *
+   * DEPRECATED: pass the component as `label` instead.
    *
    * @property labelComponent
    * @type {String | Component}

--- a/addon/components/polaris-description-list.js
+++ b/addon/components/polaris-description-list.js
@@ -1,4 +1,6 @@
 import Component from '@ember/component';
+import { A as EmberArray } from '@ember/array';
+import { deprecate } from '@ember/debug';
 import layout from '../templates/components/polaris-description-list';
 
 export default Component.extend({
@@ -21,8 +23,8 @@ export default Component.extend({
    *
    * items=(array
    *   (hash
-   *     termComponent=(component my-term-component)
-   *     descriptionComponent=(component my-description-component)
+   *     term=(component "my-term-component")
+   *     description=(component "my-description-component")
    *   )
    * )
    *
@@ -31,5 +33,30 @@ export default Component.extend({
    * @type {Array}
    * @default: null
    */
-  items: null
+  items: null,
+
+  /**
+   * Lifecycle hooks.
+   */
+  didReceiveAttrs() {
+    this._super(...arguments);
+
+    let items = EmberArray(this.get('items') || []);
+    deprecate(
+      'Passing an explicit `termComponent` in `polaris-description-list` `items` is deprecated - pass the component as `term` instead',
+      !items.any((item) => item && item.termComponent),
+      {
+        id: 'ember-polaris.polaris-description-list.term-component',
+        until: '2.0.0',
+      }
+    );
+    deprecate(
+      'Passing an explicit `descriptionComponent` in `polaris-description-list` `items` is deprecated - pass the component as `description` instead',
+      !items.any((item) => item && item.descriptionComponent),
+      {
+        id: 'ember-polaris.polaris-description-list.description-component',
+        until: '2.0.0',
+      }
+    );
+  },
 });

--- a/addon/components/polaris-radio-button.js
+++ b/addon/components/polaris-radio-button.js
@@ -20,7 +20,7 @@ export default Component.extend({
    * Label for the radio button
    *
    * @property label
-   * @type {string}
+   * @type {String|Component}
    * @default null
    */
   label: null,

--- a/addon/templates/components/polaris-choice/label.hbs
+++ b/addon/templates/components/polaris-choice/label.hbs
@@ -6,6 +6,6 @@
   {{#if labelComponent}}
     {{component labelComponent}}
   {{else}}
-    {{label}}
+    {{render-content label}}
   {{/if}}
 </span>

--- a/addon/templates/components/polaris-description-list.hbs
+++ b/addon/templates/components/polaris-description-list.hbs
@@ -3,14 +3,14 @@
     {{#if item.termComponent}}
       {{component item.termComponent}}
     {{else}}
-      {{item.term}}
+      {{render-content item.term}}
     {{/if}}
   </dt>
   <dd class="Polaris-DescriptionList__Description">
     {{#if item.descriptionComponent}}
       {{component item.descriptionComponent}}
     {{else}}
-      {{item.description}}
+      {{render-content item.description}}
     {{/if}}
   </dd>
 {{/each}}

--- a/docs/checkbox.md
+++ b/docs/checkbox.md
@@ -4,7 +4,7 @@
 
 `polaris-checkbox` implements the [Polaris Checkbox component](https://polaris.shopify.com/components/forms/checkbox).
 
-**NOTE:** _the React component's `id` property has been renamed to `inputId` in this Ember implementation. The `label` property in this implementation only supports string values - to emulate the React component's ability to pass a node in for the `label`, use `labelComponent` instead._
+**NOTE:** _the React component's `id` property has been renamed to `inputId` in this Ember implementation._
 
 ### Examples
 
@@ -30,21 +30,11 @@ Checkbox with help text and value:
 }}
 ```
 
-Checkbox with a simple component rendered as its label:
+Checkbox with a component rendered as its label:
 
 ```hbs
 {{polaris-checkbox
-  labelComponent="my-awesome-label"
-  checked=checked
-  onChange=(action (mut checked))
-}}
-```
-
-Checkbox with more advanced component usage for the label:
-
-```hbs
-{{polaris-checkbox
-  labelComponent=(component "my-awesome-label" color="purple")
+  label=(component "my-awesome-label" color="purple")
   checked=checked
   onChange=(action (mut checked))
 }}

--- a/docs/description-list.md
+++ b/docs/description-list.md
@@ -4,8 +4,6 @@
 
 `polaris-description-list` implements the [Polaris Description list component](https://polaris.shopify.com/components/lists/description-list).
 
-**NOTE:** _The item `term` and `description` properties in this implementation only support string values - to emulate the React component's ability to pass a node in for these attributes, use `termComponent` and `descriptionComponent` instead._
-
 ### Example
 
 Basic description list usage (using [ember-array-helper](https://github.com/kellyselden/ember-array-helper)):
@@ -31,12 +29,12 @@ Rendering a component in place of `item` or `description`:
 {{polaris-description-list
   items=(array
     (hash
-      termComponent=(component "my-term-component")
+      term=(component "my-term-component")
       description="..."
     )
     (hash
       term="..."
-      descriptionComponent=(component "my-description-component")
+      description=(component "my-description-component")
     )
   )
 }}

--- a/docs/radio-button.md
+++ b/docs/radio-button.md
@@ -28,3 +28,13 @@ Radio button with help text:
   onChange=(action (mut selectedValue))
 }}
 ```
+
+Radio button with customer label component:
+
+```hbs
+{{polaris-radio-button
+  label=(component "my-custom-label")
+  value="option-1"
+  onChange=(action (mut selectedValue))
+}}
+```

--- a/tests/integration/components/polaris-description-list-test.js
+++ b/tests/integration/components/polaris-description-list-test.js
@@ -71,13 +71,35 @@ test('it renders the correct HTML when items are passed in', function(assert) {
   assert.equal(itemsDescriptions.length, itemsLength, 'it renders the correct number of descriptions following terms');
 });
 
-test('it renders items with `termComponent` and `descriptionComponent` attributes', function(assert) {
+test('it renders items with explicit `termComponent` and `descriptionComponent` attributes', function(assert) {
   this.render(hbs`
     {{polaris-description-list
       items=(array
         (hash
           termComponent=(component "stub-term-component")
           descriptionComponent=(component "stub-description-component")
+        )
+      )
+    }}
+  `);
+
+  const descriptionListComponent = findAll(componentSelector);
+  assert.equal(descriptionListComponent.length, 1, 'it renders a description list component');
+
+  const termComponent = findAll(stubTermSelector);
+  assert.equal(termComponent.length, 1, 'it renders a component passed as a `termComponent` attribute');
+
+  const descriptionComponent = findAll(stubDescriptionSelector);
+  assert.equal(descriptionComponent.length, 1, 'it renders a component passed as a `descriptionComponent` attribute');
+});
+
+test('it renders items with `term` and `description` components', function(assert) {
+  this.render(hbs`
+    {{polaris-description-list
+      items=(array
+        (hash
+          term=(component "stub-term-component")
+          description=(component "stub-description-component")
         )
       )
     }}


### PR DESCRIPTION
Our implementations of `polaris-checkbox` and `polaris-description-list` had previously had separate `label`/`labelComponent` properties etc. which was out of alignment with the React implementations and a nuisance for developers to remember. With this PR, the following become deprecated:

- `labelComponent` for `polaris-checkbox`;
- `termComponent` and `descriptionComponent` for `polaris-description-list#items`.

Instead, the components can now be simply passed as `label`, `term` and `description` respectively.