### PR TITLE
Fix height bug on multiline text field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ember-polaris Changelog
 
+### Unreleased
+- [#283](https://github.com/smile-io/ember-polaris/pull/283) [FIX] Fix height bug on multiline text field
+
 ### v4.0.0 (February 26, 2019)
 - [#282](https://github.com/smile-io/ember-polaris/pull/282) [ENHANCEMENT] Allow passing component for annotated layout section's description
 

--- a/addon/templates/components/polaris-text-field/resizer.hbs
+++ b/addon/templates/components/polaris-text-field/resizer.hbs
@@ -1,8 +1,11 @@
-<div class="Polaris-TextField__DummyInput">
-  {{finalContents}}
-</div>
+{{!--
+  N.B. the two dummy input divs in this component MUST be one-liners.
+  If they are split onto multiple lines, they will be too big, and as a result
+  the text area control will appear a couple of lines taller than it should do.
+  This is because of the `white-space: pre-wrap` style applied by Polaris,
+  which replicates the white space/wrapping behaviour of the textarea control.
+--}}
+<div class="Polaris-TextField__DummyInput">{{finalContents}}</div>
 {{#if minimumLines}}
-  <div class="Polaris-TextField__DummyInput">
-    {{contentsForMinimumLines}}
-  </div>
+  <div class="Polaris-TextField__DummyInput">{{contentsForMinimumLines}}</div>
 {{/if}}


### PR DESCRIPTION
Noticed that multiline text fields were rendering a couple of lines taller than expected. This was something we'd fixed internally at @smile-io but forgotten about, and recently got exposed in our apps during some development work 🤷‍♂️ 