### PR TITLE
Add missing hidden class to `polaris-label`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 - [#148](https://github.com/smile-io/ember-polaris/pull/148) [FEATURE] Add `polaris-label` and `polaris-labelled` components.
+- [#151](https://github.com/smile-io/ember-polaris/pull/151) [FIX] Add missing `hidden` class to `polaris-label`.
 
 ### v1.6.1 (June 28, 2018)
 

--- a/addon/templates/components/polaris-label.hbs
+++ b/addon/templates/components/polaris-label.hbs
@@ -1,4 +1,4 @@
-<div class="Polaris-Label">
+<div class="Polaris-Label {{if hidden "Polaris-Label--hidden"}}">
   <label id={{labelId}} htmlFor={{id}} class="Polaris-Label__Text">
     {{#if hasBlock}}
       {{yield}}


### PR DESCRIPTION
Adds the `Polaris-Label--hidden` class that was missing from `polaris-label` when `hidden` was truthy.