### PR TITLE
Auto-bind wrapper-element attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # ember-polaris Changelog
 
 ### Unreleased
+- [#150](https://github.com/smile-io/ember-polaris/pull/150) [ENHANCEMENT] Auto-bind supplied attributes on internal `wrapper-element` component.
 - [#148](https://github.com/smile-io/ember-polaris/pull/148) [FEATURE] Add `polaris-label` and `polaris-labelled` components.
 
 ### v1.6.1 (June 28, 2018)

--- a/addon/components/wrapper-element.js
+++ b/addon/components/wrapper-element.js
@@ -1,10 +1,39 @@
 import Component from '@ember/component';
+import { isBlank } from '@ember/utils';
 import layout from '../templates/components/wrapper-element';
+
+const blacklistedAttributeBindings = [
+  'tagName',
+  'class'
+];
 
 /**
  * This is a simple utility component that lets us do things like wrap block content
  * in a conditional element, since `tagName` can't be a computed property.
  */
 export default Component.extend({
+  attributeBindings: [],
+
   layout,
+
+  blacklistedAttributeBindings,
+
+  updateAttributeBindings() {
+    if (isBlank(this.get('tagName'))) {
+      return;
+    }
+
+    let { attrs, blacklistedAttributeBindings } = this.getProperties('attrs', 'blacklistedAttributeBindings');
+
+    let newAttributeBindings = Object.keys(attrs).filter((attr) => {
+      return blacklistedAttributeBindings.indexOf(attr) === -1;
+    });
+    this.set('attributeBindings', newAttributeBindings);
+  },
+
+  didReceiveAttrs() {
+    this._super(...arguments);
+
+    this.updateAttributeBindings();
+  },
 });

--- a/tests/integration/components/wrapper-element-test.js
+++ b/tests/integration/components/wrapper-element-test.js
@@ -1,0 +1,34 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | wrapper-element', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders block content', async function(assert) {
+    await render(hbs`
+      {{#wrapper-element tagName="my-element" my-attribute="hello"}}
+        <div id="block-content">Content goes here</div>
+      {{/wrapper-element}}
+    `);
+
+    assert.dom('my-element > div#block-content').hasText('Content goes here');
+  });
+
+  test('it passes arbitrary attributes to the rendered element', async function(assert) {
+    await render(hbs`{{wrapper-element tagName="my-element" my-attribute="hello"}}`);
+
+    assert.dom('my-element').hasAttribute('my-attribute', 'hello');
+  });
+
+  test('it does not blow up when an empty `tagName` is set', async function(assert) {
+    await render(hbs`
+      {{#wrapper-element tagName="" my-attribute="hello"}}
+        <div id="block-content"></div>
+      {{/wrapper-element}}
+    `);
+
+    assert.dom('div#block-content').exists();
+  });
+});


### PR DESCRIPTION
Allows us to pass arbitrary attributes to the internal `wrapper-element` component and have them be bound to the rendered element (if there is one).