### PR TITLE
Update link to Polaris v3.10.0

### DIFF
--- a/addon/components/polaris-link.js
+++ b/addon/components/polaris-link.js
@@ -13,10 +13,10 @@ export default Component.extend({
   layout,
 
   /**
-   * The url to link to.
+   * The url to link to
    *
    * @property url
-   * @type {string}
+   * @type {String}
    * @default null
    * @public
    */
@@ -26,7 +26,7 @@ export default Component.extend({
    * The content to display inside link
    *
    * @property text
-   * @type {string}
+   * @type {String}
    * @default null
    * @public
    */
@@ -36,17 +36,27 @@ export default Component.extend({
    * Use for a links that open a different site
    *
    * @property external
-   * @type {boolean}
+   * @type {Boolean}
    * @default false
    * @public
    */
   external: false,
 
   /**
+   * Makes the link color the same as the current text color and adds an underline
+   *
+   * @property monochrome
+   * @type {Boolean}
+   * @default false
+   * @public
+   */
+  monochrome: false,
+
+  /**
    * Callback when a link is clicked
    *
    * @property onClick
-   * @type {function}
+   * @type {Function}
    * @default noop
    * @public
    */
@@ -56,13 +66,17 @@ export default Component.extend({
    * @private
    */
   linkClass: computed('class', function() {
-    let linkClass = 'Polaris-Link';
-    const externalClasses = this.get('class');
+    let linkClasses = ['Polaris-Link'];
 
-    if (externalClasses) {
-      linkClass += ` ${externalClasses}`;
+    if (this.get('monochrome')) {
+      linkClasses.push('Polaris-Link--monochrome');
     }
 
-    return linkClass;
+    const externalClasses = this.get('class');
+    if (externalClasses) {
+      linkClasses.push(externalClasses);
+    }
+
+    return linkClasses.join(' ');
   }).readOnly(),
 });

--- a/addon/templates/components/polaris-link.hbs
+++ b/addon/templates/components/polaris-link.hbs
@@ -12,7 +12,11 @@
     {{/if}}
   {{/polaris-unstyled-link}}
 {{else}}
-  <button class={{linkClass}} {{action (action onClick) bubbles=false}}>
+  <button
+    type="button"
+    class={{linkClass}}
+    {{action (action onClick) bubbles=false}}
+  >
     {{#if hasBlock}}
       {{yield}}
     {{else}}

--- a/tests/integration/components/polaris-link-test.js
+++ b/tests/integration/components/polaris-link-test.js
@@ -92,6 +92,25 @@ test('it renders the correct HTML with external attribute', function(assert) {
   );
 });
 
+test('it renders the correct HTML with monochrome attribute', function(assert) {
+  this.render(hbs`
+    {{polaris-link
+      url="http://www.somewhere.com/"
+      monochrome=true
+      text="Testing monochrome attribute"
+    }}
+  `);
+
+  const links = findAll(linkSelector);
+  assert.equal(links.length, 1, 'renders one link');
+
+  const link = links[0];
+  assert.ok(
+    link.classList.contains('Polaris-Link--monochrome'),
+    'sets the monochrome class on the link'
+  );
+});
+
 test('it renders the correct HTML in basic inline usage without a URL', function(assert) {
   this.render(hbs`{{polaris-link text="This is an inline link button"}}`);
 

--- a/tests/integration/components/polaris-link-test.js
+++ b/tests/integration/components/polaris-link-test.js
@@ -123,6 +123,7 @@ test('it renders the correct HTML in basic inline usage without a URL', function
     'This is an inline link button',
     'renders the correct link text'
   );
+  assert.equal(linkButton.type, 'button', 'renders the correct button type');
 });
 
 test('it renders the correct HTML in basic block usage without a URL', function(assert) {


### PR DESCRIPTION
Adds support for `monochrome` `polaris-link`s and ensures the correct `type` is used when link buttons are rendered.