### PR TITLE
Use children vs. childNodes in data-table cell height calc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [#225](https://github.com/smile-io/ember-polaris/pull/225) [ENHANCEMENT] Update `polaris-drop-zone` to accept Polaris v2.11.0 labelled attributes
 - [#241](https://github.com/smile-io/ember-polaris/pull/241) [FIX] Remove click event from `polaris-breadcrumb` action invocation arguments
 - [#237](https://github.com/smile-io/ember-polaris/pull/237) [FIX] Prevent event bubbling on `polaris-action-list/item`'s `onAction` method
+- [#244](https://github.com/smile-io/ember-polaris/pull/244) [FIX] Fix bug where `polaris-data-table` cell heights weren't calculating correctly
 
 ### v1.7.8 (October 10, 2018)
 - [199](https://github.com/smile-io/ember-polaris/pull/199) [ENHANCEMENT] Add support for disabled and loading states to `polaris-setting-toggle`.

--- a/addon/components/polaris-data-table.js
+++ b/addon/components/polaris-data-table.js
@@ -441,7 +441,7 @@ export default Component.extend(
 
         if (!truncate) {
           return (heights = rows.map((row) => {
-            let fixedCell = row.hasChildNodes() && row.childNodes;
+            let fixedCell = row.hasChildNodes() && row.children[0];
             return Math.max(row.clientHeight, fixedCell.clientHeight);
           }));
         }


### PR DESCRIPTION
Moved this fix out of https://github.com/smile-io/ember-polaris/pull/243 to be in it's own PR since we're going to hold off on merging https://github.com/smile-io/ember-polaris/pull/243 until we upgrade to a version of Polaris where they include the fix as well.

Copied description from 243:

As for the heights not calculating correctly, we were using `childNodes` which was also grabbing text nodes, whereas we want just html elements. The [React version](https://github.com/Shopify/polaris-react/blob/master/src/components/DataTable/DataTable.tsx#L281) gets away with using `childNodes` because they use `row.childNodes as NodeListOf<HTMLElement>` so I'm guessing this is a TS thing where it will only grab elements and filter out the text nodes.