### PR TITLE
Fix data table height not calculating correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [#241](https://github.com/smile-io/ember-polaris/pull/241) [FIX] Remove click event from `polaris-breadcrumb` action invocation arguments
 - [#237](https://github.com/smile-io/ember-polaris/pull/237) [FIX] Prevent event bubbling on `polaris-action-list/item`'s `onAction` method
 - [#244](https://github.com/smile-io/ember-polaris/pull/244) [FIX] Fix bug where `polaris-data-table` cell heights weren't calculating correctly
+- [#237](https://github.com/smile-io/ember-polaris/pull/243) [FIX] Update table cell heights when attrs are updated in `polaris-data-table`
 
 ### v1.7.8 (October 10, 2018)
 - [199](https://github.com/smile-io/ember-polaris/pull/199) [ENHANCEMENT] Add support for disabled and loading states to `polaris-setting-toggle`.

--- a/addon/components/polaris-data-table.js
+++ b/addon/components/polaris-data-table.js
@@ -482,6 +482,12 @@ export default Component.extend(
       this.addEventHandlers();
     },
 
+    didUpdateAttrs() {
+      this._super(...arguments);
+
+      this.handleResize();
+    },
+
     actions: {
       navigateTable(direction) {
         let {


### PR DESCRIPTION
### Overview

Cell heights weren't being recalculated when underlying data changed (https://github.com/smile-io/ember-polaris/issues/161)

The recalculation issue is [fixed in Polaris](https://github.com/Shopify/polaris-react/blob/master/src/components/DataTable/DataTable.tsx#L108-L113) by recalculating height when the `DataTable` component updates.

### On hold

~~This fix doesn't appear in the React version until **v3.0.0-beta.11**, so we should hold off on merging until we have a 3.0 version of ember-polaris just to keep our versions in sync.~~ (we'll ship now and add a comment)

### Demo

![heights](https://user-images.githubusercontent.com/2292367/47588134-388b1a80-d933-11e8-8cf7-3f38eee06f72.gif)
