### PR TITLE
Update empty search result to Polaris v3.10.0

### DIFF
--- a/tests/integration/components/polaris-empty-search-result-test.js
+++ b/tests/integration/components/polaris-empty-search-result-test.js
@@ -53,7 +53,7 @@ module('Integration | Component | polaris-empty-search-result', function(
     assert.dom(illustrationSelector).doesNotExist();
   });
 
-  test('displays the correct illustration when `withIllustration` is true', async function(assert) {
+  test('displays the illustration when `withIllustration` is true', async function(assert) {
     await render(hbs`
       {{polaris-empty-search-result
         title="Foo"


### PR DESCRIPTION
Tweaks the description on one of the `polaris-empty-search-result` tests, no other changes needed to match the React implementation 🤷‍♂️ 