### PR TITLE
Upgrade v2.11.0 checkbox/choice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [#168](https://github.com/smile-io/ember-polaris/pull/168) [INTERNAL] Upgrade to Ember CLI `3.4.2`
 - [#171](https://github.com/smile-io/ember-polaris/pull/171) [UPDATE] Shopify Polaris `v2.11.0`
 - [#174](https://github.com/smile-io/ember-polaris/pull/174) [FEATURE] Add `polaris-inline-error` component
+- [#187](https://github.com/smile-io/ember-polaris/pull/187) [FEATURE] Add `disabled` attribute to `polaris-choice`
 
 ### v.1.7.6 (october 5, 2018)
 - [#181](https://github.com/smile-io/ember-polaris/pull/181) [internal] autofix code to use our latest eslint rules.

--- a/addon/components/polaris-checkbox.js
+++ b/addon/components/polaris-checkbox.js
@@ -102,7 +102,7 @@ export default Component.extend({
    * Display an error state
    *
    * @property error
-   * @type {String}
+   * @type {String|Boolean}
    * @default null
    * @public
    */

--- a/addon/components/polaris-choice.js
+++ b/addon/components/polaris-choice.js
@@ -46,10 +46,20 @@ export default Component.extend({
   labelComponent: null,
 
   /**
+   * Whether the associated form control is disabled
+   *
+   * @property disabled
+   * @type {Boolean}
+   * @default: null
+   * @public
+   */
+  disabled: null,
+
+  /**
    * Error content for this choice
    *
    * @property error
-   * @type {String}
+   * @type {String|Boolean}
    * @default: null
    * @public
    */
@@ -83,9 +93,11 @@ export default Component.extend({
   /**
    * @private
    */
-  errorId: computed('inputId', function() {
-    return `${this.get('inputId')}Error`;
-  }).readOnly(),
+  shouldRenderError: computed('error', function() {
+    let error = this.get('error');
+
+    return error && typeof error !== 'boolean';
+  }),
 
   /**
    * @private

--- a/addon/components/polaris-choice/label.js
+++ b/addon/components/polaris-choice/label.js
@@ -8,7 +8,10 @@ export default Component.extend({
 
   classNames: ['Polaris-Choice'],
 
-  classNameBindings: ['labelHidden:Polaris-Choice--labelHidden'],
+  classNameBindings: [
+    'labelHidden:Polaris-Choice--labelHidden',
+    'disabled:Polaris-Choice--disabled',
+  ],
 
   layout,
 
@@ -53,4 +56,14 @@ export default Component.extend({
    * @public
    */
   labelHidden: false,
+
+  /**
+   * Whether the associated form control is disabled
+   *
+   * @property disabled
+   * @type {Boolean}
+   * @default: null
+   * @public
+   */
+  disabled: null,
 });

--- a/addon/templates/components/polaris-checkbox.hbs
+++ b/addon/templates/components/polaris-checkbox.hbs
@@ -5,6 +5,7 @@
   labelHidden=labelHidden
   helpText=helpText
   error=error
+  disabled=disabled
 }}
   <span class="Polaris-Checkbox {{if error "Polaris-Checkbox--error"}}">
     <input

--- a/addon/templates/components/polaris-choice.hbs
+++ b/addon/templates/components/polaris-choice.hbs
@@ -4,6 +4,7 @@
     label=label
     labelComponent=labelComponent
     labelHidden=labelHidden
+    disabled=disabled
   )
 as |choiceLabelComponent|
 }}
@@ -14,12 +15,12 @@ as |choiceLabelComponent|
       {{/component}}
 
       <div class="Polaris-Choice__Descriptions">
-        {{#if error}}
-          <div class="Polaris-Choice__Error" id={{errorId}}>
-            <div class="Polaris-Choice__ErrorIcon">
-              {{polaris-icon source="alert"}}
-            </div>
-            {{error}}
+        {{#if shouldRenderError}}
+          <div class="Polaris-Choice__Error">
+            {{polaris-inline-error
+              fieldID=inputId
+              message=error
+            }}
           </div>
         {{/if}}
 

--- a/tests/integration/components/polaris-choice-test.js
+++ b/tests/integration/components/polaris-choice-test.js
@@ -446,3 +446,23 @@ test('it handles label components correctly when a description is supplied', fun
     'with label - renders the correct label content'
   );
 });
+
+test('it handles the disabled attribute correctly', function(assert) {
+  let disabledClass = 'Polaris-Choice--disabled';
+
+  this.set('disabled', true);
+
+  this.render(hbs`
+    {{polaris-choice
+      inputId="disabled-test"
+      label="My label"
+      disabled=disabled
+    }}
+  `);
+
+  assert.dom(labelSelector).hasClass(disabledClass);
+
+  this.set('disabled', false);
+
+  assert.dom(labelSelector).hasNoClass(disabledClass);
+});

--- a/tests/integration/components/polaris-choice-test.js
+++ b/tests/integration/components/polaris-choice-test.js
@@ -72,7 +72,8 @@ const errorSelector = buildNestedSelector(
 );
 const errorIconSelector = buildNestedSelector(
   errorSelector,
-  'div.Polaris-Choice__ErrorIcon',
+  'div.Polaris-InlineError',
+  'div.Polaris-InlineError__Icon',
   'span.Polaris-Icon',
   'svg'
 );


### PR DESCRIPTION
Finishes https://github.com/smile-io/ember-polaris/issues/186

Diff [here](https://github.com/Shopify/polaris/compare/v2.2.0...v2.11.0?diff=split#diff-29260b22317e444058d1188413079747)

This is mostly just an update to `polaris-choice`, the only update to `polaris-checkbox` was sending down the `disabled` attribute.