### PR TITLE
Allow classes for `polaris-callout-card`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ember-polaris Changelog
 
+### Unreleased
+- [#170](https://github.com/smile-io/ember-polaris/pull/170) [FIX] Allow class names on `polaris-callout-card`.
+
 ### v.1.7.3 (August 21, 2018)
 - [#163](https://github.com/smile-io/ember-polaris/pull/163) [ENHANCEMENT] Add `image` property to `polaris-action-list/item` component.
 

--- a/addon/components/polaris-callout-card.js
+++ b/addon/components/polaris-callout-card.js
@@ -6,7 +6,7 @@ import layout from '../templates/components/polaris-callout-card';
  * See https://polaris.shopify.com/components/structure/callout-card
  */
 export default Component.extend({
-  tagName: '',
+  classNames: [ 'Polaris-Card' ],
 
   layout,
 

--- a/addon/templates/components/polaris-callout-card.hbs
+++ b/addon/templates/components/polaris-callout-card.hbs
@@ -1,4 +1,4 @@
-{{#polaris-card sectioned=true}}
+{{#polaris-card/section}}
   <div class="Polaris-CalloutCard">
     <div class="Polaris-CalloutCard__Content">
       <div class="Polaris-CalloutCard__Title">
@@ -38,4 +38,4 @@
 
     <img src={{illustration}} alt="" class="Polaris-CalloutCard__Image">
   </div>
-{{/polaris-card}}
+{{/polaris-card/section}}


### PR DESCRIPTION
`polaris-callout-card` was previously a tagless component, which meant that it was impossible to apply classes to directly. This small PR refactors the component to have the `div.Polaris-Card` as its element.