### PR TITLE
Safeguard against non finite numbers in progress bar

### DIFF
--- a/addon/components/polaris-progress-bar.js
+++ b/addon/components/polaris-progress-bar.js
@@ -56,7 +56,7 @@ export default Component.extend({
     let progress = this.get('progress');
     let parsedProgress;
 
-    if (progress < 0) {
+    if (progress < 0 || !Number.isFinite(progress)) {
       parsedProgress = 0;
     } else if (progress > 100) {
       parsedProgress = 100;


### PR DESCRIPTION
Prevents any non-finite number being used as a progress percentage in the `polaris-progress-bar`.

Alternatively this could also be caught in a `didReceiveAttrs` hook, but that might be overkill since the `progress` attr seems to only be used in computing the `parsedProgress` property. 