### PR TITLE
Add range slider component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#146](https://github.com/smile-io/ember-polaris/pull/146) Add `new` status to the Badge component
 - [#148](https://github.com/smile-io/ember-polaris/pull/148) [FEATURE] Add `polaris-label` and `polaris-labelled` components.
 - [#151](https://github.com/smile-io/ember-polaris/pull/151) [FIX] Add missing `hidden` class to `polaris-label`.
+- [#154](https://github.com/smile-io/ember-polaris/pull/154) [FEATURE] Add `polaris-range-slider` component.
 
 ### v1.6.1 (June 28, 2018)
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Below is a categorised list of the components available in `ember-polaris`. Clic
 - [Date picker](./docs/date-picker.md#date-picker)
 - [Form layout](./docs/form-layout.md#form-layout)
 - [Radio button](./docs/radio-button.md#radio-button)
+- [Range slider](./docs/range-slider.md#range-slider)
 - [Tag](./docs/tag.md#tag)
 
 #### Lists

--- a/addon/components/polaris-label.js
+++ b/addon/components/polaris-label.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { computedLabelId } from '@smile-io/ember-polaris/utils/id';
 import layout from '../templates/components/polaris-label';
 
 /**
@@ -47,7 +47,5 @@ export default Component.extend({
    * @type {String}
    * @private
    */
-  labelId: computed('id', function() {
-    return `${ this.get('id') }Label`;
-  }).readOnly(),
+  labelId: computedLabelId('id').readOnly(),
 });

--- a/addon/components/polaris-labelled.js
+++ b/addon/components/polaris-labelled.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
+import { computedErrorId, computedHelpTextId } from '@smile-io/ember-polaris/utils/id';
 import layout from '../templates/components/polaris-labelled';
 
 /**
@@ -72,9 +73,7 @@ export default Component.extend({
    * @type {String}
    * @private
    */
-  errorId: computed('id', function() {
-    return `${ this.get('id') }Error`;
-  }).readOnly(),
+  errorId: computedErrorId('id').readOnly(),
 
   /**
    * ID for the help text div
@@ -82,7 +81,5 @@ export default Component.extend({
    * @type {String}
    * @private
    */
-  helpTextId: computed('id', function() {
-    return `${ this.get('id') }HelpText`;
-  }).readOnly(),
+  helpTextId: computedHelpTextId('id').readOnly(),
 });

--- a/addon/components/polaris-range-slider.js
+++ b/addon/components/polaris-range-slider.js
@@ -100,7 +100,7 @@ export default Component.extend({
    * Increment value for range input changes
    *
    * @property {step}
-   * @type {Number?}
+   * @type {Number}
    * @default null
    * @public
    */

--- a/addon/components/polaris-range-slider.js
+++ b/addon/components/polaris-range-slider.js
@@ -1,0 +1,285 @@
+import Component from '@ember/component';
+import { guidFor } from '@ember/object/internals';
+import { computed } from '@ember/object';
+import { dasherize, htmlSafe } from '@ember/string';
+import { assign } from '@ember/polyfills';
+import { isNone } from '@ember/utils';
+import { errorId, helpTextId } from '@smile-io/ember-polaris/utils/id';
+import layout from '../templates/components/polaris-range-slider';
+
+function invertNumber(number) {
+  if (Math.sign(number) === 1) {
+    return -Math.abs(number);
+  } else if (Math.sign(number) === -1) {
+    return Math.abs(number);
+  } else {
+    return 0;
+  }
+}
+
+export default Component.extend({
+  tagName: '',
+
+  layout,
+
+  /**
+   * Label for the range input
+   *
+   * @property {label}
+   * @type {String}
+   * @public
+   */
+  label: null,
+
+  /**
+   * Adds an action to the label
+   *
+   * @property {labelAction}
+   * @type {Object}
+   * @public
+   */
+  labelAction: null,
+
+  /**
+   * Visually hide the label
+   *
+   * @property {labelHidden}
+   * @type {Boolean}
+   * @default false
+   * @public
+   */
+  labelHidden: false,
+
+  /**
+   * ID for range input
+   *
+   * Defaults to Ember's internal GUID for the component instance
+   *
+   * @property {id}
+   * @type {String}
+   * @public
+   */
+  id: computed(function() {
+    return guidFor(this);
+  }),
+
+  /**
+   * Initial value for range input
+   *
+   * @property {value}
+   * @type {Number}
+   * @default 0
+   * @public
+   */
+  value: 0,
+
+  /**
+   * Minimum possible value for range input
+   *
+   * @property {min}
+   * @type {Number}
+   * @default 0
+   * @public
+   */
+  min: 0,
+
+  /**
+   * Maximum possible value for range input
+   *
+   * @property {max}
+   * @type {Number}
+   * @default 100
+   * @public
+   */
+  max: 100,
+
+  /**
+   * Increment value for range input changes
+   *
+   * @property {step}
+   * @type {Number?}
+   * @default null
+   * @public
+   */
+  step: null,
+
+  /**
+   * Provide a tooltip while sliding, indicating the current value
+   *
+   * @property {output}
+   * @type {Boolean}
+   * @default false
+   * @public
+   */
+  output: false,
+
+  /**
+   * Additional text to aid in use
+   *
+   * @property {helpText}
+   * @type {String|Component}
+   * @public
+   */
+  helpText: null,
+
+  /**
+   * Display an error message
+   *
+   * @property {error}
+   * @type {String|Component}
+   * @public
+   */
+  error: null,
+
+  /**
+   * Disable input
+   *
+   * @property {disabled}
+   * @type {Boolean}
+   * @default false
+   * @public
+   */
+  disabled: false,
+
+   /**
+   * Callback when the range input is changed
+   *
+   * @property {onChange}
+   * @type {Function}
+   * @default no-op
+   * @public
+   */
+  onChange() {},
+
+  /**
+   * Callback when range input is focused
+   *
+   * @property {onFocus}
+   * @type {Function}
+   * @default no-op
+   * @public
+   */
+  onFocus() {},
+
+  /**
+   * Callback when focus is removed
+   *
+   * @property {onBlur}
+   * @type {Function}
+   * @default no-op
+   * @public
+   */
+  onBlur() {},
+
+  /**
+   * Class names for the range input wrapper div
+   *
+   * @property {rangeInputWrapperClassNames}
+   * @type {String}
+   * @private
+   */
+  rangeInputWrapperClassNames: computed('error', 'disabled', function() {
+    let { error, disabled } = this.getProperties('error', 'disabled');
+    let classNames = ['Polaris-RangeSlider'];
+
+    if (error) {
+      classNames.push('Polaris-RangeSlider--error');
+    }
+
+    if (disabled) {
+      classNames.push('Polaris-RangeSlider--disabled');
+    }
+
+    return classNames.join(' ');
+  }).readOnly(),
+
+  /**
+   * Style for the range input wrapper div
+   *
+   * @property {rangeInputWrapperStyle}
+   * @type {String}
+   * @private
+   */
+  rangeInputWrapperStyle: computed('min', 'max', 'value', 'sliderProgress', function() {
+    let { min, max, value: current, sliderProgress } = this.getProperties('min', 'max', 'value', 'sliderProgress');
+    let styleProps = assign({ min, max, current }, {
+      current,
+      progress: `${ sliderProgress }%`,
+      outputFactor: invertNumber((sliderProgress - 50) / 100),
+    });
+
+    let styleString = Object.keys(styleProps).reduce((styleString, propName) => {
+      return `${ styleString } --Polaris-RangeSlider-${ dasherize(propName) }:${ styleProps[propName] };`;
+    }, '');
+
+    return htmlSafe(styleString.trim());
+  }).readOnly(),
+
+  /**
+   * Slider progress percentage
+   *
+   * @property {sliderProgress}
+   * @type {Number}
+   * @private
+   */
+  sliderProgress: computed('min', 'max', 'value', function() {
+    let { min, max, value } = this.getProperties('min', 'max', 'value');
+    return ((value - min) * 100) / (max - min);
+  }).readOnly(),
+
+  /**
+   * Stringified boolean flag indicating whether an error is present
+   *
+   * @property {hasError}
+   * @type {String}
+   * @private
+   */
+  hasError: computed('error', function() {
+    return Boolean(this.get('error')).toString();
+  }).readOnly(),
+
+  /**
+   * Accessibility
+   *
+   * @property {ariaDescribedBy}
+   * @type {Boolean}
+   * @private
+   */
+  ariaDescribedBy: computed('error', 'helpText', function() {
+    let { error, helpText, id } = this.getProperties('error', 'helpText', 'id');
+    let describedBy = [];
+
+    if (error) {
+      describedBy.push(errorId(id));
+    }
+
+    if (helpText) {
+      describedBy.push(helpTextId(id));
+    }
+
+    return describedBy.length ? describedBy.join(' ') : undefined;
+  }).readOnly(),
+
+  /**
+   * Boolean flag indicating whether the output value should be displayed
+   *
+   * @property {shouldShowOutput}
+   * @type {Boolean}
+   * @private
+   */
+  shouldShowOutput: computed('disabled', 'output', function() {
+    let { disabled, output } = this.getProperties('disabled', 'output');
+    return !disabled && output;
+  }).readOnly(),
+
+  actions: {
+    handleChange(event) {
+      let onChange = this.get('onChange');
+      if (isNone(onChange)) {
+        return;
+      }
+
+      onChange(parseFloat(event.currentTarget.value), this.get('id'));
+    },
+  }
+});

--- a/addon/components/polaris-range-slider.js
+++ b/addon/components/polaris-range-slider.js
@@ -17,6 +17,10 @@ function invertNumber(number) {
   }
 }
 
+/**
+ * Polaris range slider component.
+ * See https://polaris.shopify.com/components/forms/range-slider
+ */
 export default Component.extend({
   tagName: '',
 

--- a/addon/components/polaris-range-slider.js
+++ b/addon/components/polaris-range-slider.js
@@ -3,7 +3,6 @@ import { guidFor } from '@ember/object/internals';
 import { computed } from '@ember/object';
 import { dasherize, htmlSafe } from '@ember/string';
 import { assign } from '@ember/polyfills';
-import { isNone } from '@ember/utils';
 import { errorId, helpTextId } from '@smile-io/ember-polaris/utils/id';
 import layout from '../templates/components/polaris-range-slider';
 
@@ -207,7 +206,6 @@ export default Component.extend({
   rangeInputWrapperStyle: computed('min', 'max', 'value', 'sliderProgress', function() {
     let { min, max, value: current, sliderProgress } = this.getProperties('min', 'max', 'value', 'sliderProgress');
     let styleProps = assign({ min, max, current }, {
-      current,
       progress: `${ sliderProgress }%`,
       outputFactor: invertNumber((sliderProgress - 50) / 100),
     });
@@ -278,12 +276,7 @@ export default Component.extend({
 
   actions: {
     handleChange(event) {
-      let onChange = this.get('onChange');
-      if (isNone(onChange)) {
-        return;
-      }
-
-      onChange(parseFloat(event.currentTarget.value), this.get('id'));
+      this.get('onChange')(parseFloat(event.currentTarget.value), this.get('id'));
     },
   }
 });

--- a/addon/templates/components/polaris-range-slider.hbs
+++ b/addon/templates/components/polaris-range-slider.hbs
@@ -1,0 +1,38 @@
+{{#polaris-labelled
+  id=id
+  label=label
+  error=error
+  action=labelAction
+  labelHidden=labelHidden
+  helpText=helpText
+}}
+  <div class={{rangeInputWrapperClassNames}} style={{rangeInputWrapperStyle}}>
+    <input
+      type="range"
+      class="Polaris-RangeSlider__Input"
+      id={{id}}
+      name={{id}}
+      min={{min}}
+      max={{max}}
+      step={{step}}
+      value={{value}}
+      disabled={{disabled}}
+      oninput={{action "handleChange"}}
+      onfocus={{action onFocus}}
+      onblur={{action onBlur}}
+      aria-valuemin={{min}}
+      aria-valuemax={{max}}
+      aria-valuenow={{value}}
+      aria-invalid={{hasError}}
+      aria-describedby={{ariaDescribedBy}}
+    >
+
+    {{#if shouldShowOutput}}
+      <output htmlFor={{id}} class="Polaris-RangeSlider__Output">
+        <div class="Polaris-RangeSlider__OutputBubble">
+          <span class="Polaris-RangeSlider__OutputText">{{value}}</span>
+        </div>
+      </output>
+    {{/if}}
+  </div>
+{{/polaris-labelled}}

--- a/addon/utils/id.js
+++ b/addon/utils/id.js
@@ -1,0 +1,24 @@
+import { computed } from '@ember/object';
+
+function makeComputedIdGenerator(idGenerator) {
+  return function(idPath) {
+    return computed(idPath, function() {
+      return idGenerator(this.get(idPath));
+    });
+  }
+}
+
+export function labelId(id) {
+  return `${ id }Label`;
+}
+export const computedLabelId = makeComputedIdGenerator(labelId);
+
+export function errorId(id) {
+  return `${ id }Error`;
+}
+export const computedErrorId = makeComputedIdGenerator(errorId);
+
+export function helpTextId(id) {
+  return `${ id }HelpText`;
+}
+export const computedHelpTextId = makeComputedIdGenerator(helpTextId);

--- a/app/components/polaris-range-slider.js
+++ b/app/components/polaris-range-slider.js
@@ -1,0 +1,1 @@
+export { default } from '@smile-io/ember-polaris/components/polaris-range-slider';

--- a/app/utils/id.js
+++ b/app/utils/id.js
@@ -1,0 +1,1 @@
+export { default } from '@smile-io/ember-polaris/utils/id';

--- a/docs/radio-button.md
+++ b/docs/radio-button.md
@@ -29,7 +29,7 @@ Radio button with help text:
 }}
 ```
 
-Radio button with customer label component:
+Radio button with custom label component:
 
 ```hbs
 {{polaris-radio-button

--- a/docs/range-slider.md
+++ b/docs/range-slider.md
@@ -1,0 +1,42 @@
+[< Back to Components List](../README.md#components)
+
+## Range slider
+
+`polaris-range-slider` implements the [Polaris Range slider component](https://polaris.shopify.com/components/forms/range-slider).
+
+### Examples
+
+Default range slider (range of `0`-`100`):
+
+```hbs
+{{polaris-range-slider
+  label="Opacity percentage"
+  value=value
+  onChange=(action (mut value))
+}}
+```
+
+Range slider with custom minimum, maximum and step sizes:
+
+```hbs
+{{polaris-range-slider
+  label="Logo offset"
+  min=-10
+  max=10
+  step=5
+  value=value
+  onChange=(action (mut value))
+}}
+```
+
+Passing help text and error information:
+
+```hbs
+{{polaris-range-slider
+  label="Opacity percentage"
+  value=value
+  helpText="Choose the opacity of your logo image"
+  error="Invalid opacity value"
+  onChange=(action (mut value))
+}}
+```

--- a/tests/integration/components/polaris-range-slider-test.js
+++ b/tests/integration/components/polaris-range-slider-test.js
@@ -1,0 +1,225 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, find, triggerEvent } from '@ember/test-helpers';
+import Component from '@ember/component';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | polaris-range-slider', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it allows specific props to pass through properties on the input', async function(assert) {
+    await render(hbs`
+      {{polaris-range-slider
+        label="RangeSlider"
+        value=15
+        min=10
+        max=20
+        step=0.5
+        disabled=true
+      }}
+    `);
+
+    // TODO: Ember doesn't seem to be binding the `value` attribute on the input element...
+    // assert.dom('input').hasAttribute('value', '15');
+    assert.dom('input').hasAttribute('min', '10');
+    assert.dom('input').hasAttribute('max', '20');
+    assert.dom('input').hasAttribute('step', '0.5');
+    assert.dom('input').hasAttribute('disabled');
+  });
+
+  test('it calls `onChange` with the new value when the value is changed', async function(assert) {
+    assert.expect(2);
+
+    this.set('valueChanged', (newValue, inputId) => {
+      assert.equal(newValue, 40);
+      assert.equal(inputId, 'MyRangeSlider');
+    });
+
+    await render(hbs`
+      {{polaris-range-slider
+        id="MyRangeSlider"
+        label="RangeSlider"
+        value=50
+        onChange=(action valueChanged)
+      }}
+    `);
+
+    find('input').value = '40';
+    await triggerEvent('input', 'input');
+  });
+
+  test('`onFocus` is called when the input is focused', async function(assert) {
+    assert.expect(1);
+
+    this.set('inputFocused', () => {
+      assert.ok(true);
+    });
+
+    await render(hbs`
+      {{polaris-range-slider
+        label="RangeSlider"
+        value=50
+        onFocus=(action inputFocused)
+      }}
+    `);
+
+    await triggerEvent('input', 'focus');
+  });
+
+  test('`onBlur` is called when the input is blurred', async function(assert) {
+    assert.expect(1);
+
+    this.set('inputBlurred', () => {
+      assert.ok(true);
+    });
+
+    await render(hbs`
+      {{polaris-range-slider
+        label="RangeSlider"
+        value=50
+        onBlur=(action inputBlurred)
+      }}
+    `);
+
+    await triggerEvent('input', 'blur');
+  });
+
+  test('it sets the id on the input when an ID is passed', async function(assert) {
+    await render(hbs`
+      {{polaris-range-slider
+        label="RangeSlider"
+        id="MyRangeSlider"
+        value=50
+      }}
+    `);
+
+    assert.dom('input').hasAttribute('id', 'MyRangeSlider');
+  });
+
+  test('it sets a random id on the input when none is passed', async function(assert) {
+    await render(hbs`
+      {{polaris-range-slider
+        label="RangeSlider"
+        value=50
+      }}
+    `);
+
+    assert.dom('input').hasAttribute('id');
+  });
+
+  test('it connects the input to the output when output is rendered', async function(assert) {
+    await render(hbs`
+      {{polaris-range-slider
+        label="RangeSlider"
+        id="MyRangeSlider"
+        value=50
+        output=true
+      }}
+    `);
+
+    const inputId = find('input').getAttribute('id');
+    assert.equal(typeof inputId, 'string');
+    assert.dom('output').hasAttribute('for', inputId);
+  });
+
+  test('output contains correct value text when output is rendered', async function(assert) {
+    await render(hbs`
+      {{polaris-range-slider
+        label="RangeSlider"
+        value=50
+        output=true
+      }}
+    `);
+
+    assert.dom('output span').hasText('50');
+  });
+
+  test('it connects the input to the help text when help text is supplied', async function(assert) {
+    await render(hbs`
+      {{polaris-range-slider
+        label="RangeSlider"
+        value=50
+        helpText="Some help"
+      }}
+    `);
+    const helpTextId = find('input').getAttribute('aria-describedby');
+
+    assert.equal(typeof helpTextId, 'string');
+    assert.dom(`#${ helpTextId }`).hasText('Some help');
+  });
+
+  test('it marks the input as invalid when an error is present', async function(assert) {
+    this.owner.register('component:my-error-component', Component.extend({
+      tagName: 'span',
+      layout: hbs`{{text}}`,
+
+      text: null,
+    }));
+
+    await render(hbs`
+      {{polaris-range-slider
+        label="RangeSlider"
+        value=50
+        error=(component "my-error-component" text="Invalid")
+      }}
+    `);
+    assert.dom('input').hasAttribute('aria-invalid', 'true');
+
+    await render(hbs`
+      {{polaris-range-slider
+        label="RangeSlider"
+        value=50
+        error="Some error"
+      }}
+    `);
+    assert.dom('input').hasAttribute('aria-invalid', 'true');
+  });
+
+  test('it connects the input to the error when an error is present', async function(assert) {
+    await render(hbs`
+      {{polaris-range-slider
+        label="RangeSlider"
+        value=50
+        error="Some error"
+      }}
+    `);
+    const errorId = find('input').getAttribute('aria-describedby');
+
+    assert.equal(typeof errorId, 'string');
+    assert.dom(`#${ errorId }`).hasText('Some error');
+  });
+
+  test('it connects the input to both an error and help text when both error and help text are present', async function(assert) {
+    await render(hbs`
+      {{polaris-range-slider
+        label="RangeSlider"
+        value=50
+        helpText="Some help"
+        error="Some error"
+      }}
+    `);
+    const descriptions = find('input').getAttribute('aria-describedby').split(' ');
+
+    assert.equal(descriptions.length, 2);
+    assert.dom(`#${ descriptions[1] }`).hasText('Some help');
+    assert.dom(`#${ descriptions[0] }`).hasText('Some error');
+  });
+
+  test('it sets the correct css custom properties', async function(assert) {
+    await render(hbs`
+      {{polaris-range-slider
+        label="RangeSlider"
+        id="MyRangeSlider"
+        value=25
+      }}
+    `);
+
+    const styleString = find('input').parentElement.getAttribute('style');
+
+    assert.ok(styleString.indexOf('--Polaris-RangeSlider-min:0;') > -1);
+    assert.ok(styleString.indexOf('--Polaris-RangeSlider-max:100;') > -1);
+    assert.ok(styleString.indexOf('--Polaris-RangeSlider-current:25;') > -1);
+    assert.ok(styleString.indexOf('--Polaris-RangeSlider-progress:25%;') > -1);
+    assert.ok(styleString.indexOf('--Polaris-RangeSlider-output-factor:0.25;') > -1);
+  });
+});


### PR DESCRIPTION
Adds a full implementation of the Polaris [range slider](https://polaris.shopify.com/components/forms/range-slider) component:

![polaris-range-slider](https://user-images.githubusercontent.com/5737342/42226979-103e2350-7ee9-11e8-9b22-ffe376205289.gif)
