### PR TITLE
Update card to Polaris v3.10.0

### DIFF
--- a/addon/components/polaris-card/section-header.js
+++ b/addon/components/polaris-card/section-header.js
@@ -10,7 +10,7 @@ export default Component.extend({
    * Title for the section
    *
    * @property title
-   * @type {string}
+   * @type {String|Component}
    * @default: null
    * @public
    */
@@ -24,7 +24,7 @@ export default Component.extend({
    * instead of `text`
    *
    * @property text
-   * @type {string}
+   * @type {String}
    * @default: null
    * @public
    */

--- a/addon/templates/components/polaris-card.hbs
+++ b/addon/templates/components/polaris-card.hbs
@@ -1,4 +1,5 @@
 {{#if (or title headerActions)}}
+  {{!-- TODO: check for children here as per the React implementation. --}}
   {{#if headerActions}}
     <div class="Polaris-Card__Header">
       {{#polaris-stack alignment="baseline" as |stack|}}

--- a/addon/templates/components/polaris-card.hbs
+++ b/addon/templates/components/polaris-card.hbs
@@ -1,4 +1,4 @@
-{{#if title}}
+{{#if (or title headerActions)}}
   {{#if headerActions}}
     <div class="Polaris-Card__Header">
       {{#polaris-stack alignment="baseline" as |stack|}}
@@ -63,29 +63,31 @@
 
 {{#if (or primaryFooterAction secondaryFooterAction)}}
   <div class="Polaris-Card__Footer">
-    {{#polaris-button-group}}
-
+    {{#polaris-button-group as |buttonGroup|}}
       {{#if secondaryFooterAction}}
-        {{polaris-button
-          dataTestId="secondaryFooterAction"
-          text=secondaryFooterAction.text
-          disabled=secondaryFooterAction.disabled
-          loading=secondaryFooterAction.loading
-          onClick=(action secondaryFooterAction.onAction)
-        }}
+        {{#buttonGroup.item}}
+          {{polaris-button
+            dataTestId="secondaryFooterAction"
+            text=secondaryFooterAction.text
+            disabled=secondaryFooterAction.disabled
+            loading=secondaryFooterAction.loading
+            onClick=(action secondaryFooterAction.onAction)
+          }}
+        {{/buttonGroup.item}}
       {{/if}}
 
       {{#if primaryFooterAction}}
-        {{polaris-button
-          dataTestId="primaryFooterAction"
-          primary=true
-          text=primaryFooterAction.text
-          disabled=primaryFooterAction.disabled
-          loading=primaryFooterAction.loading
-          onClick=(action primaryFooterAction.onAction)
-        }}
+        {{#buttonGroup.item}}
+          {{polaris-button
+            dataTestId="primaryFooterAction"
+            primary=true
+            text=primaryFooterAction.text
+            disabled=primaryFooterAction.disabled
+            loading=primaryFooterAction.loading
+            onClick=(action primaryFooterAction.onAction)
+          }}
+        {{/buttonGroup.item}}
       {{/if}}
-
     {{/polaris-button-group}}
   </div>
 {{/if}}

--- a/addon/templates/components/polaris-card/section-header.hbs
+++ b/addon/templates/components/polaris-card/section-header.hbs
@@ -1,5 +1,9 @@
 {{#if title}}
-  {{polaris-subheading text=title}}
+  {{#if (is-component-definition title)}}
+    {{render-content title}}
+  {{else}}
+    {{polaris-subheading text=title}}
+  {{/if}}
 {{/if}}
 
 {{#if hasBlock}}


### PR DESCRIPTION
Tweaks logic behind when card header renders and prevents potential glimmer errors when card has dynamic footer actions.

EDIT: also adds support for rendering components as card section titles (missed this file in the diff when I made the initial changes 🤦‍♂️)