### PR TITLE
Update option list to Polaris v3.10.0

### DIFF
--- a/addon/components/polaris-option-list.js
+++ b/addon/components/polaris-option-list.js
@@ -10,6 +10,7 @@ import layout from '../templates/components/polaris-option-list';
 export default Component.extend({
   tagName: 'ul',
   classNames: ['Polaris-OptionList'],
+  attributeBindings: ['role'],
 
   layout,
 

--- a/addon/templates/components/polaris-option-list.hbs
+++ b/addon/templates/components/polaris-option-list.hbs
@@ -1,7 +1,7 @@
 {{#each normalizedOptions as |normalizedOption sectionIndex|}}
   <li>
     {{#if normalizedOption.title}}
-      <p class="Polaris-OptionList__Title" role="presentation">
+      <p class="Polaris-OptionList__Title" role={{role}}>
         {{normalizedOption.title}}
       </p>
     {{/if}}

--- a/addon/templates/components/polaris-option-list/option.hbs
+++ b/addon/templates/components/polaris-option-list/option.hbs
@@ -28,6 +28,7 @@
   </label>
 {{else}}
   <button
+    id={{optionId}}
     type="button"
     class="
       Polaris-OptionList-Option__SingleSelectOption

--- a/tests/integration/components/polaris-option-list-test.js
+++ b/tests/integration/components/polaris-option-list-test.js
@@ -347,7 +347,7 @@ module('Integration | Component | polaris-option-list', function(hooks) {
       .exists({ count: totalOptions(newOptions, undefined) });
   });
 
-  test('calls onChange with the correct value', async function(assert) {
+  test('calls onChange with options and sections', async function(assert) {
     const { options, sections } = defaultProps;
     await render(hbs`
       {{polaris-option-list

--- a/tests/integration/components/polaris-option-list/checkbox-test.js
+++ b/tests/integration/components/polaris-option-list/checkbox-test.js
@@ -20,7 +20,7 @@ module('Integration | Component | polaris-option-list/checkbox', function(
     this.set('defaultProps', defaultProps);
   });
 
-  test('sets all pass through props for input', async function(assert) {
+  test('sets pass through props for input', async function(assert) {
     await render(hbs`
         {{polaris-option-list/checkbox
           checked=defaultProps.checked

--- a/tests/integration/components/polaris-option-list/option-test.js
+++ b/tests/integration/components/polaris-option-list/option-test.js
@@ -45,7 +45,7 @@ module('Integration | Component | polaris-option-list/option', function(hooks) {
     assert.dom('button').exists();
   });
 
-  test('calls onClick with correct section and index if option is not disabled', async function(assert) {
+  test('calls onClick with section and index if option is not disabled', async function(assert) {
     assert.expect(2);
 
     this.set('onOptionClicked', (optionSection, optionIndex) => {
@@ -86,7 +86,7 @@ module('Integration | Component | polaris-option-list/option', function(hooks) {
     assert.notOk(this.get('wasOnClickCalled'));
   });
 
-  test('calls onClick with correct section and index if option is not disabled and multiple options are allowed', async function(assert) {
+  test('calls onClick with section and index if option is not disabled and multiple options are allowed', async function(assert) {
     assert.expect(2);
 
     this.set('onOptionClicked', (optionSection, optionIndex) => {
@@ -129,7 +129,7 @@ module('Integration | Component | polaris-option-list/option', function(hooks) {
     assert.notOk(this.get('wasOnClickCalled'));
   });
 
-  test('correctly sets the pass through props for Checkbox if multiple items are allowed', async function(assert) {
+  test('sets the pass through props for Checkbox if multiple items are allowed', async function(assert) {
     await render(hbs`
       {{polaris-option-list/option
         optionId=defaultProps.id


### PR DESCRIPTION
Updates usage of the `role` property on `polaris-option-list` and tweaks a few test descriptions.