### PR TITLE
Allow passing a component as polaris-choice-list's helpText property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ember-polaris Changelog
 
+### Unpublished
+- [#280](https://github.com/smile-io/ember-polaris/pull/280) [ENHANCEMENT] Allow passing a component as `polaris-choice`'s `helpText` property
+
 ### v3.0.9 (February 22, 2019)
 - [#279](https://github.com/smile-io/ember-polaris/pull/279) [FIX] Ensure `polaris-choice-list` updates properly when the `selected` array is swapped out
 

--- a/addon/components/polaris-choice.js
+++ b/addon/components/polaris-choice.js
@@ -79,7 +79,7 @@ export default Component.extend({
    * Help text for this choice
    *
    * @property helpText
-   * @type {String}
+   * @type {String|Component|Object}
    * @default: null
    * @public
    */

--- a/addon/templates/components/polaris-choice.hbs
+++ b/addon/templates/components/polaris-choice.hbs
@@ -26,7 +26,7 @@
 
         {{#if helpText}}
           <div data-test-choice-help-text class="Polaris-Choice__HelpText" id={{helpTextId}}>
-            {{helpText}}
+            {{render-content helpText}}
           </div>
         {{/if}}
       </div>

--- a/tests/integration/components/polaris-choice-test.js
+++ b/tests/integration/components/polaris-choice-test.js
@@ -466,3 +466,14 @@ test('it handles the disabled attribute correctly', function(assert) {
 
   assert.dom(labelSelector).hasNoClass(disabledClass);
 });
+
+test('it allows passing a component as the helpText property', function(assert) {
+  this.render(hbs`
+    {{polaris-choice
+      inputId="help-text-component-test"
+      helpText=(component "polaris-icon" source="circle-check-mark")
+    }}
+  `);
+
+  assert.dom('[data-test-icon]').exists({ count: 1 });
+});


### PR DESCRIPTION
This is supported by the React implementation, so we should probably support it too 😉 