### PR TITLE
Add support for using a block for render-content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ember-polaris Changelog
 
+### Unreleased
+- [#274](https://github.com/smile-io/ember-polaris/pull/274) [ENHANCEMENT] Add support for using a block for `render-content`
+
 ### v3.0.5 (January 28, 2019)
 - [#273](https://github.com/smile-io/ember-polaris/pull/273) [FEATURE] Add `polaris-option-list` component
 

--- a/addon/templates/components/render-content.hbs
+++ b/addon/templates/components/render-content.hbs
@@ -3,5 +3,9 @@
 {{else if contentIsComponentDefinition}}
   {{component content}}
 {{else}}
-  {{content}}
+  {{#if hasBlock}}
+    {{yield}}
+  {{else}}
+    {{content}}
+  {{/if}}
 {{/if}}

--- a/tests/integration/components/render-content-test.js
+++ b/tests/integration/components/render-content-test.js
@@ -3,7 +3,6 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { find } from 'ember-native-dom-helpers';
 
 module('Integration | Component | render-content', function(hooks) {
   setupRenderingTest(hooks);
@@ -13,20 +12,28 @@ module('Integration | Component | render-content', function(hooks) {
     this.owner.register(
       'component:my-component',
       Component.extend({
-        classNames: ['my-test-component'],
         layout: hbs`{{text}}`,
+        'data-test-my-component': true,
       })
     );
   });
 
   test('it renders correctly when content is a string', async function(assert) {
     await render(hbs`
-      <div id="render-content-test">
+      <div data-test-render-content>
         {{render-content "blah"}}
       </div>
     `);
 
-    assert.equal(find('#render-content-test').textContent.trim(), 'blah');
+    assert.dom('[data-test-render-content]').hasText('blah');
+
+    await render(hbs`
+      {{#render-content "blah"}}
+        {{my-component text="neat!"}}
+      {{/render-content}}
+    `);
+
+    assert.dom('[data-test-my-component]').hasText('neat!');
   });
 
   test('it renders correctly when content is a hash of component name and props', async function(assert) {
@@ -41,10 +48,7 @@ module('Integration | Component | render-content', function(hooks) {
       }}
     `);
 
-    assert.equal(
-      find('.my-test-component').textContent.trim(),
-      'component content here'
-    );
+    assert.dom('[data-test-my-component]').hasText('component content here');
   });
 
   test('it renders correctly when content is a component definition', async function(assert) {
@@ -52,9 +56,6 @@ module('Integration | Component | render-content', function(hooks) {
       {{render-content (component "my-component" text="component content here")}}
     `);
 
-    assert.equal(
-      find('.my-test-component').textContent.trim(),
-      'component content here'
-    );
+    assert.dom('[data-test-my-component]').hasText('component content here');
   });
 });


### PR DESCRIPTION
### Overview

This enhances our internal `render-content` allowing us to default to using a specific component when the content is a string.

#### Example
`my-component`
```js
// String | Component
title: 'Some default'
```

```hbs
...
{{#render-content title}}
  {{!-- render the title as sub-heading, by default --}}
  {{polaris-subheading text=title}}
{{/render-content}}
```