### PR TITLE
Update form layout to Polaris v3.10.0

### DIFF
--- a/addon/components/polaris-form-layout/group.js
+++ b/addon/components/polaris-form-layout/group.js
@@ -11,7 +11,9 @@ export default Component.extend({
     'helpTextID:aria-describedby',
   ],
 
-  classNameBindings: ['condensed:Polaris-FormLayout--condensed'],
+  classNameBindings: [
+    'condensed:Polaris-FormLayout--condensed:Polaris-FormLayout--grouped',
+  ],
 
   layout,
 

--- a/tests/integration/components/polaris-form-layout-test.js
+++ b/tests/integration/components/polaris-form-layout-test.js
@@ -86,6 +86,12 @@ module('Integration | Component | polaris form layout', function(hooks) {
       );
     assert
       .dom(firstGroupSelector)
+      .hasClass(
+        'Polaris-FormLayout--grouped',
+        'first group - has grouped class'
+      );
+    assert
+      .dom(firstGroupSelector)
       .hasAttribute(
         'aria-describedby',
         `${this.firstGroupId}HelpText`,
@@ -140,6 +146,12 @@ module('Integration | Component | polaris form layout', function(hooks) {
       .hasClass(
         'Polaris-FormLayout--condensed',
         'second group - has condensed class'
+      );
+    assert
+      .dom(secondGroupSelector)
+      .hasNoClass(
+        'Polaris-FormLayout--grouped',
+        'second group - does not have grouped class'
       );
     let secondGroupItemSelector = buildNestedSelector(
       secondGroupSelector,


### PR DESCRIPTION
Adds a "grouped" class to `polaris-form-layout/group` instances with `condensed=false`.