### PR TITLE
Allow passing component for annotated layout section's description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ember-polaris Changelog
 
+### Unpublished
+- [#282](https://github.com/smile-io/ember-polaris/pull/282) [ENHANCEMENT] Allow passing component for annotated layout section's description
+
 ### v3.0.11 (February 22, 2019)
 - [#281](https://github.com/smile-io/ember-polaris/pull/281) [ENHANCEMENT] Handle non-numeric/non-finite `progress` values in `polaris-progress-bar`
 

--- a/addon/components/polaris-layout/annotated-section.js
+++ b/addon/components/polaris-layout/annotated-section.js
@@ -10,7 +10,7 @@ export default Component.extend({
    * Title for the section
    *
    * @property title
-   * @type {string}
+   * @type {String}
    * @default: null
    * @public
    */
@@ -20,7 +20,7 @@ export default Component.extend({
    * Description for the section
    *
    * @property description
-   * @type {string}
+   * @type {String|Component|Object}
    * @default: null
    * @public
    */
@@ -34,7 +34,7 @@ export default Component.extend({
    * instead of `text`
    *
    * @property text
-   * @type {string}
+   * @type {String}
    * @default: null
    * @public
    */

--- a/addon/components/polaris-layout/annotation.js
+++ b/addon/components/polaris-layout/annotation.js
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 import layout from '../../templates/components/polaris-layout/annotation';
 
 export default Component.extend({
@@ -10,8 +11,8 @@ export default Component.extend({
    * Title for the section
    *
    * @property title
-   * @type {string}
-   * @default: null
+   * @type {String}
+   * @default null
    * @public
    */
   title: null,
@@ -20,9 +21,21 @@ export default Component.extend({
    * Description for the section
    *
    * @property description
-   * @type {string}
-   * @default: null
+   * @type {String|Component|Object}
+   * @default null
    * @public
    */
   description: null,
+
+  /**
+   * Whether the `description` is a string
+   *
+   * @property hasStringDescription
+   * @type {Boolean}
+   * @private
+   */
+  hasStringDescription: computed('description', function() {
+    let description = this.get('description');
+    return typeof description === 'string';
+  }).readOnly(),
 });

--- a/addon/templates/components/polaris-layout/annotation.hbs
+++ b/addon/templates/components/polaris-layout/annotation.hbs
@@ -1,14 +1,14 @@
 {{#polaris-text-container}}
   {{polaris-heading text=title}}
 
-  {{#if (or hasBlock description)}}
+  {{#if description}}
     <div data-test-annotation-description class="Polaris-Layout__AnnotationDescription">
-      {{#if hasBlock}}
-        {{yield}}
-      {{else}}
+      {{#if hasStringDescription}}
         <p>
           {{description}}
         </p>
+      {{else if description}}
+        {{render-content description}}
       {{/if}}
     </div>
   {{/if}}

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -45,6 +45,7 @@ Annotated layout:
 
   {{#layout.annotatedSection
     title="Second section"
+    description=(component "my-custom-description-component")
   }}
     <p>Section 2 content here</p>
   {{/layout.annotatedSection}}

--- a/tests/integration/components/polaris-layout-test.js
+++ b/tests/integration/components/polaris-layout-test.js
@@ -449,191 +449,39 @@ test('it renders the correct HTML when text and description string and title are
   );
 });
 
-test('it renders the correct HTML when using annotated sections in block form', function(assert) {
+test('it renders the correct HTML when description component is passed to annotated section', function(assert) {
   this.render(hbs`
     {{#polaris-layout as |layout|}}
-      {{#layout.annotatedSection}}{{/layout.annotatedSection}}
-
-      {{#layout.annotatedSection}}
-        This is an inline annotated section without title or description
-      {{/layout.annotatedSection}}
-
-      {{#layout.annotatedSection
-        title="Inline title"
+      {{layout.annotatedSection
+        description=(component "wrapper-element" data-test-annotation-description-content=true)
       }}
-        This is an inline annotated section with a title but no description
-      {{/layout.annotatedSection}}
-
-      {{#layout.annotatedSection
-        description="Inline description"
-      }}
-        This is an inline annotated section with a description but no title
-      {{/layout.annotatedSection}}
-
-      {{#layout.annotatedSection
-        title="Inline title"
-        description="Inline description"
-      }}
-        This is an inline annotated section with both a title and description
-      {{/layout.annotatedSection}}
     {{/polaris-layout}}
   `);
 
-  const annotationWrappers = findAll(layoutAnnotationWrapperSelector);
-  assert.equal(
-    annotationWrappers.length,
-    5,
-    'renders five annotation wrappers'
+  const descriptionSelector = buildNestedSelector(
+    '[data-test-annotation-description]',
+    '[data-test-annotation-description-content]'
   );
+  assert.dom(descriptionSelector).exists({ count: 1 });
+});
 
-  const textContainerSelector = buildNestedSelector(
-    'div.Polaris-Layout__Annotation',
-    'div.Polaris-TextContainer'
+test('it renders the correct HTML when description hash is passed to annotated section', function(assert) {
+  this.render(hbs`
+    {{#polaris-layout as |layout|}}
+      {{layout.annotatedSection
+        description=(hash
+          componentName="wrapper-element"
+          props=(hash
+            data-test-annotation-description-content=true
+          )
+        )
+      }}
+    {{/polaris-layout}}
+  `);
+
+  const descriptionSelector = buildNestedSelector(
+    '[data-test-annotation-description]',
+    '[data-test-annotation-description-content]'
   );
-  const headerSelector = buildNestedSelector(
-    textContainerSelector,
-    'h2.Polaris-Heading'
-  );
-  const descriptionSelector = '[data-test-annotation-description]';
-  const contentSelector = 'div.Polaris-Layout__AnnotationContent';
-
-  // Check the first annotation.
-  let annotationWrapper = annotationWrappers[0];
-
-  let headers = findAll(headerSelector, annotationWrapper);
-  assert.equal(headers.length, 1, 'first annotation - renders header');
-  assert.equal(
-    headers[0].textContent.trim(),
-    '',
-    'first annotation - renders header correctly'
-  );
-
-  let descriptions = findAll(descriptionSelector, annotationWrapper);
-  assert.equal(
-    descriptions.length,
-    0,
-    'first annotation - renders description paragraph correctly'
-  );
-
-  let contents = findAll(contentSelector, annotationWrapper);
-  assert.equal(contents.length, 1, 'first annotation - renders content');
-  assert.equal(
-    contents[0].textContent.trim(),
-    '',
-    'first annotation - renders correct content'
-  );
-
-  // Check the second annotation.
-  annotationWrapper = annotationWrappers[1];
-
-  headers = findAll(headerSelector, annotationWrapper);
-  assert.equal(headers.length, 1, 'second annotation - renders header');
-  assert.equal(
-    headers[0].textContent.trim(),
-    '',
-    'second annotation - renders header correctly'
-  );
-
-  descriptions = findAll(descriptionSelector, annotationWrapper);
-  assert.equal(
-    descriptions.length,
-    0,
-    'second annotation - renders description paragraph correctly'
-  );
-
-  contents = findAll(contentSelector, annotationWrapper);
-  assert.equal(contents.length, 1, 'second annotation - renders content');
-  assert.equal(
-    contents[0].textContent.trim(),
-    'This is an inline annotated section without title or description',
-    'second annotation - renders correct content'
-  );
-
-  // Check the third annotation.
-  annotationWrapper = annotationWrappers[2];
-
-  headers = findAll(headerSelector, annotationWrapper);
-  assert.equal(headers.length, 1, 'third annotation - renders header');
-  assert.equal(
-    headers[0].textContent.trim(),
-    'Inline title',
-    'third annotation - renders header correctly'
-  );
-
-  descriptions = findAll(descriptionSelector, annotationWrapper);
-  assert.equal(
-    descriptions.length,
-    0,
-    'third annotation - renders description paragraph correctly'
-  );
-
-  contents = findAll(contentSelector, annotationWrapper);
-  assert.equal(contents.length, 1, 'third annotation - renders content');
-  assert.equal(
-    contents[0].textContent.trim(),
-    'This is an inline annotated section with a title but no description',
-    'third annotation - renders correct content'
-  );
-
-  // Check the fourth annotation.
-  annotationWrapper = annotationWrappers[3];
-
-  headers = findAll(headerSelector, annotationWrapper);
-  assert.equal(headers.length, 1, 'fourth annotation - renders header');
-  assert.equal(
-    headers[0].textContent.trim(),
-    '',
-    'fourth annotation - renders header correctly'
-  );
-
-  descriptions = findAll(descriptionSelector, annotationWrapper);
-  assert.equal(
-    descriptions.length,
-    1,
-    'fourth annotation - renders description paragraph'
-  );
-  assert.equal(
-    descriptions[0].textContent.trim(),
-    'Inline description',
-    'fourth annotation - renders header correctly'
-  );
-
-  contents = findAll(contentSelector, annotationWrapper);
-  assert.equal(contents.length, 1, 'fourth annotation - renders content');
-  assert.equal(
-    contents[0].textContent.trim(),
-    'This is an inline annotated section with a description but no title',
-    'fourth annotation - renders correct content'
-  );
-
-  // Check the fifth annotation.
-  annotationWrapper = annotationWrappers[4];
-
-  headers = findAll(headerSelector, annotationWrapper);
-  assert.equal(headers.length, 1, 'fifth annotation - renders header');
-  assert.equal(
-    headers[0].textContent.trim(),
-    'Inline title',
-    'fifth annotation - renders header correctly'
-  );
-
-  descriptions = findAll(descriptionSelector, annotationWrapper);
-  assert.equal(
-    descriptions.length,
-    1,
-    'fifth annotation - renders description paragraph'
-  );
-  assert.equal(
-    descriptions[0].textContent.trim(),
-    'Inline description',
-    'fifth annotation - renders header correctly'
-  );
-
-  contents = findAll(contentSelector, annotationWrapper);
-  assert.equal(contents.length, 1, 'fifth annotation - renders content');
-  assert.equal(
-    contents[0].textContent.trim(),
-    'This is an inline annotated section with both a title and description',
-    'fifth annotation - renders correct content'
-  );
+  assert.dom(descriptionSelector).exists({ count: 1 });
 });

--- a/tests/integration/components/polaris-layout-test.js
+++ b/tests/integration/components/polaris-layout-test.js
@@ -211,39 +211,15 @@ test('it renders the correct HTML when using sections', function(assert) {
   );
 });
 
-test('it renders the correct HTML when using annotated sections in inline form', function(assert) {
+test('it renders the correct HTML when no title, text or description are passed to annotated section', function(assert) {
   this.render(hbs`
     {{#polaris-layout as |layout|}}
       {{layout.annotatedSection}}
-
-      {{layout.annotatedSection
-        text="This is an inline annotated section without title or description"
-      }}
-
-      {{layout.annotatedSection
-        title="Inline title"
-        text="This is an inline annotated section with a title but no description"
-      }}
-
-      {{layout.annotatedSection
-        description="Inline description"
-        text="This is an inline annotated section with a description but no title"
-      }}
-
-      {{layout.annotatedSection
-        title="Inline title"
-        description="Inline description"
-        text="This is an inline annotated section with both a title and description"
-      }}
     {{/polaris-layout}}
   `);
 
   const annotationWrappers = findAll(layoutAnnotationWrapperSelector);
-  assert.equal(
-    annotationWrappers.length,
-    5,
-    'renders five annotation wrappers'
-  );
+  assert.equal(annotationWrappers.length, 1, 'renders one annotation wrapper');
 
   const textContainerSelector = buildNestedSelector(
     'div.Polaris-Layout__Annotation',
@@ -256,15 +232,102 @@ test('it renders the correct HTML when using annotated sections in inline form',
 
   const contentSelector = 'div.Polaris-Layout__AnnotationContent';
 
-  // Check the first annotation.
-  let annotationWrapper = annotationWrappers[0];
-
+  const annotationWrapper = annotationWrappers[0];
   let headers = findAll(headerSelector, annotationWrapper);
-  assert.equal(headers.length, 1, 'first annotation - renders header');
+  assert.equal(headers.length, 1, 'renders header');
+  assert.equal(headers[0].textContent.trim(), '', 'renders header correctly');
+
+  let descriptionSelector = '[data-test-annotation-description]';
+
+  let descriptions = findAll(descriptionSelector, annotationWrapper);
+  assert.equal(
+    descriptions.length,
+    0,
+    'renders description paragraph correctly'
+  );
+
+  let contents = findAll(contentSelector, annotationWrapper);
+  assert.equal(contents.length, 1, 'renders content');
+  assert.equal(contents[0].textContent.trim(), '', 'renders correct content');
+});
+
+test('it renders the correct HTML when a title and no text or description are passed to annotated section', function(assert) {
+  this.render(hbs`
+    {{#polaris-layout as |layout|}}
+      {{layout.annotatedSection
+        text="This is an inline annotated section without title or description"
+      }}
+    {{/polaris-layout}}
+  `);
+
+  const annotationWrappers = findAll(layoutAnnotationWrapperSelector);
+  assert.equal(annotationWrappers.length, 1, 'renders one annotation wrapper');
+
+  const textContainerSelector = buildNestedSelector(
+    'div.Polaris-Layout__Annotation',
+    'div.Polaris-TextContainer'
+  );
+  const headerSelector = buildNestedSelector(
+    textContainerSelector,
+    'h2.Polaris-Heading'
+  );
+
+  const contentSelector = 'div.Polaris-Layout__AnnotationContent';
+
+  const annotationWrapper = annotationWrappers[0];
+  let headers = findAll(headerSelector, annotationWrapper);
+  assert.equal(headers.length, 1, 'renders header');
+  assert.equal(headers[0].textContent.trim(), '', 'renders header correctly');
+
+  let descriptionSelector = '[data-test-annotation-description]';
+
+  let descriptions = findAll(descriptionSelector, annotationWrapper);
+  assert.equal(
+    descriptions.length,
+    0,
+    'renders description paragraph correctly'
+  );
+
+  let contents = findAll(contentSelector, annotationWrapper);
+  assert.equal(contents.length, 1, 'renders content');
+  assert.equal(
+    contents[0].textContent.trim(),
+    'This is an inline annotated section without title or description',
+    'renders correct content'
+  );
+});
+
+test('it renders the correct HTML when a title and text and no description are passed to annotated section', function(assert) {
+  this.render(hbs`
+    {{#polaris-layout as |layout|}}
+      {{layout.annotatedSection
+        title="Inline title"
+        text="This is an inline annotated section with a title but no description"
+      }}
+    {{/polaris-layout}}
+  `);
+
+  const annotationWrappers = findAll(layoutAnnotationWrapperSelector);
+  assert.equal(annotationWrappers.length, 1, 'renders one annotation wrapper');
+
+  const textContainerSelector = buildNestedSelector(
+    'div.Polaris-Layout__Annotation',
+    'div.Polaris-TextContainer'
+  );
+  const headerSelector = buildNestedSelector(
+    textContainerSelector,
+    'h2.Polaris-Heading'
+  );
+
+  const contentSelector = 'div.Polaris-Layout__AnnotationContent';
+
+  const annotationWrapper = annotationWrappers[0];
+  let headers = findAll(headerSelector, annotationWrapper);
+  assert.equal(headers.length, 1, 'renders header');
   assert.equal(
     headers[0].textContent.trim(),
-    '',
-    'first annotation - renders header correctly'
+    'Inline title',
+    'renders header correctly'
   );
 
   let descriptionSelector = '[data-test-annotation-description]';
@@ -273,129 +336,116 @@ test('it renders the correct HTML when using annotated sections in inline form',
   assert.equal(
     descriptions.length,
     0,
-    'first annotation - renders description paragraph correctly'
+    'renders description paragraph correctly'
   );
 
   let contents = findAll(contentSelector, annotationWrapper);
-  assert.equal(contents.length, 1, 'first annotation - renders content');
-  assert.equal(
-    contents[0].textContent.trim(),
-    '',
-    'first annotation - renders correct content'
-  );
-
-  // Check the second annotation.
-  annotationWrapper = annotationWrappers[1];
-
-  headers = findAll(headerSelector, annotationWrapper);
-  assert.equal(headers.length, 1, 'second annotation - renders header');
-  assert.equal(
-    headers[0].textContent.trim(),
-    '',
-    'second annotation - renders header correctly'
-  );
-
-  descriptions = findAll(descriptionSelector, annotationWrapper);
-  assert.equal(
-    descriptions.length,
-    0,
-    'second annotation - renders description paragraph correctly'
-  );
-
-  contents = findAll(contentSelector, annotationWrapper);
-  assert.equal(contents.length, 1, 'second annotation - renders content');
-  assert.equal(
-    contents[0].textContent.trim(),
-    'This is an inline annotated section without title or description',
-    'second annotation - renders correct content'
-  );
-
-  // Check the third annotation.
-  annotationWrapper = annotationWrappers[2];
-
-  headers = findAll(headerSelector, annotationWrapper);
-  assert.equal(headers.length, 1, 'third annotation - renders header');
-  assert.equal(
-    headers[0].textContent.trim(),
-    'Inline title',
-    'third annotation - renders header correctly'
-  );
-
-  descriptions = findAll(descriptionSelector, annotationWrapper);
-  assert.equal(
-    descriptions.length,
-    0,
-    'third annotation - renders description paragraph correctly'
-  );
-
-  contents = findAll(contentSelector, annotationWrapper);
-  assert.equal(contents.length, 1, 'third annotation - renders content');
+  assert.equal(contents.length, 1, 'renders content');
   assert.equal(
     contents[0].textContent.trim(),
     'This is an inline annotated section with a title but no description',
-    'third annotation - renders correct content'
+    'renders correct content'
+  );
+});
+
+test('it renders the correct HTML when text and description string and no title are passed to annotated section', function(assert) {
+  this.render(hbs`
+    {{#polaris-layout as |layout|}}
+      {{layout.annotatedSection
+        description="Inline description"
+        text="This is an inline annotated section with a description but no title"
+      }}
+    {{/polaris-layout}}
+  `);
+
+  const annotationWrappers = findAll(layoutAnnotationWrapperSelector);
+  assert.equal(annotationWrappers.length, 1, 'renders one annotation wrapper');
+
+  const textContainerSelector = buildNestedSelector(
+    'div.Polaris-Layout__Annotation',
+    'div.Polaris-TextContainer'
+  );
+  const headerSelector = buildNestedSelector(
+    textContainerSelector,
+    'h2.Polaris-Heading'
   );
 
-  // Check the fourth annotation.
-  annotationWrapper = annotationWrappers[3];
+  const contentSelector = 'div.Polaris-Layout__AnnotationContent';
 
-  headers = findAll(headerSelector, annotationWrapper);
-  assert.equal(headers.length, 1, 'fourth annotation - renders header');
-  assert.equal(
-    headers[0].textContent.trim(),
-    '',
-    'fourth annotation - renders header correctly'
-  );
+  const annotationWrapper = annotationWrappers[0];
+  let headers = findAll(headerSelector, annotationWrapper);
+  assert.equal(headers.length, 1, 'renders header');
+  assert.equal(headers[0].textContent.trim(), '', 'renders header correctly');
 
-  descriptions = findAll(descriptionSelector, annotationWrapper);
-  assert.equal(
-    descriptions.length,
-    1,
-    'fourth annotation - renders description paragraph'
-  );
+  let descriptionSelector = '[data-test-annotation-description]';
+
+  let descriptions = findAll(descriptionSelector, annotationWrapper);
+  assert.equal(descriptions.length, 1, 'renders description paragraph');
   assert.equal(
     descriptions[0].textContent.trim(),
     'Inline description',
-    'fourth annotation - renders header correctly'
+    'renders header correctly'
   );
 
-  contents = findAll(contentSelector, annotationWrapper);
-  assert.equal(contents.length, 1, 'fourth annotation - renders content');
+  let contents = findAll(contentSelector, annotationWrapper);
+  assert.equal(contents.length, 1, 'renders content');
   assert.equal(
     contents[0].textContent.trim(),
     'This is an inline annotated section with a description but no title',
-    'fourth annotation - renders correct content'
+    'renders correct content'
+  );
+});
+
+test('it renders the correct HTML when text and description string and title are passed to annotated section', function(assert) {
+  this.render(hbs`
+    {{#polaris-layout as |layout|}}
+      {{layout.annotatedSection
+        title="Inline title"
+        description="Inline description"
+        text="This is an inline annotated section with both a title and description"
+      }}
+    {{/polaris-layout}}
+  `);
+
+  const annotationWrappers = findAll(layoutAnnotationWrapperSelector);
+  assert.equal(annotationWrappers.length, 1, 'renders one annotation wrapper');
+
+  const textContainerSelector = buildNestedSelector(
+    'div.Polaris-Layout__Annotation',
+    'div.Polaris-TextContainer'
+  );
+  const headerSelector = buildNestedSelector(
+    textContainerSelector,
+    'h2.Polaris-Heading'
   );
 
-  // Check the fifth annotation.
-  annotationWrapper = annotationWrappers[4];
+  const contentSelector = 'div.Polaris-Layout__AnnotationContent';
 
-  headers = findAll(headerSelector, annotationWrapper);
-  assert.equal(headers.length, 1, 'fifth annotation - renders header');
+  const annotationWrapper = annotationWrappers[0];
+  let headers = findAll(headerSelector, annotationWrapper);
+  assert.equal(headers.length, 1, 'renders header');
   assert.equal(
     headers[0].textContent.trim(),
     'Inline title',
-    'fifth annotation - renders header correctly'
+    'renders header correctly'
   );
 
-  descriptions = findAll(descriptionSelector, annotationWrapper);
-  assert.equal(
-    descriptions.length,
-    1,
-    'fifth annotation - renders description paragraph'
-  );
+  let descriptionSelector = '[data-test-annotation-description]';
+
+  let descriptions = findAll(descriptionSelector, annotationWrapper);
+  assert.equal(descriptions.length, 1, 'renders description paragraph');
   assert.equal(
     descriptions[0].textContent.trim(),
     'Inline description',
-    'fifth annotation - renders header correctly'
+    'renders header correctly'
   );
 
-  contents = findAll(contentSelector, annotationWrapper);
-  assert.equal(contents.length, 1, 'fifth annotation - renders content');
+  let contents = findAll(contentSelector, annotationWrapper);
+  assert.equal(contents.length, 1, 'renders content');
   assert.equal(
     contents[0].textContent.trim(),
     'This is an inline annotated section with both a title and description',
-    'fifth annotation - renders correct content'
+    'renders correct content'
   );
 });
 


### PR DESCRIPTION
Until now, `polaris-layout/annotated-section`'s `annotation` supported being used in block form, with the block content being used in place of the `description` property. However, this block usage isn't accessible via `polaris-layout/annotated-section`'s public API; as a result I'm removing this behaviour in favour of accepting a component definition or `componentName`/`props` hash as the `description` to allow rendering arbitrary content directly via the public API.