### PR TITLE
Handle null appliedFilters in resource list filter control

### DIFF
--- a/addon/components/polaris-resource-list/filter-control.js
+++ b/addon/components/polaris-resource-list/filter-control.js
@@ -135,10 +135,11 @@ export default Component.extend(context.ConsumerMixin, {
   }).readOnly(),
 
   handleAddFilter(newFilter) {
-    let { onFiltersChange, appliedFilters = [] } = this.getProperties(
+    let { onFiltersChange, appliedFilters } = this.getProperties(
       'onFiltersChange',
       'appliedFilters'
     );
+    appliedFilters = appliedFilters || [];
 
     if (!onFiltersChange) {
       return;
@@ -159,10 +160,11 @@ export default Component.extend(context.ConsumerMixin, {
 
   handleRemoveFilter(filter) {
     let filterId = idFromFilter(filter);
-    let { onFiltersChange, appliedFilters = [] } = this.getProperties(
+    let { onFiltersChange, appliedFilters } = this.getProperties(
       'onFiltersChange',
       'appliedFilters'
     );
+    appliedFilters = appliedFilters || [];
 
     if (!onFiltersChange) {
       return;

--- a/tests/integration/components/polaris-resource-list/filter-control/filter-value-selector-test.js
+++ b/tests/integration/components/polaris-resource-list/filter-control/filter-value-selector-test.js
@@ -70,9 +70,13 @@ function getOptionsListForOperators(operators) {
   });
 }
 
-async function triggerChangeEventWithValue(selector, value) {
+async function triggerChangeEventWithValue(
+  selector,
+  value,
+  eventName = 'change'
+) {
   find(selector).value = value;
-  await triggerEvent(selector, 'change');
+  await triggerEvent(selector, eventName);
 }
 
 module(
@@ -297,7 +301,7 @@ module(
               }}
             `);
 
-            await triggerEvent('.Polaris-TextField input', 'change');
+            await triggerEvent('.Polaris-TextField input', 'input');
             assert.ok(this.get('wasOnChangeCalled'));
           });
 
@@ -333,7 +337,8 @@ module(
 
             await triggerChangeEventWithValue(
               '.Polaris-TextField input',
-              newFilterValue
+              newFilterValue,
+              'input'
             );
 
             await triggerChangeEventWithValue(

--- a/tests/integration/components/polaris-text-field-test.js
+++ b/tests/integration/components/polaris-text-field-test.js
@@ -138,7 +138,7 @@ module('Integration | Component | polaris-text-field', function(hooks) {
       }}
     `);
 
-    await triggerEvent(inputSelector, 'change', 'text');
+    await triggerEvent(inputSelector, 'input', 'text');
     await focus(inputSelector);
     await blur(inputSelector);
 


### PR DESCRIPTION
Turns out the default value notation I'd used in the resource list filter control when handling `appliedFilters` doesn't work as I'd expected it to, leading to null ref errors when adding/removing filters 🤦‍♂️ This PR fixes that by using some less fancy notation which actually gets the job done 🙏 