### PR TITLE
Make allowRange on polaris-date-picker writeable

### DIFF
--- a/addon/components/polaris-date-picker.js
+++ b/addon/components/polaris-date-picker.js
@@ -82,6 +82,19 @@ export default Component.extend({
   multiMonth: false,
 
   /**
+   * Allow a range of dates to be selected
+   *
+   * @property allowRange
+   * @public
+   * @type {Boolean}
+   */
+  allowRange: computed('selected', function() {
+    let selected = this.get('selected');
+
+    return selected !== null && !(selected instanceof Date);
+  }),
+
+  /**
    * Callback when date is selected
    *
    * @property title
@@ -104,12 +117,6 @@ export default Component.extend({
   hoverDate: null,
 
   focusDate: null,
-
-  allowRange: computed('selected', function() {
-    let selected = this.get('selected');
-
-    return selected !== null && !(selected instanceof Date);
-  }).readOnly(),
 
   showNextYear: computed('month', 'year', function() {
     let { month, year } = this.getProperties('month', 'year');


### PR DESCRIPTION
The React implementation of `DatePicker` has `allowRange` as a [public prop](https://github.com/Shopify/polaris-react/blob/master/src/components/DatePicker/DatePicker.tsx#L36). We need to make it writeable so that we can enforce selecting single dates.