### PR TITLE
Update unstyled link to Polaris v3.10.0

### DIFF
--- a/addon/components/polaris-unstyled-link.js
+++ b/addon/components/polaris-unstyled-link.js
@@ -3,12 +3,19 @@ import { computed } from '@ember/object';
 import layout from '../templates/components/polaris-unstyled-link';
 import mapEventToAction from '../utils/map-event-to-action';
 
+/**
+ * Undocumented Polaris UnstyledLink component.
+ * Note that we do not support the custom link
+ * component behaviour provided by the React
+ * implementation at this point.
+ */
 export default Component.extend({
   tagName: 'a',
 
   attributeBindings: [
     'url:href',
     'dataPolarisUnstyled:data-polaris-unstyled',
+    'download',
     'target',
     'rel',
     'ariaLabel:aria-label',
@@ -18,7 +25,7 @@ export default Component.extend({
   layout,
 
   /**
-   * The url to link to.
+   * A destination to link to
    *
    * @property url
    * @type {String}
@@ -29,7 +36,7 @@ export default Component.extend({
   url: null,
 
   /**
-   * Use for a links that open a different site
+   * Forces url to open in a new tab
    *
    * @property external
    * @type {Boolean}
@@ -37,6 +44,16 @@ export default Component.extend({
    * @public
    */
   external: false,
+
+  /**
+   * Tells the browser to download the url instead of opening it. Provides a hint for the downloaded filename if it is a string value.
+   *
+   * @property download
+   * @type {String|Boolean}
+   * @default null
+   * @public
+   */
+  download: null,
 
   /**
    * Callback when a link is clicked
@@ -49,7 +66,7 @@ export default Component.extend({
   onClick() {},
 
   /**
-   * The content to display inside link
+   * Content to display inside the link
    *
    * @property text
    * @type {String}

--- a/tests/integration/components/polaris-unstyled-link-test.js
+++ b/tests/integration/components/polaris-unstyled-link-test.js
@@ -1,0 +1,41 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | polaris-unstyled-link', function(hooks) {
+  setupRenderingTest(hooks);
+
+  module('external', function() {
+    test('adds rel and target attributes', async function(assert) {
+      await render(hbs`
+        {{polaris-unstyled-link external=true url="https://shopify.com"}}
+      `);
+      assert.dom('a').hasAttribute('target', '_blank');
+      assert.dom('a').hasAttribute('rel', 'noopener noreferrer');
+    });
+  });
+
+  module('download', function() {
+    test('adds true as a boolean attribute', async function(assert) {
+      await render(hbs`
+        {{polaris-unstyled-link download=true url="https://shopify.com"}}
+      `);
+      assert.dom('a').hasAttribute('download', 'true');
+    });
+
+    test('adds the provided string', async function(assert) {
+      await render(hbs`
+        {{polaris-unstyled-link download="file.txt" url="https://shopify.com"}}
+      `);
+      assert.dom('a').hasAttribute('download', 'file.txt');
+    });
+
+    test('does not add the attribute when not set', async function(assert) {
+      await render(hbs`
+        {{polaris-unstyled-link url="https://shopify.com"}}
+      `);
+      assert.dom('a').doesNotHaveAttribute('download');
+    });
+  });
+});


### PR DESCRIPTION
Updates the comments/JSDoc for `polaris-unstyled-link`, adds the `download` property, and adds ports of the applicable React tests.