### PR TITLE
Add action groups to page component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ember-polaris Changelog
 
+### Unpublished
+- [#247](https://github.com/smile-io/ember-polaris/pull/247) [ENHANCEMENT] Add `actionGroups` support to `polaris-page`
+
 ### v2.0.0 (October 30, 2018)
 - [#168](https://github.com/smile-io/ember-polaris/pull/168) [INTERNAL] Upgrade to Ember CLI `3.4.2`
 - [#171](https://github.com/smile-io/ember-polaris/pull/171) [UPDATE] Shopify Polaris `v2.11.0`

--- a/addon/components/polaris-page.js
+++ b/addon/components/polaris-page.js
@@ -123,11 +123,18 @@ export default Component.extend({
   /**
    * Collection of page-level groups of secondary actions
    *
+   * Properties:
+   *
+   * @property {String} title Action group title
+   * @property {String} icon Icon to display
+   * @property {Object[]} actions List of actions
+   * @property {String|Component|Object} details Action details
+   * @property {Function} onActionAnyItem Callback when any action takes place
+   *
    * @property actionGroups
    * @public
-   * @type {Array}
+   * @type {Object[]}
    * @default null
-   * TODO: not implemented yet
    */
   actionGroups: null,
 

--- a/addon/components/polaris-page/action.js
+++ b/addon/components/polaris-page/action.js
@@ -61,14 +61,6 @@ export default Component.extend({
   icon: null,
 
   /**
-   * @property onAction
-   * @type {Function}
-   * @default noop
-   * @public
-   */
-  onAction() {},
-
-  /**
    * @property accessibilityLabel
    * @type {String}
    * @default null
@@ -99,6 +91,14 @@ export default Component.extend({
    * @public
    */
   hasIndicator: false,
+
+  /**
+   * @property onAction
+   * @type {Function}
+   * @default noop
+   * @public
+   */
+  onAction() {},
 
   type: 'button',
 

--- a/addon/components/polaris-page/action.js
+++ b/addon/components/polaris-page/action.js
@@ -8,11 +8,7 @@ import mapEventToAction from '../../utils/map-event-to-action';
 export default Component.extend({
   tagName: 'button',
 
-  attributeBindings: [
-    'type',
-    'disabled',
-    'accessibilityLabel:aria-label',
-  ],
+  attributeBindings: ['type', 'disabled', 'accessibilityLabel:aria-label'],
 
   classNames: ['Polaris-Page__Action'],
   classNameBindings: [
@@ -80,7 +76,7 @@ export default Component.extend({
    */
   accessibilityLabel: null,
 
-   /**
+  /**
    * @property disabled
    * @type {Boolean}
    * @default false

--- a/addon/components/polaris-page/action.js
+++ b/addon/components/polaris-page/action.js
@@ -1,4 +1,6 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { isBlank } from '@ember/utils';
 import layout from '../../templates/components/polaris-page/action';
 import { handleMouseUpByBlurring } from '../../utils/focus';
 import mapEventToAction from '../../utils/map-event-to-action';
@@ -8,39 +10,106 @@ export default Component.extend({
 
   attributeBindings: [
     'type',
-    'action.disabled:disabled',
-    'action.accessibilityLabel:aria-label',
+    'disabled',
+    'accessibilityLabel:aria-label',
   ],
 
   classNames: ['Polaris-Page__Action'],
-
-  classNameBindings: ['action.disabled:Polaris-Page--disabled'],
+  classNameBindings: [
+    'disabled:Polaris-Page--disabled',
+    'isIconOnly:Polaris-Page--iconOnly',
+  ],
 
   layout,
 
   /**
-   * The action to render. The following properties can be set:
-   *  - text
-   *  - icon
-   *  - accessibilityLabel
-   *  - disabled
-   *  - onAction
-   *
-   * These properties are available in the React component
-   * but are not yet implemented in `ember-polaris`:
-   *  - url
-   *  - external
-   *  - disclosure
-   *
-   * @property action
-   * @public
-   * @type {Object}
+   * @property text
+   * @type {String}
    * @default null
+   * @public
    */
-  action: null,
+  text: null,
+
+  /**
+   * @property disclosure
+   * @type {Boolean}
+   * @default false
+   * @public
+   */
+  disclosure: false,
+
+  /**
+   * @property url
+   * @type {String}
+   * @default null
+   * @public
+   * TODO: not implemented
+   */
+  url: null,
+
+  /**
+   * @property external
+   * @type {Boolean}
+   * @default false
+   * @public
+   * TODO: not implemented
+   */
+  external: false,
+
+  /**
+   * @property icon
+   * @type {String}
+   * @default null
+   * @public
+   */
+  icon: null,
+
+  /**
+   * @property onAction
+   * @type {Function}
+   * @default noop
+   * @public
+   */
+  onAction() {},
+
+  /**
+   * @property accessibilityLabel
+   * @type {String}
+   * @default null
+   * @public
+   */
+  accessibilityLabel: null,
+
+   /**
+   * @property disabled
+   * @type {Boolean}
+   * @default false
+   * @public
+   */
+  disabled: false,
+
+  /**
+   * @property showIndicator
+   * @type {Boolean}
+   * @default false
+   * @public
+   */
+  showIndicator: false,
+
+  /**
+   * @property hasIndicator
+   * @type {Boolean}
+   * @default false
+   * @public
+   */
+  hasIndicator: false,
 
   type: 'button',
 
   mouseUp: handleMouseUpByBlurring,
-  click: mapEventToAction('action.onAction'),
+  click: mapEventToAction('onAction'),
+
+  isIconOnly: computed('text', 'icon', function() {
+    return this.get('icon') && isBlank(this.get('text'));
+  }).readOnly(),
 });

--- a/addon/components/polaris-page/header.js
+++ b/addon/components/polaris-page/header.js
@@ -40,7 +40,7 @@ export default Component.extend({
    *
    * @property titleHidden
    * @public
-   * @type {boolean}
+   * @type {Boolean}
    * @default false
    */
   titleHidden: false,
@@ -71,10 +71,20 @@ export default Component.extend({
    *
    * @property separator
    * @public
-   * @type {boolean}
+   * @type {Boolean}
    * @default false
    */
   separator: false,
+
+  /**
+   * Primary page-level action
+   *
+   * @property primaryAction
+   * @public
+   * @type {Object}
+   * @default null
+   */
+  primaryAction: null,
 
   /**
    * Collection of secondary page-level actions
@@ -87,14 +97,14 @@ export default Component.extend({
   secondaryActions: null,
 
   /**
-   * Primary page-level action
+   * Collection of page-level groups of secondary actions
    *
-   * @property primaryAction
+   * @property actionGroups
    * @public
-   * @type {Object}
+   * @type {Array}
    * @default null
    */
-  primaryAction: null,
+  actionGroups: null,
 
   /**
    * Page-level pagination
@@ -114,7 +124,7 @@ export default Component.extend({
   hasNavigation: or('hasBreadcrumbs', 'pagination').readOnly(),
   hasActions: or('primaryAction', 'secondaryActions').readOnly(),
   hasSecondaryActions: gt('secondaryActions.length', 0).readOnly(),
-  hasRollup: gt('secondaryActions.length', 1).readOnly(),
+  hasActionGroups: gt('actionGroups.length', 0).readOnly(),
 
   shouldRenderPrimaryActionAsPrimary: computed(
     'primaryAction.primary',
@@ -127,4 +137,18 @@ export default Component.extend({
       );
     }
   ).readOnly(),
+
+  hasRollup: computed('secondaryActions.length', 'actionGroups.length', function() {
+    let secondaryActions = this.get('secondaryActions') || [];
+    let actionGroups = this.get('actionGroups') || [];
+
+    return secondaryActions.length + actionGroups.length > 1;
+  }).readOnly(),
+
+  actionGroupsAsActionListSections: computed('actionGroups.[]', function() {
+    let actionGroups = this.get('actionGroups') || [];
+    return actionGroups.map(({ title, actions }) => {
+      return { title, items: actions };
+    });
+  }).readOnly(),
 });

--- a/addon/components/polaris-page/header.js
+++ b/addon/components/polaris-page/header.js
@@ -138,12 +138,16 @@ export default Component.extend({
     }
   ).readOnly(),
 
-  hasRollup: computed('secondaryActions.length', 'actionGroups.length', function() {
-    let secondaryActions = this.get('secondaryActions') || [];
-    let actionGroups = this.get('actionGroups') || [];
+  hasRollup: computed(
+    'secondaryActions.length',
+    'actionGroups.length',
+    function() {
+      let secondaryActions = this.get('secondaryActions') || [];
+      let actionGroups = this.get('actionGroups') || [];
 
-    return secondaryActions.length + actionGroups.length > 1;
-  }).readOnly(),
+      return secondaryActions.length + actionGroups.length > 1;
+    }
+  ).readOnly(),
 
   actionGroupsAsActionListSections: computed('actionGroups.[]', function() {
     let actionGroups = this.get('actionGroups') || [];

--- a/addon/templates/components/polaris-page.hbs
+++ b/addon/templates/components/polaris-page.hbs
@@ -7,6 +7,7 @@
     breadcrumbs=breadcrumbs
     separator=separator
     secondaryActions=secondaryActions
+    actionGroups=actionGroups
     primaryAction=primaryAction
     pagination=pagination
   }}

--- a/addon/templates/components/polaris-page/action.hbs
+++ b/addon/templates/components/polaris-page/action.hbs
@@ -1,12 +1,16 @@
-{{!-- TODO: support action.url --}}
-{{#if action.icon}}
+{{!-- TODO: support url --}}
+{{#if (or icon disclosure)}}
   <span class="Polaris-Page__ActionContent">
-    {{polaris-page/action-icon icon=action.icon}}
+    {{#if icon}}
+      {{polaris-page/action-icon icon=icon}}
+    {{/if}}
 
-    <span>
-      {{action.text}}
-    </span>
+    <span>{{text}}</span>
+
+    {{#if disclosure}}
+      {{polaris-page/action-icon icon="caret-down"}}
+    {{/if}}
   </span>
 {{else}}
-  {{action.text}}
+  {{text}}
 {{/if}}

--- a/addon/templates/components/polaris-page/header.hbs
+++ b/addon/templates/components/polaris-page/header.hbs
@@ -53,7 +53,7 @@
           </div>
         {{/if}}
 
-        {{#if hasSecondaryActions}}
+        {{#if (or hasSecondaryActions hasActionGroups)}}
           <div class="Polaris-Page__SecondaryActions">
             {{#if hasRollup}}
               <div class="Polaris-Page__Rollup">
@@ -68,6 +68,7 @@
                   {{#popover.content}}
                     {{polaris-action-list
                       items=secondaryActions
+                      sections=actionGroupsAsActionListSections
                       onActionAnyItem=(action popover.close)
                     }}
                   {{/popover.content}}
@@ -77,10 +78,51 @@
 
             <div class="Polaris-Page__IndividualActions">
               {{#each secondaryActions as |secondaryAction|}}
-                {{polaris-page/action action=secondaryAction}}
+                {{polaris-page/action
+                  text=secondaryAction.text
+                  disclosure=secondaryAction.disclosure
+                  url=secondaryAction.url
+                  external=secondaryAction.external
+                  icon=secondaryAction.icon
+                  accessibilityLabel=secondaryAction.accessibilityLabel
+                  disabled=secondaryAction.disabled
+                  showIndicator=secondaryAction.showIndicator
+                  hasIndicator=secondaryAction.hasIndicator
+                  onAction=(action secondaryAction.onAction)
+                }}
               {{/each}}
 
-              {{!-- TODO: implement action groups here. --}}
+              {{#if actionGroups}}
+                {{#each actionGroups as |actionGroup|}}
+                  <div class="Polaris-Page__ActionGroup">
+                    {{#polaris-popover as |popover|}}
+                      {{#popover.activator}}
+                        {{polaris-page/action
+                          disclosure=true
+                          icon=actionGroup.icon
+                          text=actionGroup.title
+                        }}
+                      {{/popover.activator}}
+
+                      {{#popover.content}}
+                        {{polaris-action-list
+                          items=actionGroup.actions
+                          onActionAnyItem=(action popover.close)
+                        }}
+
+                        {{#if actionGroup.details}}
+                          <div class="
+                            Polaris-Page__Details
+                            {{if actionGroup.actions "Polaris-Page--withActions"}}
+                          ">
+                            {{render-content actionGroup.details}}
+                          </div>
+                        {{/if}}
+                      {{/popover.content}}
+                    {{/polaris-popover}}
+                  </div>
+                {{/each}}
+              {{/if}}
             </div>
           </div>
         {{/if}}

--- a/docs/page.md
+++ b/docs/page.md
@@ -3,7 +3,7 @@
 ## Page
 `polaris-page` implements the [Polaris Page component](https://polaris.shopify.com/components/structure/page).
 
-**NOTE:** _the `icon`, `actionGroups` and `pagination` properties are currently unimplemented._
+**NOTE:** _the `icon` and `pagination` properties are currently unimplemented._
 
 ### Examples
 
@@ -17,7 +17,7 @@ Basic usage:
 {{/polaris-page}}
 ```
 
-Full-width page with disableable primary action and secondary actions (using [ember-array-helper](https://github.com/kellyselden/ember-array-helper)):
+Full-width page with disableable primary action, secondary actions and action groups (using [ember-array-helper](https://github.com/kellyselden/ember-array-helper)):
 
 ```hbs
 {{polaris-page
@@ -36,6 +36,26 @@ Full-width page with disableable primary action and secondary actions (using [em
     (hash
       text="Do something else"
       onAction=(action (mut secondaryAction2Fired) true)
+    )
+  )
+  actionGroups=(array
+    (hash
+      title="Action group with details"
+      actions=(array
+        (hash
+          text="Group action 1.1"
+          onAction=(action (mut group1Button1Clicked) true)
+        )
+        (hash
+          text="Group action 1.2"
+          onAction=(action (mut group1Button2Clicked) true)
+        )
+      )
+      details=(component
+        "polaris-text-style"
+        variation="positive"
+        text="This is an action group with details"
+      )
     )
   )
 }}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -20,6 +20,39 @@
       onAction=(action (mut secondary2Clicked) true)
     )
   )
+  actionGroups=(array
+    (hash
+      title="Action group with details"
+      actions=(array
+        (hash
+          text="Group action 1.1"
+          onAction=(action (mut group1Button1Clicked) true)
+        )
+        (hash
+          text="Group action 1.2"
+          onAction=(action (mut group1Button2Clicked) true)
+        )
+      )
+      details=(component
+        "polaris-text-style"
+        variation="positive"
+        text="This is an action group with details"
+      )
+    )
+    (hash
+      title="Action group with actions"
+      actions=(array
+        (hash
+          text="Group action 2.1"
+          onAction=(action (mut group2Button1Clicked) true)
+        )
+        (hash
+          text="Group action 2.2"
+          onAction=(action (mut group2Button2Clicked) true)
+        )
+      )
+    )
+  )
 }}
 
   {{#polaris-list as |list|}}

--- a/tests/integration/components/polaris-page-test.js
+++ b/tests/integration/components/polaris-page-test.js
@@ -361,8 +361,7 @@ module('Integration | Component | polaris page', function(hooks) {
       'button.Polaris-Page__Action',
       'span.Polaris-Page__ActionContent'
     );
-    const secondaryActions = findAll(secondaryActionsSelector);
-    assert.equal(secondaryActions.length, 2, 'renders two secondary actions');
+    assert.dom(secondaryActionsSelector).exists({ count: 2 });
 
     const secondaryActionIconSelector = buildNestedSelector(
       secondaryActionsSelector,
@@ -370,12 +369,10 @@ module('Integration | Component | polaris page', function(hooks) {
       'span.Polaris-Icon',
       'svg'
     );
+    assert.dom(secondaryActionIconSelector).exists({ count: 2 });
+
+    // TODO: target these using selectors so we can use qunit-dom assertions here.
     const secondaryActionIcons = findAll(secondaryActionIconSelector);
-    assert.equal(
-      secondaryActionIcons.length,
-      2,
-      'renders two secondary action icons'
-    );
     assert.equal(
       secondaryActionIcons[0].dataset.iconSource,
       'polaris/add',

--- a/tests/integration/components/polaris-page-test.js
+++ b/tests/integration/components/polaris-page-test.js
@@ -341,10 +341,12 @@ module('Integration | Component | polaris page', function(hooks) {
           (hash
             text="First secondary action"
             icon="add"
+            onAction=(action (mut dummy))
           )
           (hash
             text="Second secondary action"
             icon="cancel"
+            onAction=(action (mut dummy))
           )
         )
       }}


### PR DESCRIPTION
Pulls the functionality added in [v1.7.9](https://github.com/smile-io/ember-polaris/releases/tag/v1.7.9) into v2.

Screen grab (minus SVG icons 😬) showing the new functionality:
![image](https://user-images.githubusercontent.com/5737342/48001546-8eb94400-e111-11e8-9928-6319d2f4c822.png)
