### PR TITLE
Prevent glimmer error when changing selected filter on resource list filter creator

### DIFF
--- a/addon/templates/components/polaris-resource-list/filter-control/filter-creator.hbs
+++ b/addon/templates/components/polaris-resource-list/filter-control/filter-creator.hbs
@@ -18,7 +18,7 @@
 
   {{#popover.content}}
     {{#polaris-form onSubmit=(action handleAddFilter popover)}}
-      {{#polaris-form-layout}}
+      {{#polaris-form-layout as |formLayout|}}
         {{polaris-select
           placeholder="Select a filter..."
           label=selectLabel
@@ -28,20 +28,24 @@
         }}
 
         {{#if selectedFilter}}
-          {{polaris-resource-list/filter-control/filter-value-selector
-            filter=selectedFilter
-            filterKey=selectedFilterKey
-            value=selectedFilterValue
-            onFilterKeyChange=(action handleFilterKeyChange)
-            onChange=(action (mut selectedFilterValue))
-          }}
+          {{#formLayout.item}}
+            {{polaris-resource-list/filter-control/filter-value-selector
+              filter=selectedFilter
+              filterKey=selectedFilterKey
+              value=selectedFilterValue
+              onFilterKeyChange=(action handleFilterKeyChange)
+              onChange=(action (mut selectedFilterValue))
+            }}
+          {{/formLayout.item}}
 
-          {{polaris-button
-            dataTestId="add-filter"
-            text="Add filter"
-            disabled=(not canAddFilter)
-            onClick=(action handleAddFilter popover)
-          }}
+          {{#formLayout.item}}
+            {{polaris-button
+              dataTestId="add-filter"
+              text="Add filter"
+              disabled=(not canAddFilter)
+              onClick=(action handleAddFilter popover)
+            }}
+          {{/formLayout.item}}
         {{/if}}
       {{/polaris-form-layout}}
     {{/polaris-form}}


### PR DESCRIPTION
Fixes #275 by ensuring that conditionally-rendered children for `polaris-form-layout` on `polaris-resource-list/filter-creator` are wrapped in `polaris-form-layout/item` instances as per https://github.com/smile-io/ember-polaris/pull/159.