### PR TITLE
Add "destructive" support to page primary action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # ember-polaris Changelog
 
+### Unreleased
+- [#278](https://github.com/smile-io/ember-polaris/pull/278) [ENHANCEMENT] Add support for `destructive` property on `polaris-page`'s `primaryAction`
+
 ### v3.0.7 (February 18, 2019)
-- [#288](https://github.com/smile-io/ember-polaris/pull/288) [ENHANCEMENT] Add support for props such as `primary` etc. on `polaris-callout-card` actions
+- [#277](https://github.com/smile-io/ember-polaris/pull/277) [ENHANCEMENT] Add support for props such as `primary` etc. on `polaris-callout-card` actions
 
 ### v3.0.6 (January 31, 2019)
 - [#276](https://github.com/smile-io/ember-polaris/pull/276) [FIX] Prevent glimmer error when changing selected filter on resource list filter creator

--- a/addon/templates/components/polaris-page/header.hbs
+++ b/addon/templates/components/polaris-page/header.hbs
@@ -26,6 +26,7 @@
         text=primaryAction.text
         disabled=primaryAction.disabled
         loading=primaryAction.loading
+        destructive=primaryAction.destructive
       )
       (component "wrapper-element" tagName="")
     )


### PR DESCRIPTION
`polaris-page`'s `primaryAction` should support the `destructive` flag as the React implementation does, but until this point it didn't 🤷‍♂️ 