### PR TITLE
Update page to v2.11.0

### DIFF
--- a/addon/components/polaris-page.js
+++ b/addon/components/polaris-page.js
@@ -20,17 +20,27 @@ export default Component.extend({
    *
    * @property title
    * @public
-   * @type {string}
+   * @type {String}
    * @default null
    */
   title: null,
+
+  /**
+   * Important and non-interactive status information shown immediately after the title
+   *
+   * @property titleMetadata
+   * @public
+   * @type {String|Component}
+   * @default null
+   */
+  titleMetadata: null,
 
   /**
    * Visually hide the title
    *
    * @property titleHidden
    * @public
-   * @type {boolean}
+   * @type {Boolean}
    * @default false
    */
   titleHidden: false,
@@ -40,7 +50,7 @@ export default Component.extend({
    *
    * @property icon
    * @public
-   * @type {string}
+   * @type {String}
    * @default null
    * TODO: not implemented yet.
    */
@@ -75,7 +85,7 @@ export default Component.extend({
    *
    * @property fullWidth
    * @public
-   * @type {boolean}
+   * @type {Boolean}
    * @default false
    */
   fullWidth: false,
@@ -85,7 +95,7 @@ export default Component.extend({
    *
    * @property singleColumn
    * @public
-   * @type {boolean}
+   * @type {Boolean}
    * @default false
    */
   singleColumn: false,
@@ -95,7 +105,7 @@ export default Component.extend({
    *
    * @property separator
    * @public
-   * @type {boolean}
+   * @type {Boolean}
    * @default false
    */
   separator: false,

--- a/addon/components/polaris-page/header.js
+++ b/addon/components/polaris-page/header.js
@@ -25,6 +25,16 @@ export default Component.extend({
   title: null,
 
   /**
+   * Important and non-interactive status information shown immediately after the title
+   *
+   * @property titleMetadata
+   * @public
+   * @type {String|Component}
+   * @default null
+   */
+  titleMetadata: null,
+
+  /**
    * Visually hide the title
    *
    * @property titleHidden

--- a/addon/components/polaris-page/header.js
+++ b/addon/components/polaris-page/header.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import layout from '../../templates/components/polaris-page/header';
+import { computed } from '@ember/object';
 import { gt, or } from '@ember/object/computed';
 
 export default Component.extend({
@@ -114,4 +115,11 @@ export default Component.extend({
   hasActions: or('primaryAction', 'secondaryActions').readOnly(),
   hasSecondaryActions: gt('secondaryActions.length', 0).readOnly(),
   hasRollup: gt('secondaryActions.length', 1).readOnly(),
+
+  shouldRenderPrimaryActionAsPrimary: computed('primaryAction.primary', function() {
+    let primaryAction = this.get('primaryAction');
+
+    return primaryAction &&
+      (primaryAction.primary === undefined ? true : primaryAction.primary);
+  }).readOnly(),
 });

--- a/addon/templates/components/polaris-page.hbs
+++ b/addon/templates/components/polaris-page.hbs
@@ -1,6 +1,7 @@
 {{#if hasHeaderContent}}
   {{polaris-page/header
     title=title
+    titleMetadata=titleMetadata
     titleHidden=titleHidden
     icon=icon
     breadcrumbs=breadcrumbs

--- a/addon/templates/components/polaris-page/header.hbs
+++ b/addon/templates/components/polaris-page/header.hbs
@@ -22,7 +22,7 @@
   {{#with
     (if primaryAction
       (component "polaris-button"
-        primary=true
+        primary=shouldRenderPrimaryActionAsPrimary
         text=primaryAction.text
         disabled=primaryAction.disabled
         loading=primaryAction.loading

--- a/addon/templates/components/polaris-page/header.hbs
+++ b/addon/templates/components/polaris-page/header.hbs
@@ -17,7 +17,7 @@
     Note that we do not pass the `onClick` action in here because it causes
     the template to blow up if no primary action is supplied.
   --}}
-  {{! template-lint-disable attribute-indentation}}
+  {{! template-lint-disable attribute-indentation }}
   {{!-- TODO remove rule above once linter handles this correctly --}}
   {{#with
     (if primaryAction
@@ -40,6 +40,10 @@
         {{#polaris-display-text tagName="h1" size="large"}}
           {{title}}
         {{/polaris-display-text}}
+
+        {{#if titleMetadata}}
+          {{render-content titleMetadata}}
+        {{/if}}
       </div>
 
       <div class="Polaris-Page__Actions">


### PR DESCRIPTION
Closes #217 by adding `titleMetadata` and `primary` support to page header.

Screen grab with `titleMetadata=(component "polaris-badge" status="success" text="Metadata")` and `primaryAction=(hash primary=false ...)`:

![image](https://user-images.githubusercontent.com/5737342/47299269-7f6ecc80-d622-11e8-9c54-612697c370b4.png)
