### PR TITLE
Fix test error from using string as component name

### DIFF
--- a/addon/templates/components/polaris-card/section.hbs
+++ b/addon/templates/components/polaris-card/section.hbs
@@ -1,12 +1,12 @@
-{{#with "polaris-card/section-header" as |header|}}
+{{#with (component "polaris-card/section-header") as |headerComponent|}}
   {{#if title}}
-    {{component header title=title}}
+    {{component headerComponent title=title}}
   {{/if}}
 
   {{#if hasBlock}}
     {{yield
       (hash
-        header=header
+        header=headerComponent
       )
     }}
   {{else}}


### PR DESCRIPTION
Noticed a couple of tests on a few recent Polaris v2.11.0 update branches were failing on `ember-beta` and `ember-canary`, this branch puts a fix in for the error:

![image](https://user-images.githubusercontent.com/5737342/47340329-922ae500-d6a6-11e8-940c-0326ad55dd06.png)
