### PR TITLE
Update form to Polaris v3.10.0

### DIFF
--- a/addon/components/polaris-form.js
+++ b/addon/components/polaris-form.js
@@ -62,13 +62,14 @@ export default Component.extend({
   implicitSubmit: true,
 
   /**
-   * Method used to submit form
+   * Method used to submit form.
+   * Can be one of 'post', 'get' or 'action'.
    *
    * @type {String}
-   * @default null
+   * @default 'post'
    * @public
    */
-  method: null,
+  method: 'post',
 
   /**
    * A unique name for the form

--- a/tests/integration/components/polaris-form-test.js
+++ b/tests/integration/components/polaris-form-test.js
@@ -54,7 +54,7 @@ module('Integration | Component | polaris-form', function(hooks) {
       .hasAttribute(
         'autoComplete',
         'off',
-        'renders autoComplete attribute when provided'
+        'sets the autocomplete attribute to "off" when provided as false'
       );
     assert
       .dom('[data-test-form]')
@@ -90,6 +90,13 @@ module('Integration | Component | polaris-form', function(hooks) {
       .doesNotExist(
         'does not render submit button when `implicitSubmit` is false'
       );
+  });
+
+  test('defaults to post when no method is set', async function(assert) {
+    await render(hbs`{{polaris-form}}`);
+    assert
+      .dom('[data-test-form]')
+      .hasAttribute('method', 'post', 'defaults to post when no method is set');
   });
 
   test('invokes `onSubmit` when form is submitted', async function(assert) {


### PR DESCRIPTION
Defaults `polaris-form`'s `method` property to POST.