### PR TITLE
Remove click event object from breadcrumb action args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#234](https://github.com/smile-io/ember-polaris/pull/234) [UPDATE] Drop Ember 2.12 support
 - [#236](https://github.com/smile-io/ember-polaris/pull/236) [ENHANCEMENT] Add `destructive` attribute to `polaris-action-list/item`
 - [#225](https://github.com/smile-io/ember-polaris/pull/225) [ENHANCEMENT] Update `polaris-drop-zone` to accept Polaris v2.11.0 labelled attributes
+- [#241](https://github.com/smile-io/ember-polaris/pull/241) [FIX] Remove click event from `polaris-breadcrumb` action invocation arguments
 
 ### v1.7.8 (October 10, 2018)
 - [199](https://github.com/smile-io/ember-polaris/pull/199) [ENHANCEMENT] Add support for disabled and loading states to `polaris-setting-toggle`.

--- a/addon/components/polaris-breadcrumbs.js
+++ b/addon/components/polaris-breadcrumbs.js
@@ -49,4 +49,10 @@ export default Component.extend({
       ? breadcrumbs[breadcrumbsCount - 1]
       : null;
   }).readOnly(),
+
+  actions: {
+    fireAction(action) {
+      action();
+    },
+  },
 });

--- a/addon/components/polaris-breadcrumbs.js
+++ b/addon/components/polaris-breadcrumbs.js
@@ -49,10 +49,4 @@ export default Component.extend({
       ? breadcrumbs[breadcrumbsCount - 1]
       : null;
   }).readOnly(),
-
-  actions: {
-    fireAction(action) {
-      action();
-    },
-  },
 });

--- a/addon/templates/components/polaris-breadcrumbs.hbs
+++ b/addon/templates/components/polaris-breadcrumbs.hbs
@@ -15,8 +15,8 @@
   <button
     class="Polaris-Breadcrumbs__Breadcrumb"
     type="button"
-    onclick={{action "fireAction" breadcrumb.onAction}}
     onmouseup={{handleMouseUpByBlurring}}
+    {{action breadcrumb.onAction}}
   >
     <span data-test-breadcrumb-icon class="Polaris-Breadcrumbs__Icon">
       {{polaris-icon source="chevron-left"}}

--- a/addon/templates/components/polaris-breadcrumbs.hbs
+++ b/addon/templates/components/polaris-breadcrumbs.hbs
@@ -15,7 +15,7 @@
   <button
     class="Polaris-Breadcrumbs__Breadcrumb"
     type="button"
-    onclick={{action breadcrumb.onAction}}
+    onclick={{action "fireAction" breadcrumb.onAction}}
     onmouseup={{handleMouseUpByBlurring}}
   >
     <span data-test-breadcrumb-icon class="Polaris-Breadcrumbs__Icon">

--- a/tests/integration/components/polaris-breadcrumbs-test.js
+++ b/tests/integration/components/polaris-breadcrumbs-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 const content = 'Content value';
@@ -61,5 +61,26 @@ module('Integration | Component | polaris-breadcrumbs', function(hooks) {
     assert
       .dom('[data-test-breadcrumbs] > button')
       .exists('it renders a button');
+  });
+
+  test('it does not append the click event to the invoked action args', async function(assert) {
+    this.set('breadcrumbs', [
+      {
+        content,
+        onAction(...invocationArgs) {
+          assert.step(`Action invoked with ${invocationArgs.length} args`);
+        },
+      },
+    ]);
+
+    await render(hbs`
+      {{polaris-breadcrumbs breadcrumbs=breadcrumbs}}
+    `);
+
+    await click('button');
+    assert.verifySteps(
+      ['Action invoked with 0 args'],
+      'action does not append click event to invoked action args'
+    );
   });
 });


### PR DESCRIPTION
Fixes #240 by swallowing the click event object when invoking breadcrumb actions.