### PR TITLE
Fix "empty tagName" warnings coming from polaris-inline-error

### DIFF
--- a/addon/components/polaris-inline-error.js
+++ b/addon/components/polaris-inline-error.js
@@ -26,8 +26,8 @@ export default Component.extend({
    */
   message: null,
 
-  'data-test-inline-error': true,
-  'data-test-inline-error-icon': true,
+  dataTestInlineError: true,
+  dataTestInlineErrorIcon: true,
 
   init() {
     this._super(...arguments);

--- a/addon/templates/components/polaris-inline-error.hbs
+++ b/addon/templates/components/polaris-inline-error.hbs
@@ -2,11 +2,11 @@
   <div
     class="Polaris-InlineError"
     id={{concat fieldID "Error"}}
-    data-test-inline-error={{data-test-inline-error}}
+    data-test-inline-error={{dataTestInlineError}}
   >
     <div
       class="Polaris-InlineError__Icon"
-      data-test-inline-error-icon={{data-test-inline-error-icon}}
+      data-test-inline-error-icon={{dataTestInlineErrorIcon}}
     >
       {{polaris-icon source="alert"}}
     </div>


### PR DESCRIPTION
Noticed that we were hitting some warnings in tests due to having `data-test-*` properties defined on `polaris-inline-error`, which is a tagless component:

![image](https://user-images.githubusercontent.com/5737342/47498210-4a05f100-d865-11e8-890a-bf82f5685684.png)

By naming these camel-cased instead of dasherized, `ember-test-selectors` doesn't attempt to bind them to the component's tag.