### PR TITLE
Handle non-numeric progress values in progress bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ember-polaris Changelog
 
+### Unpublished
+- [#281](https://github.com/smile-io/ember-polaris/pull/281) [ENHANCEMENT] Handle non-numeric/non-finite `progress` values in `polaris-progress-bar`
+
 ### v3.0.10 (February 22, 2019)
 - [#280](https://github.com/smile-io/ember-polaris/pull/280) [ENHANCEMENT] Allow passing a component as `polaris-choice`'s `helpText` property
 

--- a/addon/components/polaris-progress-bar.js
+++ b/addon/components/polaris-progress-bar.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { classify, htmlSafe } from '@ember/string';
+import { isPresent } from '@ember/utils';
 import layout from '../templates/components/polaris-progress-bar';
 
 const allowedSizes = ['small', 'medium', 'large'];
@@ -59,6 +60,10 @@ export default Component.extend({
     let progress = this.get('progress');
     let parsedProgress;
 
+    if (typeof progress !== 'number') {
+      return null;
+    }
+
     if (progress < 0) {
       parsedProgress = 0;
     } else if (progress > 100) {
@@ -74,6 +79,11 @@ export default Component.extend({
    * @private
    */
   progressStyle: computed('parsedProgress', function() {
-    return htmlSafe(`width: ${this.get('parsedProgress')}%;`);
+    let parsedProgress = this.get('parsedProgress');
+    if (isPresent(parsedProgress)) {
+      return htmlSafe(`width: ${parsedProgress}%;`);
+    }
+
+    return null;
   }).readOnly(),
 });

--- a/tests/integration/components/polaris-progress-bar-test.js
+++ b/tests/integration/components/polaris-progress-bar-test.js
@@ -130,7 +130,7 @@ module('Integration | Component | polaris progress bar', function(hooks) {
       );
   });
 
-  test('it correctly handles out-of-bounds progress numbers', async function(assert) {
+  test('it correctly handles out-of-bounds progress values', async function(assert) {
     this.set('progress', -23);
     await render(hbs`{{polaris-progress-bar progress=progress}}`);
 
@@ -142,6 +142,15 @@ module('Integration | Component | polaris progress bar', function(hooks) {
         'sets the progress element to 0 when the progress is negative'
       );
 
+    this.set('progress', -Infinity);
+    assert
+      .dom(barProgressSelector)
+      .hasAttribute(
+        'value',
+        '0',
+        'sets the progress element to 0 when the progress is negative infinity'
+      );
+
     this.set('progress', 145);
     assert
       .dom(barProgressSelector)
@@ -149,6 +158,39 @@ module('Integration | Component | polaris progress bar', function(hooks) {
         'value',
         '100',
         'sets the progress element to 100 when the progress is greater than 100'
+      );
+
+    this.set('progress', Infinity);
+    assert
+      .dom(barProgressSelector)
+      .hasAttribute(
+        'value',
+        '100',
+        'sets the progress element to 100 when the progress is infinite'
+      );
+
+    this.set('progress', null);
+    assert
+      .dom(barProgressSelector)
+      .doesNotHaveAttribute(
+        'value',
+        'does not set the progress element value when progress is null'
+      );
+
+    this.set('progress', 'a string');
+    assert
+      .dom(barProgressSelector)
+      .doesNotHaveAttribute(
+        'value',
+        'does not set the progress element value when progress is a string'
+      );
+
+    this.set('progress', undefined);
+    assert
+      .dom(barProgressSelector)
+      .doesNotHaveAttribute(
+        'value',
+        'does not set the progress element value when progress is undefined'
       );
   });
 });


### PR DESCRIPTION
Because the React Polaris components use TypeScript, their `ProgressBar` component handles non-numeric values quite cleanly. Our implementation unfortunately did not, so in this PR I've updated its behaviour to match the Shopify version's:

- non-numeric `progress` values result in the bar being rendered without a `value` attribute, making it appear empty;
- Values of +/-infinity are now clamped to 100 and 0 internally respectively.