### PR TITLE
Pass action properties through to callout card buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # ember-polaris Changelog
 
+### Unreleased
+- [#288](https://github.com/smile-io/ember-polaris/pull/288) [ENHANCEMENT] Add support for props such as `primary` etc. on `polaris-callout-card` actions
+
 ### v3.0.6 (January 31, 2019)
-- [#276](https://github.com/smile-io/ember-polaris/pull/276) [Fix] Prevent glimmer error when changing selected filter on resource list filter creator
+- [#276](https://github.com/smile-io/ember-polaris/pull/276) [FIX] Prevent glimmer error when changing selected filter on resource list filter creator
 
 ### v3.0.5 (January 28, 2019)
 - [#273](https://github.com/smile-io/ember-polaris/pull/273) [FEATURE] Add `polaris-option-list` component

--- a/addon/templates/components/polaris-callout-card.hbs
+++ b/addon/templates/components/polaris-callout-card.hbs
@@ -19,6 +19,12 @@
         {{#with
           (component "polaris-button"
             text=primaryAction.text
+            accessibilityLabel=primaryAction.accessibilityLabel
+            disabled=primaryAction.disabled
+            primary=primaryAction.primary
+            destructive=primaryAction.destructive
+            icon=primaryAction.icon
+            loading=primaryAction.loading
             onClick=(action primaryAction.onAction)
           )
           as |primaryButton|
@@ -30,6 +36,10 @@
               {{polaris-button
                 plain=true
                 text=secondaryAction.text
+                accessibilityLabel=secondaryAction.accessibilityLabel
+                disabled=secondaryAction.disabled
+                icon=secondaryAction.icon
+                loading=secondaryAction.loading
                 onClick=(action secondaryAction.onAction)
               }}
             {{/polaris-button-group}}


### PR DESCRIPTION
Adds support for props such as `primary` etc. on `polaris-callout-card` actions