### PR TITLE
Update action list to v3.10.0

### DIFF
--- a/addon/components/polaris-action-list.js
+++ b/addon/components/polaris-action-list.js
@@ -36,6 +36,16 @@ export default Component.extend({
   sections: null,
 
   /**
+   * Defines a specific role attribute for each action in the list
+   *
+   * @property actionRole
+   * @public
+   * @type {String}
+   * @default null
+   */
+  actionRole: null,
+
+  /**
    * Callback when any item is clicked or keypressed
    *
    * @property onActionAnyItem

--- a/addon/components/polaris-action-list/item.js
+++ b/addon/components/polaris-action-list/item.js
@@ -6,6 +6,8 @@ import layout from '../../templates/components/polaris-action-list/item';
 export default Component.extend({
   tagName: 'li',
 
+  attributeBindings: ['role', 'active:aria-selected'],
+
   layout,
 
   /**
@@ -13,12 +15,15 @@ export default Component.extend({
    *
    * Supported properties:
    *  - content
+   *  - helpText
    *  - url (not currently supported)
    *  - destructive
    *  - disabled
    *  - icon
    *  - image
    *  - ellipsis (not currently supported)
+   *  - active
+   *  - role
    *  - badge (not currently supported)
    *  - onAction
    *
@@ -39,10 +44,10 @@ export default Component.extend({
    */
   onAction() {},
 
-  itemClasses: computed('item.{destructive,disabled}', function() {
+  itemClasses: computed('item.{destructive,disabled,active}', function() {
     let classNames = ['Polaris-ActionList__Item'];
     let item = this.get('item');
-    let { destructive, disabled } = item;
+    let { destructive, disabled, active } = item;
 
     if (destructive) {
       classNames.push('Polaris-ActionList--destructive');
@@ -50,6 +55,10 @@ export default Component.extend({
 
     if (disabled) {
       classNames.push('Polaris-ActionList--disabled');
+    }
+
+    if (active) {
+      classNames.push('Polaris-ActionList--active');
     }
 
     return classNames.join(' ');

--- a/addon/components/polaris-action-list/item.js
+++ b/addon/components/polaris-action-list/item.js
@@ -11,43 +11,110 @@ export default Component.extend({
   layout,
 
   /**
-   * The item to display
-   *
-   * Supported properties:
-   *  - content
-   *  - helpText
-   *  - url (not currently supported)
-   *  - destructive
-   *  - disabled
-   *  - icon
-   *  - image
-   *  - ellipsis (not currently supported)
-   *  - active
-   *  - role
-   *  - badge (not currently supported)
-   *  - onAction
-   *
-   * @property item
+   * @property text
+   * @type {String}
+   * @default null
    * @public
+   */
+  text: null,
+
+  /**
+   * @property helpText
+   * @type {String}
+   * @default null
+   * @public
+   */
+  helpText: null,
+
+  /**
+   * Not currently supported
+   * @property url
+   * @type {String}
+   * @default null
+   * @public
+   */
+  url: null,
+
+  /**
+   * @property destructive
+   * @type {Boolean}
+   * @default false
+   * @public
+   */
+  destructive: false,
+
+  /**
+   * @property disabled
+   * @type {Boolean}
+   * @default false
+   * @public
+   */
+  disabled: false,
+
+  /**
+   * @property icon
+   * @type {String}
+   * @default null
+   * @public
+   */
+  icon: null,
+
+  /**
+   * @property image
+   * @type {String}
+   * @default null
+   * @public
+   */
+  image: null,
+
+  /**
+   * Not currently supported
+   * @property ellipsis
+   * @type {Boolean}
+   * @default false
+   * @public
+   */
+  ellipsis: false,
+
+  /**
+   * @property active
+   * @type {Boolean}
+   * @default false
+   * @public
+   */
+  active: false,
+
+  /**
+   * @property role
+   * @type {String}
+   * @default null
+   * @public
+   */
+  role: null,
+
+  /**
+   * Object with `status` and `content` properties
+   * Not currently supported
+   * @property badge
    * @type {Object}
    * @default null
+   * @public
    */
-  item: null,
+  badge: null,
 
   /**
    * Callback for the item when clicked
    *
    * @property onAction
    * @public
-   * @type {function}
+   * @type {Function}
    * @default no-op
    */
   onAction() {},
 
-  itemClasses: computed('item.{destructive,disabled,active}', function() {
+  itemClasses: computed('destructive', 'disabled', 'active', function() {
     let classNames = ['Polaris-ActionList__Item'];
-    let item = this.get('item');
-    let { destructive, disabled, active } = item;
+    let { destructive, disabled, active } = this;
 
     if (destructive) {
       classNames.push('Polaris-ActionList--destructive');
@@ -64,8 +131,8 @@ export default Component.extend({
     return classNames.join(' ');
   }),
 
-  imageBackgroundStyle: computed('item.image', function() {
-    let url = this.get('item.image');
+  imageBackgroundStyle: computed('image', function() {
+    let url = this.get('image');
     return url ? htmlSafe(`background-image: url(${url})`) : '';
   }).readOnly(),
 });

--- a/addon/components/polaris-action-list/section.js
+++ b/addon/components/polaris-action-list/section.js
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 import { invokeAction } from 'ember-invoke-action';
 import layout from '../../templates/components/polaris-action-list/section';
 
@@ -22,10 +23,24 @@ export default Component.extend({
    *
    * @property hasMultipleSections
    * @public
-   * @type {boolean}
+   * @type {Boolean}
    * @default false
    */
   hasMultipleSections: false,
+
+  /**
+   * Defines a specific role attribute for each action in the list
+   *
+   * @property actionRole
+   * @public
+   * @type {String}
+   * @default null
+   */
+  actionRole: null,
+
+  sectionRole: computed('actionRole', function() {
+    return this.get('actionRole') === 'option' ? 'presentation' : undefined;
+  }).readOnly(),
 
   actions: {
     onItemAction(item, event) {

--- a/addon/templates/components/polaris-action-list.hbs
+++ b/addon/templates/components/polaris-action-list.hbs
@@ -6,6 +6,7 @@
     {{polaris-action-list/section
       section=section
       hasMultipleSections=hasMultipleSections
+      actionRole=actionRole
       onActionAnyItem=(action onActionAnyItem)
     }}
   {{/each}}

--- a/addon/templates/components/polaris-action-list/item.hbs
+++ b/addon/templates/components/polaris-action-list/item.hbs
@@ -2,15 +2,15 @@
 
 <button
   class={{itemClasses}}
-  disabled={{item.disabled}}
+  disabled={{disabled}}
   onclick={{action onAction}}
 >
   <div class="Polaris-ActionList__Content">
-    {{#if item.icon}}
+    {{#if icon}}
       <div class="Polaris-ActionList__Image">
-        {{polaris-icon source=item.icon}}
+        {{polaris-icon source=icon}}
       </div>
-    {{else if item.image}}
+    {{else if image}}
       <div
         role="presentation"
         class="Polaris-ActionList__Image"
@@ -20,13 +20,13 @@
     {{/if}}
 
     <div class="Polaris-ActionList__Text">
-      {{#if item.helpText}}
+      {{#if helpText}}
         <div>
-          <div>{{item.text}}</div>
-          {{polaris-text-style variation="subdued" text=item.helpText}}
+          <div>{{text}}</div>
+          {{polaris-text-style variation="subdued" text=helpText}}
         </div>
       {{else}}
-        {{item.text}}
+        {{text}}
       {{/if}}
     </div>
   </div>

--- a/addon/templates/components/polaris-action-list/item.hbs
+++ b/addon/templates/components/polaris-action-list/item.hbs
@@ -1,3 +1,5 @@
+{{!-- TODO: add scroll support here when `polaris-scrollable` is available. --}}
+
 <button
   class={{itemClasses}}
   disabled={{item.disabled}}
@@ -18,7 +20,14 @@
     {{/if}}
 
     <div class="Polaris-ActionList__Text">
-      {{item.text}}
+      {{#if item.helpText}}
+        <div>
+          <div>{{item.text}}</div>
+          {{polaris-text-style variation="subdued" text=item.helpText}}
+        </div>
+      {{else}}
+        {{item.text}}
+      {{/if}}
     </div>
   </div>
 </button>

--- a/addon/templates/components/polaris-action-list/section.hbs
+++ b/addon/templates/components/polaris-action-list/section.hbs
@@ -9,10 +9,23 @@
       </p>
     {{/if}}
 
-    <ul class="Polaris-ActionList__Actions">
+    <ul
+      class="Polaris-ActionList__Actions"
+      role={{sectionRole}}
+    >
       {{#each section.items as |item|}}
         {{polaris-action-list/item
-          item=item
+          text=item.text
+          helpText=item.helpText
+          url=item.url
+          destructive=item.destructive
+          disabled=item.disabled
+          icon=item.icon
+          image=item.image
+          ellipsis=item.ellipsis
+          active=item.active
+          role=actionRole
+          badge=item.badge
           onAction=(action "onItemAction" item)
         }}
       {{/each}}

--- a/tests/integration/components/polaris-action-list-test.js
+++ b/tests/integration/components/polaris-action-list-test.js
@@ -303,6 +303,7 @@ module('Integration | Component | polaris action list', function(hooks) {
           },
           {
             text: 'Section 2 item 2',
+            helpText: 'Helpful stuff',
           },
         ],
       },
@@ -384,11 +385,19 @@ module('Integration | Component | polaris action list', function(hooks) {
         'Section 2 item 1',
         "second section's first item renders the correct text"
       );
+
     assert
-      .dom(items[1])
+      .dom('.Polaris-ActionList__Text div div', items[1])
       .hasText(
         'Section 2 item 2',
         "second section's second item renders the correct text"
+      );
+
+    assert
+      .dom('.Polaris-ActionList__Text [data-test-text-style]', items[1])
+      .hasText(
+        'Helpful stuff',
+        "second section's second item renders the correct help text"
       );
 
     let item = items[0];

--- a/tests/integration/components/polaris-action-list-test.js
+++ b/tests/integration/components/polaris-action-list-test.js
@@ -449,4 +449,21 @@ module('Integration | Component | polaris action list', function(hooks) {
     assert.ok(this.get('nestedActionFired'), 'nested action was fired');
     assert.notOk(this.get('formSubmitted'), 'form submit action is not fired');
   });
+
+  test('renders helpText when the helpText prop is defined', async function(assert) {
+    await render(hbs`
+      {{polaris-action-list
+        items=(array
+          (hash
+            text="I'm helpful"
+            helpText="Yay I'm helping!"
+          )
+        )
+      }}
+    `);
+
+    assert
+      .dom(`${actionListItemSelector} [data-test-text-style]`)
+      .hasText(`Yay I'm helping!`);
+  });
 });


### PR DESCRIPTION
Updates `polaris-action-list` and child components to match Polaris v3.10.0. I haven't added the new scroll functionality since we don't currently need it anywhere and don't have an implementation of the Polaris `Scrollable` component that we'd need for it anyway.