### PR TITLE
Update banner to Polaris v3.10.0

### DIFF
--- a/addon/components/polaris-banner.js
+++ b/addon/components/polaris-banner.js
@@ -8,6 +8,8 @@ import { capitalize } from '@ember/string';
 import { invokeAction } from 'ember-invoke-action';
 import { handleMouseUpByBlurring } from '../utils/focus';
 
+// TODO icon-update: use new icon names here when @shopify/polaris-icons
+// is consumable by Ember apps.
 const bannerIcons = {
   success: {
     iconName: 'circle-check-mark',

--- a/addon/templates/components/polaris-banner.hbs
+++ b/addon/templates/components/polaris-banner.hbs
@@ -35,13 +35,16 @@
       {{#if action}}
         <div class="Polaris-Banner__Actions">
           {{#polaris-button-group}}
-            {{polaris-button
-              outline=true
-              text=action.text
-              disabled=action.disabled
-              loading=action.loading
-              onClick=(action "triggerAction" action)
-            }}
+            <div class="Polaris-Banner__PrimaryAction">
+              {{polaris-button
+                outline=true
+                size=(if withinContentContainer "slim")
+                text=action.text
+                disabled=action.disabled
+                loading=action.loading
+                onClick=(action "triggerAction" action)
+              }}
+            </div>
 
             {{#if secondaryAction}}
               <button

--- a/tests/integration/components/polaris-banner-test.js
+++ b/tests/integration/components/polaris-banner-test.js
@@ -349,7 +349,7 @@ test('it supports `action` and `secondaryAction`', function(assert) {
   actions = find(actionsSelector, content);
   let btnGroup = find('div.Polaris-ButtonGroup', actions);
   let actionBtn = find(
-    'div.Polaris-ButtonGroup__Item > button.Polaris-Button.Polaris-Button--outline',
+    'div.Polaris-ButtonGroup__Item > div.Polaris-Banner__PrimaryAction > button.Polaris-Button.Polaris-Button--outline',
     btnGroup
   );
   let secondaryActionBtn = find(
@@ -385,7 +385,7 @@ test('it supports `action` and `secondaryAction`', function(assert) {
   actions = find(actionsSelector, content);
   btnGroup = find('div.Polaris-ButtonGroup', actions);
   actionBtn = find(
-    'div.Polaris-ButtonGroup__Item > button.Polaris-Button.Polaris-Button--outline',
+    'div.Polaris-ButtonGroup__Item > div.Polaris-Banner__PrimaryAction > button.Polaris-Button.Polaris-Button--outline',
     btnGroup
   );
   secondaryActionBtn = find(


### PR DESCRIPTION
Tweaks `polaris-banner` to add the new `div` around the primary action, and sets the primary action button size to `slim` when `withinContentContainer` is truthy. Also added a `TODO` to update the icons when we figure out how to progress with the `@shopify/polaris-icons` package 🙏 