### PR TITLE
Add notes about avoiding Glimmer error under dynamic usages of auto-wrapping components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ember-polaris Changelog
 
+### Unreleased
+- [#159](https://github.com/smile-io/ember-polaris/pull/159) [DOCUMENTATION] Add notes about avoiding Glimmer error under dynamic usages of auto-wrapping components (`polaris-button-group`, `polaris-form-layout`, `polaris-form-layout/group` and `polaris-stack`).
+
 ### v.1.7.1 (July 9, 2018)
 - [#158](https://github.com/smile-io/ember-polaris/pull/158) [FIX] Pass textfield selectors to `polaris-text-field` event listener.
 

--- a/docs/button-group.md
+++ b/docs/button-group.md
@@ -53,5 +53,12 @@ For dynamic button groups where buttons are added or removed once the button gro
     {{#group.item}}
       ...
     {{/group.item}}
+  {{/each}}
+
+  {{#if canRemove}}
+    {{#group.item}}
+      ...
+    {{/group.item}}
+  {{/if}}
 {{/polaris-button-group}}
 ```

--- a/docs/button-group.md
+++ b/docs/button-group.md
@@ -44,3 +44,14 @@ Plain buttons:
   {{/buttonGroup.item}}
 {{/polaris-button-group}}
 ```
+
+For dynamic button groups where buttons are added or removed once the button group has rendered, you must explicitly add an item component around each item to prevent a Glimmer error such as `Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node`:
+
+```hbs
+{{#polaris-button-group as |group|}}
+  {{#each buttons as |button|}}
+    {{#group.item}}
+      ...
+    {{/group.item}}
+{{/polaris-button-group}}
+```

--- a/docs/form-layout.md
+++ b/docs/form-layout.md
@@ -28,3 +28,23 @@ Form layout with two groups, the second of which is condensed:
   {{/formLayout.group}}
 {{/polaris-form-layout}}
 ```
+
+For dynamic forms where items are added or removed once the form has rendered, you must explicitly a form layout item component around each item to prevent a Glimmer error such as `Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node`:
+
+```hbs
+{{#polaris-form-layout as |formLayout|}}
+  {{#each formItems as |formItem|}}
+    {{#formLayout.item}}
+      ...
+    {{/formLayout.item}}
+  {{/each}}
+
+  {{#formLayout.group as |group|}}
+    {{#each formGroupItems as |formGroupItem|}}
+      {{#group.item}}
+        ...
+      {{/group.item}}
+    {{/each}}
+  {{/formLayout.group}}
+{{/polaris-form-layout}}
+```

--- a/docs/form-layout.md
+++ b/docs/form-layout.md
@@ -33,11 +33,11 @@ For dynamic forms where items are added or removed once the form has rendered, y
 
 ```hbs
 {{#polaris-form-layout as |formLayout|}}
-  {{#each formItems as |formItem|}}
+  {{#if canEdit}}
     {{#formLayout.item}}
       ...
     {{/formLayout.item}}
-  {{/each}}
+  {{/if}}
 
   {{#formLayout.group as |group|}}
     {{#each formGroupItems as |formGroupItem|}}

--- a/docs/form-layout.md
+++ b/docs/form-layout.md
@@ -29,7 +29,7 @@ Form layout with two groups, the second of which is condensed:
 {{/polaris-form-layout}}
 ```
 
-For dynamic forms where items are added or removed once the form has rendered, you must explicitly a form layout item component around each item to prevent a Glimmer error such as `Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node`:
+For dynamic forms where items are added or removed once the form has rendered, you must explicitly add a form layout item component around each item to prevent a Glimmer error such as `Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node`:
 
 ```hbs
 {{#polaris-form-layout as |formLayout|}}

--- a/docs/stack.md
+++ b/docs/stack.md
@@ -46,5 +46,12 @@ For dynamic stacks where items are added or removed once the stack has rendered,
     {{#stack.item}}
       ...
     {{/stack.item}}
+  {{/each}}
+
+  {{#unless isUpdating}}
+    {{#stack.item}}
+      ...
+    {{/stack.item}}
+  {{/unless}}
 {{/polaris-stack}}
 ```

--- a/docs/stack.md
+++ b/docs/stack.md
@@ -37,3 +37,14 @@ Stack with one item on the left and one pushed to the right:
   <div>Stack item 2</div>
 {{/polaris-stack}}
 ```
+
+For dynamic stacks where items are added or removed once the stack has rendered, you must explicitly add an item component around each item to prevent a Glimmer error such as `Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node`:
+
+```hbs
+{{#polaris-stack as |stack|}}
+  {{#each stackItems as |stackItem|}}
+    {{#stack.item}}
+      ...
+    {{/stack.item}}
+{{/polaris-stack}}
+```


### PR DESCRIPTION
At present, 4 of the components in `ember-polaris` auto-wrap their child elements in `div`s - `polaris-button-group`, `polaris-form-layout`, `polaris-form-layout/group` and `polaris-stack`. If any of these components are used with dynamic contents (e.g. with an `if`- or `each`-block inside), whenever an item is added or removed a Glimmer error can occur. Unfortunately I don't think we can detect this possibility and avoid it automatically (certainly not quickly), so I thought it was worth adding notes and examples to the docs for those components affected.