### PR TITLE
Pass selector to value listener in polaris-text-field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ember-polaris Changelog
 
+### v.1.7.1 (July 9, 2018)
+- [#158](https://github.com/smile-io/ember-polaris/pull/158) [FIX] Pass textfield selectors to `polaris-text-field` event listener.
+
 ### v.1.7.0 (July 9, 2018)
 - [#144](https://github.com/smile-io/ember-polaris/pull/144) [UPDATE] Shopify Polaris `v2.2.0`
 - [#146](https://github.com/smile-io/ember-polaris/pull/146) [ENHANCEMENT] Add `new` status to the Badge component

--- a/addon/components/polaris-text-field.js
+++ b/addon/components/polaris-text-field.js
@@ -422,7 +422,7 @@ export default Component.extend(ContextBoundTasksMixin, ContextBoundEventListene
   }).readOnly(),
 
   addValueListener() {
-    this.addEventListener('keyup', () => {
+    this.addEventListener('input, textarea', 'keyup', () => {
       this.debounceTask('debouncedUpdateValue', 250);
     });
   },


### PR DESCRIPTION
### Overview

The `polaris-text-field` uses ember-lifeline to add an event listener for the `keyup` event on the input field. It [doesn't require](https://github.com/ember-lifeline/ember-lifeline/blob/master/addon/mixins/dom.js#L57) a selector to be passed in, and worked fine in the dummy app. However when pulled into other apps it seems to be having issues (throws error: `Called addEventListener with selector not found in DOM: keyup`) so to be safe I'm passing the selector, which fixes the error and still works as expected.