### PR TITLE
Update labelled to v2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#195](https://github.com/smile-io/ember-polaris/pull/195) [ENHANCEMENT] Add `nextKeys` and `previousKeys` attribute to `polaris-pagination`
 - [#193](https://github.com/smile-io/ember-polaris/pull/193) [ENHANCEMENT] Update `polaris-choice-list` to render `error` and `aria` attributes
 - [#197](https://github.com/smile-io/ember-polaris/pull/197) [ENHANCEMENT] Update `polaris-data-table` to match Polaris v2.11.0 refactor
+- [#216](https://github.com/smile-io/ember-polaris/pull/216) [ENHANCEMENT] Update `polaris-labelled` to match Polaris v2.11.0
 
 ### v1.7.8 (October 10, 2018)
 - [199](https://github.com/smile-io/ember-polaris/pull/199) [ENHANCEMENT] Add support for disabled and loading states to `polaris-setting-toggle`.

--- a/addon/components/polaris-inline-error.js
+++ b/addon/components/polaris-inline-error.js
@@ -6,6 +6,7 @@ export default Component.extend({
   tagName: '',
 
   layout,
+
   /**
    * Unique identifier of the invalid form field that the message describes
    *

--- a/addon/components/polaris-labelled.js
+++ b/addon/components/polaris-labelled.js
@@ -40,7 +40,7 @@ export default Component.extend({
   /**
    * Error to display beneath the label
    *
-   * @type {String|Component}
+   * @type {String|Component|Boolean}
    * @public
    */
   error: null,
@@ -87,4 +87,15 @@ export default Component.extend({
    * @private
    */
   helpTextId: computedHelpTextId('id').readOnly(),
+
+  /**
+   * Flag indicating whether to render the error component
+   *
+   * @type {Boolean}
+   * @private
+   */
+  shouldRenderError: computed('error', function() {
+    let { error } = this;
+    return error && typeof error !== 'boolean';
+  }).readOnly(),
 });

--- a/addon/components/polaris-labelled.js
+++ b/addon/components/polaris-labelled.js
@@ -95,7 +95,7 @@ export default Component.extend({
    * @private
    */
   shouldRenderError: computed('error', function() {
-    let { error } = this;
+    let error = this.get('error');
     return error && typeof error !== 'boolean';
   }).readOnly(),
 });

--- a/addon/templates/components/polaris-labelled.hbs
+++ b/addon/templates/components/polaris-labelled.hbs
@@ -22,10 +22,7 @@
 
   {{#if shouldRenderError}}
     <div id={{errorId}} class="Polaris-Labelled__Error">
-      <div class="Polaris-Labelled__ErrorIcon">
-        {{polaris-icon source="alert"}}
-      </div>
-      {{render-content error}}
+      {{polaris-inline-error message=error fieldID=id}}
     </div>
   {{/if}}
 

--- a/addon/templates/components/polaris-labelled.hbs
+++ b/addon/templates/components/polaris-labelled.hbs
@@ -20,7 +20,7 @@
 
   {{yield}}
 
-  {{#if error}}
+  {{#if shouldRenderError}}
     <div id={{errorId}} class="Polaris-Labelled__Error">
       <div class="Polaris-Labelled__ErrorIcon">
         {{polaris-icon source="alert"}}

--- a/addon/templates/components/polaris-labelled.hbs
+++ b/addon/templates/components/polaris-labelled.hbs
@@ -21,7 +21,7 @@
   {{yield}}
 
   {{#if shouldRenderError}}
-    <div id={{errorId}} class="Polaris-Labelled__Error">
+    <div class="Polaris-Labelled__Error">
       {{polaris-inline-error message=error fieldID=id}}
     </div>
   {{/if}}

--- a/tests/integration/components/polaris-labelled-test.js
+++ b/tests/integration/components/polaris-labelled-test.js
@@ -33,6 +33,14 @@ module('Integration | Component | polaris-labelled', function(hooks) {
     assert.dom('#my-labelledError').hasText('Error message');
   });
 
+  test('renders no error markup when provided with a boolean value', async function(assert) {
+    await render(
+      hbs`{{polaris-labelled id="my-labelled" label="Label" error=true}}`
+    );
+
+    assert.dom('.Polaris-InlineError').doesNotExist();
+  });
+
   test('renders the content as a child outside of the label', async function(assert) {
     await render(hbs`
       {{#polaris-labelled}}


### PR DESCRIPTION
Closes #215

I didn't update to use `ember-test-selectors` here simply because the existing tests are just straight ports of the React implementation's tests. Let me know if you guys feel like we should make that update anyway and I'll do it :+1: