### PR TITLE
Break infinite loop in sticky manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ember-polaris Changelog
 
+### Unreleased
+- [#284](https://github.com/smile-io/ember-polaris/pull/284) [FIX] Fix infinite loop in `sticky-manager` service
+
 ### v4.0.1 (February 28, 2019)
 - [#283](https://github.com/smile-io/ember-polaris/pull/283) [FIX] Fix height bug on multiline text field
 

--- a/addon/services/sticky-manager.js
+++ b/addon/services/sticky-manager.js
@@ -66,7 +66,7 @@ export default Service.extend(
       this.throttleTask('manageStickyItems', 50);
     },
 
-    manageStickyItems() {
+    manageStickyItems(isFinalRun = false) {
       let stickyItems = this.get('stickyItems');
       if (stickyItems.length <= 0) {
         return;
@@ -90,16 +90,18 @@ export default Service.extend(
         handlePositioning(sticky, top, left, width);
       });
 
-      /*
-       * This call isn't in the original code, but there seems to be
-       * a difference between how the throttle implementations work
-       * between the React and Ember worlds, which meant that sticky
-       * items in Ember could end up in the wrong position after a
-       * scroll/resize event, until the next such event. This is a
-       * workaround that ensures that no sticky items will be left
-       * in the wrong positions more than 50ms after these events.
-       */
-      this.debounceTask('manageStickyItems', 50);
+      if (!isFinalRun) {
+        /*
+         * This call isn't in the original code, but there seems to be
+         * a difference between how the throttle implementations work
+         * between the React and Ember worlds, which meant that sticky
+         * items in Ember could end up in the wrong position after a
+         * scroll/resize event, until the next such event. This is a
+         * workaround that ensures that no sticky items will be left
+         * in the wrong positions more than 50ms after these events.
+         */
+        this.debounceTask('manageStickyItems', true, 50);
+      }
     },
 
     evaluateStickyItem(stickyItem, scrollTop, containerTop) {

--- a/addon/services/sticky-manager.js
+++ b/addon/services/sticky-manager.js
@@ -1,236 +1,225 @@
 import Service from '@ember/service';
 import { A as EmberArray } from '@ember/array';
 import ContextBoundEventListenersMixin from 'ember-lifeline/mixins/dom';
-import ContextBoundTasksMixin from 'ember-lifeline/mixins/run';
+import { throttleTask, runDisposables } from 'ember-lifeline';
 import tokens from '@shopify/polaris-tokens';
 import { getRectForNode } from '@shopify/javascript-utilities/geometry';
 import stackedContent from '@smile-io/ember-polaris/utils/breakpoints';
 
-export default Service.extend(
-  ContextBoundEventListenersMixin,
-  ContextBoundTasksMixin,
-  {
-    /**
-     * @property stickyItems
-     * @type {Object[]}
-     * @private
-     */
-    stickyItems: EmberArray(),
+export default Service.extend(ContextBoundEventListenersMixin, {
+  /**
+   * @property stickyItems
+   * @type {Object[]}
+   * @private
+   */
+  stickyItems: EmberArray(),
 
-    /**
-     * @property stuckItems
-     * @type {Object[]}
-     * @private
-     */
-    stuckItems: EmberArray(),
+  /**
+   * @property stuckItems
+   * @type {Object[]}
+   * @private
+   */
+  stuckItems: EmberArray(),
 
-    /**
-     * @property container
-     * @type {Document|HTMLElement}
-     * @private
-     */
-    container: null,
+  /**
+   * @property container
+   * @type {Document|HTMLElement}
+   * @private
+   */
+  container: null,
 
-    registerStickyItem(stickyItem) {
-      this.get('stickyItems').push(stickyItem);
-    },
+  registerStickyItem(stickyItem) {
+    this.get('stickyItems').push(stickyItem);
+  },
 
-    unregisterStickyItem(nodeToRemove) {
-      let stickyItems = this.get('stickyItems');
-      let nodeIndex = stickyItems.findIndex(
-        ({ stickyNode }) => nodeToRemove === stickyNode
+  unregisterStickyItem(nodeToRemove) {
+    let stickyItems = this.get('stickyItems');
+    let nodeIndex = stickyItems.findIndex(
+      ({ stickyNode }) => nodeToRemove === stickyNode
+    );
+    stickyItems.splice(nodeIndex, 1);
+  },
+
+  setContainer(el) {
+    this.set('container', el);
+    this.addEventListener(el, 'scroll', this.handleScroll);
+    this.addEventListener(window, 'resize', this.handleResize);
+    this.manageStickyItems();
+  },
+
+  removeScrollListener() {
+    let container = this.get('container');
+    if (container) {
+      this.removeEventListener(container, 'scroll', this.handleScroll);
+      this.removeEventListener(window, 'resize', this.handleResize);
+    }
+  },
+
+  handleResize() {
+    throttleTask(this, 'manageStickyItems', 50, false);
+  },
+
+  handleScroll() {
+    throttleTask(this, 'manageStickyItems', 50, false);
+  },
+
+  manageStickyItems() {
+    let stickyItems = this.get('stickyItems');
+    if (stickyItems.length <= 0) {
+      return;
+    }
+
+    let container = this.get('container');
+    let scrollTop = scrollTopFor(container);
+    let containerTop = getRectForNode(container).top;
+
+    stickyItems.forEach((stickyItem) => {
+      let { handlePositioning } = stickyItem;
+
+      let { sticky, top, left, width } = this.evaluateStickyItem(
+        stickyItem,
+        scrollTop,
+        containerTop
       );
-      stickyItems.splice(nodeIndex, 1);
-    },
 
-    setContainer(el) {
-      this.set('container', el);
-      this.addEventListener(el, 'scroll', this.handleScroll);
-      this.addEventListener(window, 'resize', this.handleResize);
-      this.manageStickyItems();
-    },
+      this.updateStuckItems(stickyItem, sticky);
 
-    removeScrollListener() {
-      let container = this.get('container');
-      if (container) {
-        this.removeEventListener(container, 'scroll', this.handleScroll);
-        this.removeEventListener(window, 'resize', this.handleResize);
-      }
-    },
+      handlePositioning(sticky, top, left, width);
+    });
+  },
 
-    handleResize() {
-      this.throttleTask('manageStickyItems', 50);
-    },
+  evaluateStickyItem(stickyItem, scrollTop, containerTop) {
+    let {
+      stickyNode,
+      placeHolderNode,
+      boundingElement,
+      offset,
+      disableWhenStacked,
+    } = stickyItem;
 
-    handleScroll() {
-      this.throttleTask('manageStickyItems', 50);
-    },
-
-    manageStickyItems(isFinalRun = false) {
-      let stickyItems = this.get('stickyItems');
-      if (stickyItems.length <= 0) {
-        return;
-      }
-
-      let container = this.get('container');
-      let scrollTop = scrollTopFor(container);
-      let containerTop = getRectForNode(container).top;
-
-      stickyItems.forEach((stickyItem) => {
-        let { handlePositioning } = stickyItem;
-
-        let { sticky, top, left, width } = this.evaluateStickyItem(
-          stickyItem,
-          scrollTop,
-          containerTop
-        );
-
-        this.updateStuckItems(stickyItem, sticky);
-
-        handlePositioning(sticky, top, left, width);
-      });
-
-      if (!isFinalRun) {
-        /*
-         * This call isn't in the original code, but there seems to be
-         * a difference between how the throttle implementations work
-         * between the React and Ember worlds, which meant that sticky
-         * items in Ember could end up in the wrong position after a
-         * scroll/resize event, until the next such event. This is a
-         * workaround that ensures that no sticky items will be left
-         * in the wrong positions more than 50ms after these events.
-         */
-        this.debounceTask('manageStickyItems', true, 50);
-      }
-    },
-
-    evaluateStickyItem(stickyItem, scrollTop, containerTop) {
-      let {
-        stickyNode,
-        placeHolderNode,
-        boundingElement,
-        offset,
-        disableWhenStacked,
-      } = stickyItem;
-
-      if (disableWhenStacked && stackedContent().matches) {
-        return {
-          sticky: false,
-          top: 0,
-          left: 0,
-          width: 'auto',
-        };
-      }
-
-      let stickyOffset = offset
-        ? this.getOffset(stickyNode) + parseInt(tokens.spacingLoose, 10)
-        : this.getOffset(stickyNode);
-
-      let scrollPosition = scrollTop + stickyOffset;
-      let placeHolderNodeCurrentTop =
-        placeHolderNode.getBoundingClientRect().top - containerTop + scrollTop;
-      let top = containerTop + stickyOffset;
-      let width = placeHolderNode.getBoundingClientRect().width;
-      let left = placeHolderNode.getBoundingClientRect().left;
-
-      let sticky;
-
-      if (boundingElement == null) {
-        sticky = scrollPosition >= placeHolderNodeCurrentTop;
-      } else {
-        let stickyItemHeight = stickyNode.getBoundingClientRect().height;
-        let stickyItemBottomPosition =
-          boundingElement.getBoundingClientRect().bottom -
-          stickyItemHeight +
-          scrollTop -
-          containerTop;
-
-        sticky =
-          scrollPosition >= placeHolderNodeCurrentTop &&
-          scrollPosition < stickyItemBottomPosition;
-      }
-
+    if (disableWhenStacked && stackedContent().matches) {
       return {
-        sticky,
-        top,
-        left,
-        width,
+        sticky: false,
+        top: 0,
+        left: 0,
+        width: 'auto',
       };
-    },
+    }
 
-    updateStuckItems(item, sticky) {
-      let { stickyNode } = item;
-      if (sticky && !this.isNodeStuck(stickyNode)) {
-        this.addStuckItem(item);
-      } else if (!sticky && this.isNodeStuck(stickyNode)) {
-        this.removeStuckItem(item);
-      }
-    },
+    let stickyOffset = offset
+      ? this.getOffset(stickyNode) + parseInt(tokens.spacingLoose, 10)
+      : this.getOffset(stickyNode);
 
-    addStuckItem(stickyItem) {
-      this.get('stuckItems').push(stickyItem);
-    },
+    let scrollPosition = scrollTop + stickyOffset;
+    let placeHolderNodeCurrentTop =
+      placeHolderNode.getBoundingClientRect().top - containerTop + scrollTop;
+    let top = containerTop + stickyOffset;
+    let width = placeHolderNode.getBoundingClientRect().width;
+    let left = placeHolderNode.getBoundingClientRect().left;
 
-    removeStuckItem(stickyItem) {
-      let stuckItems = this.get('stuckItems');
-      let { stickyNode: nodeToRemove } = stickyItem;
-      let nodeIndex = stuckItems.findIndex(
-        ({ stickyNode }) => nodeToRemove === stickyNode
-      );
-      stuckItems.splice(nodeIndex, 1);
-    },
+    let sticky;
 
-    getOffset(node) {
-      let stuckItems = this.get('stuckItems');
-      let stuckNodesLength = stuckItems.get('length');
-      if (stuckNodesLength === 0) {
-        return 0;
-      }
+    if (boundingElement == null) {
+      sticky = scrollPosition >= placeHolderNodeCurrentTop;
+    } else {
+      let stickyItemHeight = stickyNode.getBoundingClientRect().height;
+      let stickyItemBottomPosition =
+        boundingElement.getBoundingClientRect().bottom -
+        stickyItemHeight +
+        scrollTop -
+        containerTop;
 
-      let offset = 0;
-      let count = 0;
-      let nodeRect = getRectForNode(node);
+      sticky =
+        scrollPosition >= placeHolderNodeCurrentTop &&
+        scrollPosition < stickyItemBottomPosition;
+    }
 
-      while (count < stuckNodesLength) {
-        let stuckNode = stuckItems[count].stickyNode;
-        if (stuckNode !== node) {
-          let stuckNodeRect = getRectForNode(stuckNode);
-          if (!horizontallyOverlaps(nodeRect, stuckNodeRect)) {
-            offset += getRectForNode(stuckNode).height;
-          }
-        } else {
-          break;
+    return {
+      sticky,
+      top,
+      left,
+      width,
+    };
+  },
+
+  updateStuckItems(item, sticky) {
+    let { stickyNode } = item;
+    if (sticky && !this.isNodeStuck(stickyNode)) {
+      this.addStuckItem(item);
+    } else if (!sticky && this.isNodeStuck(stickyNode)) {
+      this.removeStuckItem(item);
+    }
+  },
+
+  addStuckItem(stickyItem) {
+    this.get('stuckItems').push(stickyItem);
+  },
+
+  removeStuckItem(stickyItem) {
+    let stuckItems = this.get('stuckItems');
+    let { stickyNode: nodeToRemove } = stickyItem;
+    let nodeIndex = stuckItems.findIndex(
+      ({ stickyNode }) => nodeToRemove === stickyNode
+    );
+    stuckItems.splice(nodeIndex, 1);
+  },
+
+  getOffset(node) {
+    let stuckItems = this.get('stuckItems');
+    let stuckNodesLength = stuckItems.get('length');
+    if (stuckNodesLength === 0) {
+      return 0;
+    }
+
+    let offset = 0;
+    let count = 0;
+    let nodeRect = getRectForNode(node);
+
+    while (count < stuckNodesLength) {
+      let stuckNode = stuckItems[count].stickyNode;
+      if (stuckNode !== node) {
+        let stuckNodeRect = getRectForNode(stuckNode);
+        if (!horizontallyOverlaps(nodeRect, stuckNodeRect)) {
+          offset += getRectForNode(stuckNode).height;
         }
-        count++;
+      } else {
+        break;
       }
+      count++;
+    }
 
-      return offset;
-    },
+    return offset;
+  },
 
-    isNodeStuck(node) {
-      let nodeFound = this.get('stuckItems').findIndex(
-        ({ stickyNode }) => node === stickyNode
-      );
+  isNodeStuck(node) {
+    let nodeFound = this.get('stuckItems').findIndex(
+      ({ stickyNode }) => node === stickyNode
+    );
 
-      return nodeFound >= 0;
-    },
+    return nodeFound >= 0;
+  },
 
-    init() {
-      this._super(...arguments);
+  init() {
+    this._super(...arguments);
 
-      /*
-       * The original `StickyManager` React code doesn't default this to `document`,
-       * but the React `AppProvider` *does* set it to `document` if that exists.
-       * This default value is here to recreate this behaviour without having to
-       * implement `AppProvider`.
-       */
-      let container = this.get('container') || document;
-      if (container) {
-        this.setContainer(container);
-      }
-    },
-  }
-);
+    /*
+     * The original `StickyManager` React code doesn't default this to `document`,
+     * but the React `AppProvider` *does* set it to `document` if that exists.
+     * This default value is here to recreate this behaviour without having to
+     * implement `AppProvider`.
+     */
+    let container = this.get('container') || document;
+    if (container) {
+      this.setContainer(container);
+    }
+  },
+
+  willDestroy() {
+    this._super(...arguments);
+
+    runDisposables(this);
+  },
+});
 
 function isDocument(node) {
   return node === document;


### PR DESCRIPTION
Noticed today while testing `polaris-sticky` in one of our apps that the `manageStickyItems` method in `sticky-manager` has an infinite loop, figured I should _probably_ fix it 🤦‍♂️ 