### PR TITLE
Add `fullWidth` support to `polaris-popover`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ember-polaris Changelog
 
+### UNRELEASED
+- [#272](https://github.com/smile-io/ember-polaris/pull/272) [ENHANCEMENT] Add `fullWidth` support to `polaris-popover`
+
 ### v3.0.3 (January 14, 2019)
 - [#271](https://github.com/smile-io/ember-polaris/pull/271) [FIX] Fix dismissable banner class
 

--- a/addon/components/polaris-popover.js
+++ b/addon/components/polaris-popover.js
@@ -90,6 +90,16 @@ export default Component.extend({
   sectioned: false,
 
   /**
+   * Allow popover to stretch to the full width of its activator
+   *
+   * @property fullWidth
+   * @type {Boolean}
+   * @default false
+   * @public
+   */
+  fullWidth: false,
+
+  /**
    * Allow popover to stretch to fit content vertically
    *
    * @property fullHeight

--- a/addon/components/polaris-popover/content.js
+++ b/addon/components/polaris-popover/content.js
@@ -20,6 +20,16 @@ export default Component.extend({
   sectioned: false,
 
   /**
+   * Allow popover to stretch to the full width of its activator
+   *
+   * @property fullWidth
+   * @type {Boolean}
+   * @default false
+   * @public
+   */
+  fullWidth: false,
+
+  /**
    * Allow popover to stretch to fit content vertically
    *
    * @property fullHeight

--- a/addon/templates/components/polaris-popover.hbs
+++ b/addon/templates/components/polaris-popover.hbs
@@ -11,6 +11,7 @@
         contentComponent=dd.content
         uniqueId=dd.uniqueId
         sectioned=sectioned
+        fullWidth=fullWidth
         fullHeight=fullHeight
       )
       open=(action dd.actions.open)

--- a/addon/templates/components/polaris-popover/content.hbs
+++ b/addon/templates/components/polaris-popover/content.hbs
@@ -1,6 +1,12 @@
 {{#if contentComponent}}
   {{#component contentComponent class="Polaris-PositionedOverlay"}}
-    <div class="Polaris-Popover" data-polaris-overlay="true">
+    <div
+      data-polaris-overlay="true"
+      class="
+        Polaris-Popover
+        {{if fullWidth "Polaris-Popover--fullWidth"}}
+      "
+    >
       <div class="Polaris-Popover__Tip"></div>
       <div class="Polaris-Popover__FocusTracker" tabindex="0"></div>
       <div class="Polaris-Popover__Wrapper">


### PR DESCRIPTION
`polaris-popover` really needs to be rebuilt from scratch as a direct port of the React implementation, but until then this is a quick implementation of the `fullWidth` property.