### PR TITLE
Add label and labelled components

### DIFF
--- a/addon/components/polaris-label.js
+++ b/addon/components/polaris-label.js
@@ -1,0 +1,53 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import layout from '../templates/components/polaris-label';
+
+/**
+ * Internal Polaris label component.
+ */
+export default Component.extend({
+  // Tagless component so that Ember doesn't apply the `id`
+  // attribute to the component's root element.
+  tagName: '',
+
+  layout,
+
+  /**
+   * Label content
+   *
+   * This component can be used in block form,
+   * in which case the block content will be used
+   * instead of `text`
+   *
+   * @type {String|Component}
+   * @public
+   */
+  text: null,
+
+  /**
+   * A unique identifier for the label
+   *
+   * @type {String}
+   * @public
+   */
+  id: null,
+
+  /**
+   * Visually hide the label
+   *
+   * @type {Boolean}
+   * @default false
+   * @public
+   */
+  hidden: false,
+
+  /**
+   * ID for the label element
+   *
+   * @type {String}
+   * @private
+   */
+  labelID: computed('id', function() {
+    return `${ this.get('id') }Label`;
+  }).readOnly(),
+});

--- a/addon/components/polaris-labelled.js
+++ b/addon/components/polaris-labelled.js
@@ -1,0 +1,100 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import layout from '../templates/components/polaris-labelled';
+
+/**
+ * Internal Polaris labelled component, used to add labels to form fields.
+ */
+export default Component.extend({
+  // Tagless component so that Ember doesn't apply the `id`
+  // attribute to the component's root element.
+  tagName: '',
+
+  layout,
+
+  /**
+   * Text for the label
+   *
+   * @type {String}
+   * @public
+   */
+  label: null,
+
+  /**
+   * Error to display beneath the label
+   *
+   * @type {String|Component}
+   * @public
+   */
+  error: null,
+
+  /**
+   * An action
+   *
+   * @type {Object}
+   * @public
+   */
+  action: null,
+
+  /**
+   * Additional hint text to display
+   *
+   * @type {String|Component}
+   * @public
+   */
+  helpText: null,
+
+  // /**
+  //  * Content to display inside the connected
+  //  *
+  //  * This component can be used in block form,
+  //  * in which case the block content will be used
+  //  * instead of `text`
+  //  *
+  //  * @type {String}
+  //  * @public
+  //  */
+  // text: null,
+
+  /**
+   * Visually hide the label
+   *
+   * @type {Boolean}
+   * @default false
+   * @public
+   */
+  labelHidden: false,
+
+  /**
+   * A unique identifier for the label
+   * Note that we default this to Ember's GUID for this component instance,
+   * but the value can be overridden by the outside world.
+   *
+   * @type {String}
+   * @public
+   */
+  id: computed(function() {
+    return guidFor(this);
+  }),
+
+  /**
+   * ID for the error message div
+   *
+   * @type {String}
+   * @private
+   */
+  errorID: computed('id', function() {
+    return `${ this.get('id') }Error`;
+  }).readOnly(),
+
+  /**
+   * ID for the help text div
+   *
+   * @type {String}
+   * @private
+   */
+  helpTextID: computed('id', function() {
+    return `${ this.get('id') }HelpText`;
+  }).readOnly(),
+});

--- a/addon/templates/components/polaris-label.hbs
+++ b/addon/templates/components/polaris-label.hbs
@@ -1,0 +1,9 @@
+<div class="Polaris-Label">
+  <label id={{labelID}} htmlFor={{id}} class="Polaris-Label__Text">
+    {{#if hasBlock}}
+      {{yield}}
+    {{else}}
+      {{render-content text}}
+    {{/if}}
+  </label>
+</div>

--- a/addon/templates/components/polaris-labelled.hbs
+++ b/addon/templates/components/polaris-labelled.hbs
@@ -1,0 +1,37 @@
+<div class={{if labelHidden "Polaris-Labelled--hidden"}}>
+  {{#if label}}
+    <div class="Polaris-Labelled__LabelWrapper">
+      {{#polaris-label id=id hidden=false}}
+        {{label}}
+      {{/polaris-label}}
+
+      {{#if action}}
+        {{polaris-button
+          plain=true
+          text=action.text
+          disabled=action.disabled
+          loading=action.loading
+          accessibilityLabel=action.accessibilityLabel
+          onClick=(action action.onAction)
+        }}
+      {{/if}}
+    </div>
+  {{/if}}
+
+  {{yield}}
+
+  {{#if error}}
+    <div id={{errorID}} class="Polaris-Labelled__Error">
+      <div class="Polaris-Labelled__ErrorIcon">
+        {{polaris-icon source="alert"}}
+      </div>
+      {{render-content error}}
+    </div>
+  {{/if}}
+
+  {{#if helpText}}
+    <div id={{helpTextID}} class="Polaris-Labelled__HelpText">
+      {{render-content helpText}}
+    </div>
+  {{/if}}
+</div>

--- a/app/components/polaris-label.js
+++ b/app/components/polaris-label.js
@@ -1,0 +1,1 @@
+export { default } from '@smile-io/ember-polaris/components/polaris-label';

--- a/app/components/polaris-labelled.js
+++ b/app/components/polaris-labelled.js
@@ -1,0 +1,1 @@
+export { default } from '@smile-io/ember-polaris/components/polaris-labelled';

--- a/tests/integration/components/polaris-label-test.js
+++ b/tests/integration/components/polaris-label-test.js
@@ -1,0 +1,18 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | polaris-label', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it uses the ID as the for attribute', async function(assert) {
+    await render(hbs`{{polaris-label id="MyThing"}}`);
+    assert.dom('.Polaris-Label label').hasAttribute('for', 'MyThing');
+  });
+
+  test('it creates an ID for the label from the ID of the connected resource', async function(assert) {
+    await render(hbs`{{polaris-label id="MyThing"}}`);
+    assert.dom('.Polaris-Label label').hasAttribute('id', 'MyThingLabel');
+  });
+});

--- a/tests/integration/components/polaris-labelled-test.js
+++ b/tests/integration/components/polaris-labelled-test.js
@@ -1,0 +1,72 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import Component from '@ember/component';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | polaris-labelled', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    // Register a simple component to test rendering with.
+    this.owner.register('component:my-component', Component.extend({
+      classNames: ['my-component'],
+    }));
+  });
+
+  test('passes relevant attrs along to the label', async function(assert) {
+    await render(hbs`{{polaris-labelled id="my-label" label="Label"}}`);
+
+    const labelSelector = '.Polaris-Label label';
+    assert.dom(labelSelector).hasAttribute('id', 'my-labelLabel');
+    assert.dom(labelSelector).hasText('Label');
+  });
+
+  test('renders error markup when provided with a value', async function(assert) {
+    await render(hbs`{{polaris-labelled id="my-labelled" label="Label" error="Error message"}}`);
+
+    assert.dom('#my-labelledError').hasText('Error message');
+  });
+
+  test('renders the content as a child outside of the label', async function(assert) {
+    await render(hbs`
+      {{#polaris-labelled}}
+        {{my-component}}
+      {{/polaris-labelled}}
+    `);
+
+    assert.dom('.my-component').exists();
+  });
+
+  test('renders a plain button with the specified attributes when given an action', async function(assert) {
+    this.set('action', {
+      text: 'My action',
+      accessibilityLabel: 'My action with more description',
+      onAction: () => this.set('actionFired', true),
+    });
+    await render(hbs`{{polaris-labelled id="MyLabelled" label="Label" action=action}}`);
+
+    const actionButtonSelector = 'button.Polaris-Button';
+    assert.dom(actionButtonSelector).hasAttribute('aria-label', 'My action with more description');
+    assert.dom(actionButtonSelector).hasClass('Polaris-Button--plain');
+    assert.dom(actionButtonSelector).hasText('My action');
+
+    await click(actionButtonSelector);
+    assert.ok(this.get('actionFired'));
+  });
+
+  test('does not render any block-level elements in the label element when given an action', async function(assert) {
+    await render(hbs`
+      {{polaris-labelled
+        id="MyThing"
+        label="My thing"
+        action=(hash
+          text="My action"
+          onAction=(action (mut actionFired) true)
+        )
+      }}
+    `);
+
+    assert.dom('label div').doesNotExist();
+  });
+});


### PR DESCRIPTION
Adds the internal `polaris-label` and `polaris-labelled` components, which are needed to build the other form controls like `polaris-text-field`, `polaris-range-slider` etc.