### PR TITLE
Update date picker to Polaris v3.10.0

### DIFF
--- a/addon/components/polaris-date-picker/day.js
+++ b/addon/components/polaris-date-picker/day.js
@@ -231,7 +231,7 @@ export default Component.extend({
 
       const { start, end } = selectedDates;
 
-      return start === end && day > start && day <= hoverDate;
+      return isSameDay(start, end) && day > start && day <= hoverDate;
     }
   ).readOnly(),
 


### PR DESCRIPTION
Tweaks the logic on `polaris-date-picker`'s `inHoveringRange` to match the React implementation.