### PR TITLE
Update resource list to Polaris v3.10.0

### DIFF
--- a/addon/components/polaris-resource-list.js
+++ b/addon/components/polaris-resource-list.js
@@ -225,6 +225,7 @@ export default Component.extend(
     /**
      * @property selectMode
      * @type {Boolean}
+     * @default false
      * @private
      */
     selectMode: false,
@@ -236,6 +237,17 @@ export default Component.extend(
      * @private
      */
     loadingPosition: 0,
+
+    /**
+     * Reference to the `ul` element that makes up the main list.
+     * This is used in place of the React implementation's `listRef`.
+     *
+     * @property listNode
+     * @type {HTMLUListElement}
+     * @default null
+     * @private
+     */
+    listNode: null,
 
     /**
      * @property defaultResourceName
@@ -274,18 +286,6 @@ export default Component.extend(
     wrapperId: computed(function() {
       return guidFor(this);
     }).readOnly(),
-
-    /**
-     * Reference to the `ul` element that makes up the main list.
-     * This is used in place of the React implementation's `listRef`.
-     */
-    listNode: computed(function() {
-      return (
-        document.querySelector(
-          `#${this.get('wrapperId')} ul.Polaris-ResourceList`
-        ) || null
-      );
-    }).volatile(),
 
     /**
      * List of item/id tuples needed for rendering items
@@ -740,6 +740,14 @@ export default Component.extend(
       }
     },
 
+    setListNode() {
+      let listNode =
+        document.querySelector(
+          `#${this.get('wrapperId')} ul.Polaris-ResourceList`
+        ) || null;
+      this.set('listNode', listNode);
+    },
+
     init() {
       this._super(...arguments);
 
@@ -812,6 +820,12 @@ export default Component.extend(
       if (this.get('loading')) {
         this.setLoadingPosition();
       }
+    },
+
+    didRender() {
+      this._super(...arguments);
+
+      this.setListNode();
     },
   }
 );

--- a/addon/components/polaris-resource-list/item.js
+++ b/addon/components/polaris-resource-list/item.js
@@ -16,6 +16,7 @@ export default Component.extend(context.ConsumerMixin, {
     'persistActions:Polaris-ResourceList-Item--persistActions',
     'focusedInner:Polaris-ResourceList-Item--focusedInner',
   ],
+  attributeBindings: ['url:data-href'],
 
   layout,
 
@@ -221,6 +222,7 @@ export default Component.extend(context.ConsumerMixin, {
       'selectMode',
       'element'
     );
+    let { ctrlKey, metaKey } = event;
     let anchor = element && element.querySelector('a');
 
     if (selectMode) {
@@ -234,6 +236,11 @@ export default Component.extend(context.ConsumerMixin, {
 
     if (onClick) {
       onClick(itemId);
+    }
+
+    if (url && (ctrlKey || metaKey)) {
+      window.open(url, '_blank');
+      return;
     }
 
     if (url && anchor) {

--- a/addon/components/polaris-resource-list/loading-overlay.js
+++ b/addon/components/polaris-resource-list/loading-overlay.js
@@ -1,0 +1,10 @@
+import Component from '@ember/component';
+
+/**
+ * Internal component used to DRY up rendering resource list loading state.
+ */
+export default Component.extend({
+  loading: false,
+  spinnerStyle: null,
+  spinnerSize: null,
+});

--- a/addon/components/polaris-resource-list/loading-overlay.js
+++ b/addon/components/polaris-resource-list/loading-overlay.js
@@ -1,9 +1,14 @@
 import Component from '@ember/component';
+import layout from '../../templates/components/polaris-resource-list/loading-overlay';
 
 /**
  * Internal component used to DRY up rendering resource list loading state.
  */
 export default Component.extend({
+  tagName: '',
+
+  layout,
+
   loading: false,
   spinnerStyle: null,
   spinnerSize: null,

--- a/addon/components/polaris-unstyled-link.js
+++ b/addon/components/polaris-unstyled-link.js
@@ -20,6 +20,7 @@ export default Component.extend({
     'rel',
     'ariaLabel:aria-label',
     'ariaDescribedBy:aria-describedby',
+    'tabIndex:tabindex',
   ],
 
   layout,

--- a/addon/templates/components/polaris-resource-list.hbs
+++ b/addon/templates/components/polaris-resource-list.hbs
@@ -1,145 +1,164 @@
 {{#polaris-resource-list/provider value=context}}
-  <div class="Polaris-ResourceList__ResourceListWrapper" id={{wrapperId}}>
-    {{#if filterControl}}
-      <div class="Polaris-ResourceList__FiltersWrapper">
-        {{render-content filterControl}}
-      </div>
-    {{/if}}
+  {{#with
+    (component "polaris-resource-list/loading-overlay"
+      loading=loading
+      spinnerStyle=spinnerStyle
+      spinnerSize=spinnerSize
+    )
+    as |loadingOverlay|
+  }}
+    <div class="Polaris-ResourceList__ResourceListWrapper" id={{wrapperId}}>
+      {{#if filterControl}}
+        <div class="Polaris-ResourceList__FiltersWrapper">
+          {{render-content filterControl}}
+        </div>
+      {{/if}}
 
-    {{#if (and
-      (or showHeader needsHeader)
-      listNode
-      itemsExist
-    )}}
-      <div class="Polaris-ResourceList__HeaderOuterWrapper">
-        {{#polaris-sticky boundingElement=listNode as |sticky|}}
-          <div
-            data-test-id="resource-list-header"
-            class="
-              Polaris-ResourceList__HeaderWrapper
-              {{if sortOptions.length "Polaris-ResourceList__HeaderWrapper--hasSort"}}
-              {{if selectable "Polaris-ResourceList__HeaderWrapper--hasSelect"}}
-              {{if loading "Polaris-ResourceList__HeaderWrapper--disabled"}}
-              {{if (and selectable selectMode) "Polaris-ResourceList__HeaderWrapper--inSelectMode"}}
-              {{if sticky.isSticky "Polaris-ResourceList__HeaderWrapper--isSticky"}}
-            "
-          >
-            {{#if loading}}
-              <div class="Polaris-ResourceList__HeaderWrapper--overlay"></div>
-            {{/if}}
+      {{#if (and
+        (or showHeader needsHeader)
+        listNode
+        itemsExist
+      )}}
+        <div class="Polaris-ResourceList__HeaderOuterWrapper">
+          {{#polaris-sticky boundingElement=listNode as |sticky|}}
+            <div
+              data-test-id="resource-list-header"
+              class="
+                Polaris-ResourceList__HeaderWrapper
+                {{if (and sortOptions.length (not alternateTool)) "Polaris-ResourceList__HeaderWrapper--hasSort"}}
+                {{if selectable "Polaris-ResourceList__HeaderWrapper--hasSelect"}}
+                {{if alternateTool "Polaris-ResourceList__HeaderWrapper--hasAlternateTool"}}
+                {{if loading "Polaris-ResourceList__HeaderWrapper--disabled"}}
+                {{if (and selectable selectMode) "Polaris-ResourceList__HeaderWrapper--inSelectMode"}}
+                {{if sticky.isSticky "Polaris-ResourceList__HeaderWrapper--isSticky"}}
+              "
+            >
+              {{#if loading}}
+                <div class="Polaris-ResourceList__HeaderWrapper--overlay"></div>
+              {{/if}}
 
-            <div class="Polaris-ResourceList__HeaderContentWrapper">
-              <div
-                class="Polaris-ResourceList__ItemCountTextWrapper"
-                data-test-id="item-count-text-wrapper"
-              >
-                {{itemCountText}}
+              <div class="Polaris-ResourceList__HeaderContentWrapper">
+                <div
+                  class="Polaris-ResourceList__HeaderTitleWrapper"
+                  data-test-id="header-title-wrapper"
+                >
+                  {{headerTitle}}
+                </div>
+
+                {{#if selectable}}
+                  <div class="Polaris-ResourceList__CheckableButtonWrapper">
+                    {{polaris-resource-list/checkable-button
+                      plain=true
+                      disabled=loading
+                      accessibilityLabel=bulkActionsAccessibilityLabel
+                      label=headerTitle
+                      onToggleAll=(action handleToggleAll)
+                    }}
+                  </div>
+                {{/if}}
+
+                {{#if (and alternateTool (not sortOptions))}}
+                  <div class="Polaris-ResourceList__AlternateToolWrapper">
+                    {{render-content alternateTool}}
+                  </div>
+                {{/if}}
+
+                {{#if (and sortOptions (not alternateTool))}}
+                  <div class="Polaris-ResourceList__SortWrapper">
+                    <label class="Polaris-ResourceList__SortLabel" htmlFor={{selectId}}>
+                      Sort by
+                    </label>
+
+                    {{polaris-select
+                      label="Sort by"
+                      labelHidden=true
+                      options=sortOptions
+                      value=(or sortValue "")
+                      disabled=selectMode
+                      onChange=(action onSortChange)
+                    }}
+                  </div>
+                {{/if}}
+
+                {{#if selectable}}
+                  <div class="Polaris-ResourceList__SelectButtonWrapper">
+                    {{!-- TODO: include enable-selection icon --}}
+                    {{polaris-button
+                      text="Select"
+                      disabled=selectMode
+                      icon="enable-selection"
+                      onClick=(action handleSelectMode true)
+                    }}
+                  </div>
+                {{/if}}
               </div>
 
               {{#if selectable}}
-                <div class="Polaris-ResourceList__CheckableButtonWrapper">
-                  {{polaris-resource-list/checkable-button
-                    plain=true
-                    disabled=loading
+                <div class="Polaris-ResourceList__BulkActionsWrapper">
+                  {{polaris-resource-list/bulk-actions
+                    label=bulkActionsLabel
                     accessibilityLabel=bulkActionsAccessibilityLabel
-                    label=itemCountText
+                    selected=bulkSelectState
                     onToggleAll=(action handleToggleAll)
-                  }}
-                </div>
-              {{/if}}
-
-              {{#if sortOptions}}
-                <div class="Polaris-ResourceList__SortWrapper">
-                  <label class="Polaris-ResourceList__SortLabel" htmlFor={{selectId}}>
-                    Sort by
-                  </label>
-
-                  {{polaris-select
-                    label="Sort by"
-                    labelHidden=true
-                    options=sortOptions
-                    value=(or sortValue "")
-                    disabled=selectMode
-                    onChange=(action onSortChange)
-                  }}
-                </div>
-              {{/if}}
-
-              {{#if selectable}}
-                <div class="Polaris-ResourceList__SelectButtonWrapper">
-                  {{!-- TODO: include enable-selection icon --}}
-                  {{polaris-button
-                    text="Select"
-                    disabled=selectMode
-                    icon="enable-selection"
-                    onClick=(action handleSelectMode true)
+                    selectMode=selectMode
+                    onSelectModeToggle=(action handleSelectMode)
+                    promotedActions=promotedBulkActions
+                    paginatedSelectAllAction=paginatedSelectAllAction
+                    paginatedSelectAllText=paginatedSelectAllText
+                    actionsCollection=bulkActions
+                    disabled=loading
                   }}
                 </div>
               {{/if}}
             </div>
+          {{/polaris-sticky}}
+        </div>
+      {{/if}}
 
-            {{#if selectable}}
-              <div class="Polaris-ResourceList__BulkActionsWrapper">
-                {{polaris-resource-list/bulk-actions
-                  label=bulkActionsLabel
-                  accessibilityLabel=bulkActionsAccessibilityLabel
-                  selected=bulkSelectState
-                  onToggleAll=(action handleToggleAll)
-                  selectMode=selectMode
-                  onSelectModeToggle=(action handleSelectMode)
-                  promotedActions=promotedBulkActions
-                  paginatedSelectAllAction=paginatedSelectAllAction
-                  paginatedSelectAllText=paginatedSelectAllText
-                  actionsCollection=bulkActions
-                  disabled=loading
-                }}
-              </div>
-            {{/if}}
-          </div>
-        {{/polaris-sticky}}
-      </div>
-    {{/if}}
+      {{#if itemsExist}}
+        {{!--
+          NOTE: Polaris-ResourceList--disabledPointerEvents doesn't exist at this point,
+          but Polaris-ResourceList__DisabledPointerEvents does. The former is probably
+          what was intended in the React source, so matching that for now as the class
+          doesn't seem to be necessary for the list's `loading` behaviour to work.
+        --}}
+        <ul
+          class="Polaris-ResourceList {{if loading "Polaris-ResourceList--disabledPointerEvents"}}"
+          aria-live="polite"
+          aria-busy={{loading}}
+        >
+          {{component loadingOverlay}}
 
-    {{#if itemsExist}}
-      {{!--
-        NOTE: Polaris-ResourceList--disabledPointerEvents doesn't exist at this point,
-        but Polaris-ResourceList__DisabledPointerEvents does. The former is probably
-        what was intended in the React source, so matching that for now as the class
-        doesn't seem to be necessary for the list's `loading` behaviour to work.
-      --}}
-      <ul
-        class="Polaris-ResourceList {{if loading "Polaris-ResourceList--disabledPointerEvents"}}"
-        aria-live="polite"
-        aria-busy={{loading}}
-      >
-        {{#if loading}}
-          <div class="Polaris-ResourceList__SpinnerContainer" style={{spinnerStyle}}>
-            {{polaris-spinner
-              accessibilityLabel="Items are loading"
-              size=spinnerSize
-            }}
-          </div>
-          <div class="Polaris-ResourceList__LoadingOverlay"></div>
-        {{/if}}
+          {{#each itemsWithId as |itemWithId|}}
+            <li
+              class="Polaris-ResourceList__ItemWrapper"
+              data-test-item-id={{itemWithId.id}}
+            >
+              {{component itemComponent item=itemWithId.item itemId=itemWithId.id}}
+            </li>
+          {{/each}}
+        </ul>
+      {{else if showEmptyState}}
+        <div class="Polaris-ResourceList__EmptySearchResultWrapper">
+          {{polaris-empty-search-result
+            withIllustration=true
+            description="Try changing the filters or search term"
+            title=emptySearchResultTitle
+          }}
+        </div>
+      {{/if}}
 
-        {{#each itemsWithId as |itemWithId|}}
-          <li
-            class="Polaris-ResourceList__ItemWrapper"
-            data-test-item-id={{itemWithId.id}}
-            tabIndex={{if loading -1 0}}
-          >
-            {{component itemComponent item=itemWithId.item itemId=itemWithId.id}}
-          </li>
-        {{/each}}
-      </ul>
-    {{else if showEmptyState}}
-      <div class="Polaris-ResourceList__EmptySearchResultWrapper">
-        {{polaris-empty-search-result
-          withIllustration=true
-          description="Try changing the filters or search term"
-          title=emptySearchResultTitle
-        }}
-      </div>
-    {{/if}}
-  </div>
+      {{#if (and loading (not itemsExist))}}
+        <div
+          class="
+            Polaris-ResourceList__ItemWrapper
+            {{if loading "Polaris-ResourceList__ItemWrapper--isLoading"}}
+          "
+          tabIndex="-1"
+        >
+          {{component loadingOverlay}}
+        </div>
+      {{/if}}
+    </div>
+  {{/with}}
 {{/polaris-resource-list/provider}}

--- a/addon/templates/components/polaris-resource-list.hbs
+++ b/addon/templates/components/polaris-resource-list.hbs
@@ -57,12 +57,6 @@
                   </div>
                 {{/if}}
 
-                {{#if (and alternateTool (not sortOptions))}}
-                  <div class="Polaris-ResourceList__AlternateToolWrapper">
-                    {{render-content alternateTool}}
-                  </div>
-                {{/if}}
-
                 {{#if (and sortOptions (not alternateTool))}}
                   <div class="Polaris-ResourceList__SortWrapper">
                     <label class="Polaris-ResourceList__SortLabel" htmlFor={{selectId}}>
@@ -77,6 +71,10 @@
                       disabled=selectMode
                       onChange=(action onSortChange)
                     }}
+                  </div>
+                {{else if alternateTool}}
+                  <div class="Polaris-ResourceList__AlternateToolWrapper">
+                    {{render-content alternateTool}}
                   </div>
                 {{/if}}
 

--- a/addon/templates/components/polaris-resource-list/item.hbs
+++ b/addon/templates/components/polaris-resource-list/item.hbs
@@ -1,24 +1,28 @@
-{{#if url}}
-  {{polaris-unstyled-link
-    class="Polaris-ResourceList-Item__Link"
-    ariaDescribedBy=itemId
-    ariaLabel=accessibilityLabel
-    url=url
-    focusIn=(action handleAnchorFocus)
-    focusOut=(action handleFocusedBlur)
-  }}
-{{else}}
-  {{wrapper-element
-    tagName="button"
-    class="Polaris-ResourceList-Item__Button"
-    aria-label=accessibilityLabel
-    aria-controls=ariaControls
-    aria-expanded=ariaExpanded
-    click=(action handleClick)
-    focusIn=(action handleAnchorFocus)
-    focusOut=(action handleFocusedBlur)
-  }}
-{{/if}}
+{{#with (if loading "-1" "0") as |tabIndex|}}
+  {{#if url}}
+    {{polaris-unstyled-link
+      class="Polaris-ResourceList-Item__Link"
+      ariaDescribedBy=itemId
+      ariaLabel=accessibilityLabel
+      url=url
+      focusIn=(action handleAnchorFocus)
+      focusOut=(action handleFocusedBlur)
+      tabIndex=tabIndex
+    }}
+  {{else}}
+    {{wrapper-element
+      tagName="button"
+      class="Polaris-ResourceList-Item__Button"
+      aria-label=accessibilityLabel
+      aria-controls=ariaControls
+      aria-expanded=ariaExpanded
+      click=(action handleClick)
+      focusIn=(action handleAnchorFocus)
+      focusOut=(action handleFocusedBlur)
+      tabIndex=tabIndex
+    }}
+  {{/if}}
+{{/with}}
 
 <div
   data-test-id="item-content"
@@ -69,7 +73,7 @@
     </div>
   {{/if}}
 
-  {{#if shortcutActions}}
+  {{#if (and shortcutActions (not loading))}}
     {{#wrapper-element
       tagName="div"
       class="Polaris-ResourceList-Item__Actions"

--- a/addon/templates/components/polaris-resource-list/loading-overlay.hbs
+++ b/addon/templates/components/polaris-resource-list/loading-overlay.hbs
@@ -1,0 +1,9 @@
+{{#if loading}}
+  <div class="Polaris-ResourceList__SpinnerContainer" style={{spinnerStyle}}>
+    {{polaris-spinner
+      accessibilityLabel="Items are loading"
+      size=spinnerSize
+    }}
+  </div>
+  <div class="Polaris-ResourceList__LoadingOverlay"></div>
+{{/if}}

--- a/app/components/polaris-resource-list/loading-overlay.js
+++ b/app/components/polaris-resource-list/loading-overlay.js
@@ -1,0 +1,3 @@
+export {
+  default,
+} from '@smile-io/ember-polaris/components/polaris-resource-list/loading-overlay';

--- a/tests/helpers/component-attribute-capture.js
+++ b/tests/helpers/component-attribute-capture.js
@@ -1,0 +1,17 @@
+export function setUpAttributeCaptureOnComponent(
+  testContext,
+  componentPath,
+  componentClass,
+  attributeName
+) {
+  testContext.owner.register(
+    `component:${componentPath}`,
+    componentClass.extend({
+      didReceiveAttrs() {
+        this._super(...arguments);
+
+        testContext.set(attributeName, this.get(attributeName));
+      },
+    })
+  );
+}

--- a/tests/integration/components/polaris-resource-list-test.js
+++ b/tests/integration/components/polaris-resource-list-test.js
@@ -6,6 +6,7 @@ import { computed } from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
 import BulkActionsComponent from '@smile-io/ember-polaris/components/polaris-resource-list/bulk-actions';
 import SelectComponent from '@smile-io/ember-polaris/components/polaris-select';
+import { setUpAttributeCaptureOnComponent } from '../../helpers/component-attribute-capture';
 
 const itemsNoID = [{ url: 'item 1' }, { url: 'item 2' }];
 const singleItemNoID = [{ url: 'item 1' }];
@@ -68,24 +69,6 @@ const ItemComponent = Component.extend({
     return `View details for ${this.get('item.title')}`;
   }).readOnly(),
 });
-
-function setUpAttributeCaptureOnComponent(
-  testContext,
-  componentPath,
-  componentClass,
-  attributeName
-) {
-  testContext.owner.register(
-    `component:${componentPath}`,
-    componentClass.extend({
-      didReceiveAttrs() {
-        this._super(...arguments);
-
-        testContext.set(attributeName, this.get(attributeName));
-      },
-    })
-  );
-}
 
 module('Integration | Component | polaris-resource-list', function(hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/polaris-resource-list-test.js
+++ b/tests/integration/components/polaris-resource-list-test.js
@@ -198,7 +198,7 @@ module('Integration | Component | polaris-resource-list', function(hooks) {
           }}
         `);
         assert
-          .dom('[data-test-id="item-count-text-wrapper"]')
+          .dom('[data-test-id="header-title-wrapper"]')
           .hasText('Showing 1 item');
       });
 
@@ -212,7 +212,7 @@ module('Integration | Component | polaris-resource-list', function(hooks) {
           }}
         `);
         assert
-          .dom('[data-test-id="item-count-text-wrapper"]')
+          .dom('[data-test-id="header-title-wrapper"]')
           .hasText('Showing 1 product');
       });
     });
@@ -223,7 +223,7 @@ module('Integration | Component | polaris-resource-list', function(hooks) {
           {{polaris-resource-list items=itemsNoID itemComponent="item-component" showHeader=true}}
         `);
         assert
-          .dom('[data-test-id="item-count-text-wrapper"]')
+          .dom('[data-test-id="header-title-wrapper"]')
           .hasText('Showing 2 items');
       });
 
@@ -237,9 +237,26 @@ module('Integration | Component | polaris-resource-list', function(hooks) {
           }}
         `);
         assert
-          .dom('[data-test-id="item-count-text-wrapper"]')
+          .dom('[data-test-id="header-title-wrapper"]')
           .hasText('Showing 2 products');
       });
+    });
+  });
+
+  module('headerTitle', function() {
+    test('prints loading text when loading is true', async function(assert) {
+      await render(hbs`
+        {{polaris-resource-list
+          items=singleItemWithID
+          itemComponent="item-component"
+          bulkActions=bulkActions
+          loading=true
+        }}
+      `);
+
+      assert
+        .dom('[data-test-id="header-title-wrapper"]')
+        .hasText('Loading items');
     });
   });
 
@@ -279,7 +296,7 @@ module('Integration | Component | polaris-resource-list', function(hooks) {
         assert.equal(this.get('accessibilityLabel'), 'Deselect item');
       });
 
-      test('provides the BulkActions with the right accessibilityLabel if there’s multiple items and they are all selected', async function(assert) {
+      test('provides the BulkActions with the right accessibilityLabel if there are multiple items and they are selected', async function(assert) {
         await render(hbs`
         {{polaris-resource-list
           items=itemsWithID
@@ -377,6 +394,17 @@ module('Integration | Component | polaris-resource-list', function(hooks) {
       assert.dom('[data-test-id="resource-list-header"]').exists();
     });
 
+    test('renders when an alternateTool is provided', async function(assert) {
+      await render(hbs`
+        {{polaris-resource-list
+          alternateTool=(component "wrapper-element" class="AlternateTool")
+          items=itemsWithID
+          itemComponent="item-component"
+        }}
+      `);
+      assert.dom('[data-test-id="resource-list-header"]').exists();
+    });
+
     test('renders when bulkActions are given', async function(assert) {
       await render(hbs`
         {{polaris-resource-list
@@ -404,6 +432,21 @@ module('Integration | Component | polaris-resource-list', function(hooks) {
         {{polaris-resource-list items=itemsWithID itemComponent="item-component"}}
       `);
       assert.dom('[data-test-id="resource-list-header"]').doesNotExist();
+    });
+
+    test('renders on non-initial load when items are provided', async function(assert) {
+      this.set('items', []);
+      await render(hbs`
+        {{polaris-resource-list
+          bulkActions=bulkActions
+          items=items
+          itemComponent="item-component"
+        }}
+      `);
+      assert.dom('[data-test-id="resource-list-header"]').doesNotExist();
+
+      this.set('items', itemsWithID);
+      assert.dom('[data-test-id="resource-list-header"]').exists({ count: 1 });
     });
   });
 
@@ -452,6 +495,17 @@ module('Integration | Component | polaris-resource-list', function(hooks) {
       `);
       assert.dom('.Polaris-EmptySearchResult').doesNotExist();
     });
+
+    test('does not render when filterControl exists, items is empty, and loading is true', async function(assert) {
+      await render(hbs`
+        {{polaris-resource-list
+          items=(array)
+          itemComponent="shallow-item-component"
+          filterControl=(component "wrapper-element")
+        }}
+      `);
+      assert.dom('.Polaris-EmptySearchResult').doesNotExist();
+    });
   });
 
   module('Sorting', function() {
@@ -471,6 +525,53 @@ module('Integration | Component | polaris-resource-list', function(hooks) {
         }}
       `);
       assert.dom('.Polaris-Select').exists();
+    });
+
+    test('does not render a sort select if an alternateTool is provided', async function(assert) {
+      await render(hbs`
+        {{polaris-resource-list
+          items=itemsWithID
+          sortOptions=sortOptions
+          itemComponent="item-component"
+          alternateTool=(component "wrapper-element" class="AlternateTool")
+        }}
+      `);
+      assert.dom('.Polaris-Select').doesNotExist();
+    });
+
+    module('Alternate Tool', function() {
+      test('does not render if an alternateTool is not provided', async function(assert) {
+        await render(hbs`
+          {{polaris-resource-list
+            items=itemsWithID
+            itemComponent="item-component"
+          }}
+        `);
+        assert.dom('.AlternateTool').doesNotExist();
+      });
+
+      test('renders if an alternateTool is provided', async function(assert) {
+        await render(hbs`
+          {{polaris-resource-list
+            items=itemsWithID
+            itemComponent="item-component"
+            alternateTool=(component "wrapper-element" class="AlternateTool")
+          }}
+        `);
+        assert.dom('.AlternateTool').exists();
+      });
+
+      test('renders even if sortOptions are provided', async function(assert) {
+        await render(hbs`
+          {{polaris-resource-list
+            items=itemsWithID
+            itemComponent="item-component"
+            sortOptions=sortOptions
+            alternateTool=(component "wrapper-element" class="AlternateTool")
+          }}
+        `);
+        assert.dom('.AlternateTool').exists();
+      });
     });
 
     module(
@@ -558,6 +659,33 @@ module('Integration | Component | polaris-resource-list', function(hooks) {
       // Checking for spinner container here because currently
       // our tests can't render SVGs so the spinner doesn't appear.
       assert.dom('.Polaris-ResourceList__SpinnerContainer').exists();
+    });
+
+    test('does not render an <Item /> if loading is true and there are no items', async function(assert) {
+      await render(hbs`
+        {{polaris-resource-list
+          items=(array)
+          sortOptions=sortOptions
+          itemComponent="item-component"
+          loading=true
+        }}
+      `);
+
+      assert.dom('[data-test-id="item-wrapper"]').doesNotExist();
+    });
+  });
+
+  module('BulkActions', function() {
+    test('renders on initial load when items are selected', async function(assert) {
+      await render(hbs`
+        {{polaris-resource-list
+          items=singleItemWithID
+          itemComponent="item-component"
+          bulkActions=bulkActions
+          selectedItems=(array "1")
+        }}
+      `);
+      assert.dom('[data-test-bulk-actions]').exists({ count: 1 });
     });
   });
 });

--- a/tests/integration/components/polaris-resource-list/bulk-actions-test.js
+++ b/tests/integration/components/polaris-resource-list/bulk-actions-test.js
@@ -50,180 +50,187 @@ module('Integration | Component | polaris-resource-list/bulk-actions', function(
 ) {
   setupRenderingTest(hooks);
 
-  test('promotedActions render in the correct position on intial load', async function(assert) {
-    this.setProperties({
-      promotedActions,
+  module('actions', function() {
+    test('promotedActions render in the last position on intial load', async function(assert) {
+      this.setProperties({
+        promotedActions,
+      });
+
+      await render(hbs`
+        {{polaris-resource-list/bulk-actions
+          promotedActions=promotedActions
+          selectMode=true
+        }}
+      `);
+
+      let allActionsButtons = findAll(actionsButtonGroupButtonsSelector);
+
+      assert.equal(
+        allActionsButtons[0].textContent.trim(),
+        'button 1',
+        'first promoted action is the first button rendered'
+      );
+      assert.equal(
+        allActionsButtons[1].textContent.trim(),
+        'button 2',
+        'second promoted action is the second button rendered'
+      );
     });
 
-    await render(hbs`
-      {{polaris-resource-list/bulk-actions
-        promotedActions=promotedActions
-        selectMode=true
-      }}
-    `);
+    test('actionsCollection actions render in the first position on initial load', async function(assert) {
+      this.setProperties({
+        actionsCollection,
+        promotedActions,
+      });
 
-    let allActionsButtons = findAll(actionsButtonGroupButtonsSelector);
+      await render(hbs`
+        {{polaris-resource-list/bulk-actions
+          actionsCollection=actionsCollection
+          promotedActions=promotedActions
+          selectMode=true
+        }}
+      `);
 
-    assert.equal(
-      allActionsButtons[0].textContent.trim(),
-      'button 1',
-      'first promoted action is the first button rendered'
-    );
-    assert.equal(
-      allActionsButtons[1].textContent.trim(),
-      'button 2',
-      'second promoted action is the second button rendered'
-    );
+      assert
+        .dom(actionsButtonGroupSelector)
+        .doesNotIncludeText(
+          'button 3',
+          'non promoted actions are not rendered (button 3)'
+        );
+      assert
+        .dom(actionsButtonGroupSelector)
+        .doesNotIncludeText(
+          'button 4',
+          'non promoted actions are not rendered (button 4)'
+        );
+      assert
+        .dom(actionsButtonGroupSelector)
+        .doesNotIncludeText(
+          'button 5',
+          'non promoted actions are not rendered (button 5)'
+        );
+    });
+
+    test('it renders a popover', async function(assert) {
+      this.setProperties({
+        actionsCollection,
+      });
+
+      await render(hbs`
+        {{polaris-resource-list/bulk-actions
+          actionsCollection=actionsCollection
+          selectMode=true
+        }}
+      `);
+
+      assert
+        .dom(actionsPopoverSelector)
+        .exists('it renders a popover when actionsCollection is present');
+    });
   });
 
-  test('actionsCollection actions render in the correct position on initial load', async function(assert) {
-    this.setProperties({
-      actionsCollection,
-      promotedActions,
-    });
+  module('props', function() {
+    test('it correctly passes attributes down to checkable-button component', async function(assert) {
+      let label = 'Test-Label';
+      let accessibilityLabel = 'test-aria-label';
 
-    await render(hbs`
-      {{polaris-resource-list/bulk-actions
-        actionsCollection=actionsCollection
-        promotedActions=promotedActions
-        selectMode=true
-      }}
-    `);
-
-    assert
-      .dom(actionsButtonGroupSelector)
-      .doesNotIncludeText(
-        'button 3',
-        'non promoted actions are not rendered (button 3)'
-      );
-    assert
-      .dom(actionsButtonGroupSelector)
-      .doesNotIncludeText(
-        'button 4',
-        'non promoted actions are not rendered (button 4)'
-      );
-    assert
-      .dom(actionsButtonGroupSelector)
-      .doesNotIncludeText(
-        'button 5',
-        'non promoted actions are not rendered (button 5)'
-      );
-  });
-
-  test('it renders a popover', async function(assert) {
-    this.setProperties({
-      actionsCollection,
-    });
-
-    await render(hbs`
-      {{polaris-resource-list/bulk-actions
-        actionsCollection=actionsCollection
-        selectMode=true
-      }}
-    `);
-
-    assert
-      .dom(actionsPopoverSelector)
-      .exists('it renders a popover when actionsCollection is present');
-  });
-
-  test('it correctly passes attributes down to checkable-button component', async function(assert) {
-    let label = 'Test-Label';
-    let accessibilityLabel = 'test-aria-label';
-
-    this.setProperties({
-      label,
-      accessibilityLabel,
-      disabled: true,
-    });
-
-    await render(hbs`
-      {{polaris-resource-list/bulk-actions
-        selectMode=true
-        label=label
-        accessibilityLabel=accessibilityLabel
-        disabled=disabled
-      }}
-    `);
-
-    assert
-      .dom(checkableButtonLabelSelector)
-      .hasText(label, 'label is passed down and rendered in checkable-button');
-    assert
-      .dom(checkableButtonAriaLabelSelector)
-      .hasText(
+      this.setProperties({
+        label,
         accessibilityLabel,
-        'accessibilityLabel is passed down and rendered in checkable-button'
-      );
-    assert
-      .dom(checkableButtonCheckboxSelector)
-      .hasAttribute(
-        'disabled',
-        '',
-        'disabled is passed down into checkable-button'
-      );
-  });
+        disabled: true,
+      });
 
-  test('renders a button for actions and one for each item in promotedActions', async function(assert) {
-    this.setProperties({
-      promotedActions,
+      await render(hbs`
+        {{polaris-resource-list/bulk-actions
+          selectMode=true
+          label=label
+          accessibilityLabel=accessibilityLabel
+          disabled=disabled
+        }}
+      `);
+
+      assert
+        .dom(checkableButtonLabelSelector)
+        .hasText(
+          label,
+          'label is passed down and rendered in checkable-button'
+        );
+      assert
+        .dom(checkableButtonAriaLabelSelector)
+        .hasText(
+          accessibilityLabel,
+          'accessibilityLabel is passed down and rendered in checkable-button'
+        );
+      assert
+        .dom(checkableButtonCheckboxSelector)
+        .hasAttribute(
+          'disabled',
+          '',
+          'disabled is passed down into checkable-button'
+        );
     });
 
-    await render(hbs`
-      {{polaris-resource-list/bulk-actions
-        promotedActions=promotedActions
-        selectMode=true
-      }}
-    `);
+    test('renders a button for actions and one for each item in promotedActions', async function(assert) {
+      this.setProperties({
+        promotedActions,
+      });
 
-    assert
-      .dom(actionsButtonGroupButtonsSelector)
-      .exists(
-        { count: 2 },
-        'it renders the correct amount of buttons for promotedActions'
-      );
-    assert
-      .dom(checkableButtonSelector)
-      .exists({ count: 1 }, 'it renders a single button for actions');
-  });
+      await render(hbs`
+        {{polaris-resource-list/bulk-actions
+          promotedActions=promotedActions
+          selectMode=true
+        }}
+      `);
 
-  test('it correctly handles paginatedSelectAllText and paginatedSelectAllAction attributes', async function(assert) {
-    let paginatedSelectAllText = 'paginated select all text string';
-    let paginatedSelectAllActionText =
-      'paginated select all action text string';
-
-    this.setProperties({
-      paginatedSelectAllText,
-      paginatedSelectAllActionText,
-      actionCalled: false,
+      assert
+        .dom(actionsButtonGroupButtonsSelector)
+        .exists(
+          { count: 2 },
+          'it renders the correct amount of buttons for promotedActions'
+        );
+      assert
+        .dom(checkableButtonSelector)
+        .exists({ count: 1 }, 'it renders a single button for actions');
     });
 
-    await render(hbs`
-      {{polaris-resource-list/bulk-actions
-        selectMode=true
-        paginatedSelectAllText=paginatedSelectAllText
-        paginatedSelectAllAction=(hash
-          content=paginatedSelectAllActionText
-          onAction=(action (mut actionCalled) true)
-        )
-      }}
-    `);
+    test('it correctly handles paginatedSelectAllText and paginatedSelectAllAction attributes', async function(assert) {
+      let paginatedSelectAllText = 'paginated select all text string';
+      let paginatedSelectAllActionText =
+        'paginated select all action text string';
 
-    assert
-      .dom(selectAllText)
-      .hasText(paginatedSelectAllText, 'paginatedSelectAllText is rendered');
-    assert
-      .dom(selectAllButton)
-      .hasText(
+      this.setProperties({
+        paginatedSelectAllText,
         paginatedSelectAllActionText,
-        'paginatedSelectAllAction `content` is rendered'
+        actionCalled: false,
+      });
+
+      await render(hbs`
+        {{polaris-resource-list/bulk-actions
+          selectMode=true
+          paginatedSelectAllText=paginatedSelectAllText
+          paginatedSelectAllAction=(hash
+            content=paginatedSelectAllActionText
+            onAction=(action (mut actionCalled) true)
+          )
+        }}
+      `);
+
+      assert
+        .dom(selectAllText)
+        .hasText(paginatedSelectAllText, 'paginatedSelectAllText is rendered');
+      assert
+        .dom(selectAllButton)
+        .hasText(
+          paginatedSelectAllActionText,
+          'paginatedSelectAllAction `content` is rendered'
+        );
+
+      await click(selectAllButton);
+
+      assert.ok(
+        this.get('actionCalled'),
+        'paginatedSelectAllAction `onAction` was called'
       );
-
-    await click(selectAllButton);
-
-    assert.ok(
-      this.get('actionCalled'),
-      'paginatedSelectAllAction `onAction` was called'
-    );
+    });
   });
 });

--- a/tests/integration/components/polaris-resource-list/filter-control-test.js
+++ b/tests/integration/components/polaris-resource-list/filter-control-test.js
@@ -1,6 +1,14 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, fillIn, click, find, triggerEvent } from '@ember/test-helpers';
+import {
+  render,
+  fillIn,
+  click,
+  find,
+  triggerEvent,
+  focus,
+  blur,
+} from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import FilterCreatorComponent from '@smile-io/ember-polaris/components/polaris-resource-list/filter-control/filter-creator';
 import { FilterType } from '@smile-io/ember-polaris/components/polaris-resource-list/filter-control/filter-value-selector';
@@ -111,131 +119,6 @@ module(
       });
     });
 
-    module('onSearchChange()', function() {
-      test('calls onSearchChange with the new searchValue when onChange is triggered', async function(assert) {
-        const newSearchValue = 'new search value';
-        await render(hbs`
-          {{#polaris-resource-list/provider value=mockDefaultContext}}
-            {{polaris-resource-list/filter-control
-              onSearchChange=(action (mut newSearchValue))
-            }}
-          {{/polaris-resource-list/provider}}
-        `);
-
-        await fillIn('.Polaris-TextField input', newSearchValue);
-
-        assert.equal(this.get('newSearchValue'), newSearchValue);
-      });
-    });
-
-    module(
-      'filters',
-      {
-        beforeEach() {
-          this.set('mockFilters', mockFilters);
-        },
-      },
-      function() {
-        test('renders no <FilterCreator/> if there are no filters', async function(assert) {
-          await render(hbs`
-            {{#polaris-resource-list/provider value=mockDefaultContext}}
-              {{polaris-resource-list/filter-control}}
-            {{/polaris-resource-list/provider}}
-          `);
-
-          assert.dom('[data-test-connected-item="left"]').doesNotExist();
-        });
-
-        test('renders <FilterCreator/> if there is filters', async function(assert) {
-          await render(hbs`
-            {{#polaris-resource-list/provider value=mockDefaultContext}}
-              {{polaris-resource-list/filter-control
-                filters=mockFilters
-              }}
-            {{/polaris-resource-list/provider}}
-          `);
-
-          assert.dom('[data-test-id="filter-activator"]').exists();
-        });
-
-        test('renders <FilterCreator/> with filters', async function(assert) {
-          let receivedFilters = null;
-          this.owner.register(
-            'component:polaris-resource-list/filter-control/filter-creator',
-            FilterCreatorComponent.extend({
-              init() {
-                this._super(...arguments);
-                receivedFilters = this.get('filters');
-              },
-            })
-          );
-          await render(hbs`
-            {{#polaris-resource-list/provider value=mockDefaultContext}}
-              {{polaris-resource-list/filter-control
-                filters=mockFilters
-              }}
-            {{/polaris-resource-list/provider}}
-          `);
-
-          assert.equal(receivedFilters, mockFilters);
-        });
-      }
-    );
-
-    module(
-      'onFiltersChange()',
-      {
-        beforeEach() {
-          this.setProperties({
-            mockFilters,
-            mockAppliedFilters,
-          });
-        },
-      },
-      function() {
-        test('gets call with the new filter when FilterCreator.onAddFilter is triggered', async function(assert) {
-          const newFilter = {
-            key: 'filterKey2',
-            value: 'new value',
-          };
-
-          await render(hbs`
-            {{#polaris-resource-list/provider value=mockDefaultContext}}
-              {{polaris-resource-list/filter-control
-                filters=mockFilters
-                appliedFilters=mockAppliedFilters
-                onFiltersChange=(action (mut newAppliedFilters))
-              }}
-            {{/polaris-resource-list/provider}}
-          `);
-
-          await triggerAddFilter(newFilter);
-
-          assert.deepEqual(this.get('newAppliedFilters'), [
-            ...mockAppliedFilters,
-            newFilter,
-          ]);
-        });
-
-        test('does not get call if the new filter already exist when FilterCreator.onAddFilter is triggered', async function(assert) {
-          const newFilter = mockAppliedFilters[0];
-          await render(hbs`
-            {{#polaris-resource-list/provider value=mockDefaultContext}}
-              {{polaris-resource-list/filter-control
-                filters=mockFilters
-                appliedFilters=mockAppliedFilters
-                onFiltersChange=(action (mut wasOnFiltersChangeCalled) true)
-              }}
-            {{/polaris-resource-list/provider}}
-          `);
-
-          await triggerAddFilter(newFilter);
-
-          assert.notOk(this.get('wasOnFiltersChangeCalled'));
-        });
-      }
-    );
-
     module(
       'appliedFilters',
       {
@@ -258,7 +141,7 @@ module(
             .exists({ count: mockAppliedFilters.length });
         });
 
-        test('calls onFiltersChange without the applied filter when user click remove on the appliedFilter', async function(assert) {
+        test('calls onFiltersChange without the applied filter when user clicks remove on the appliedFilter', async function(assert) {
           await render(hbs`
             {{#polaris-resource-list/provider value=mockDefaultContext}}
               {{polaris-resource-list/filter-control
@@ -275,7 +158,7 @@ module(
           ]);
         });
 
-        test('renders the correct applied filter string when applied filter label exist', async function(assert) {
+        test('renders the provided applied filter string when applied filter label exist', async function(assert) {
           const appliedFilterLabel = 'shorten electronic';
           const filter = {
             key: 'filterKey1',
@@ -313,7 +196,7 @@ module(
             );
         });
 
-        test('renders the correct applied filter string when filter value exist in FilterSelect as an option string', async function(assert) {
+        test('renders the provided applied filter string when filter value exist in FilterSelect as an option string', async function(assert) {
           const filterValue = 'Bundle';
           const filter = {
             key: 'filterKey1',
@@ -344,7 +227,7 @@ module(
             .hasText(`${filter.label} ${filter.operatorText} ${filterValue}`);
         });
 
-        test('renders the correct applied filter string when filter value exist in FilterSelect as an option object', async function(assert) {
+        test('renders the provided applied filter string when filter value exist in FilterSelect as an option object', async function(assert) {
           const filterValue = 'Electronic';
           const filter = {
             key: 'filterKey1',
@@ -380,7 +263,7 @@ module(
             .hasText(`${filter.label} ${filter.operatorText} ${filterValue}`);
         });
 
-        test('renders the correct applied filter string when filter value cannot be found in FilterSelect options', async function(assert) {
+        test('renders the provided applied filter string when filter value cannot be found in FilterSelect options', async function(assert) {
           const appliedFilterValue = 'new Bundle';
           const filter = {
             key: 'filterKey1',
@@ -413,7 +296,7 @@ module(
             );
         });
 
-        test('renders the correct applied filter string when filter is a FilterTextField', async function(assert) {
+        test('renders the provided applied filter string when filter is a FilterTextField', async function(assert) {
           const appliedFilterValue = 'new Bundle';
           const filter = {
             key: 'filterKey2',
@@ -445,7 +328,7 @@ module(
             );
         });
 
-        test('only renders the correct localized applied filter string when filter is a FilterDateSelector without date predicate', async function(assert) {
+        test('only renders the provided localized applied filter string when filter is a FilterDateSelector without date predicate', async function(assert) {
           const appliedFilterValue = DateFilterOption.PastWeek;
 
           const filter = {
@@ -482,7 +365,7 @@ module(
             );
         });
 
-        test('renders the correct localized applied filter string when filter is a FilterDateSelector with minimum date predicate (on or after)', async function(assert) {
+        test('renders the provided localized applied filter string when filter is a FilterDateSelector with minimum date predicate (on or after)', async function(assert) {
           const selectedDate = '2018-09-16';
           const filter = {
             key: 'starts',
@@ -518,7 +401,7 @@ module(
             .hasText(`${filter.label} ${expectedLocalizedLabel}`);
         });
 
-        test('renders the correct localized applied filter string when filter is a FilterDateSelector with maximum date predicate (on or before)', async function(assert) {
+        test('renders the provided localized applied filter string when filter is a FilterDateSelector with maximum date predicate (on or before)', async function(assert) {
           const selectedDate = '2018-09-16';
           const filter = {
             key: 'starts',
@@ -588,7 +471,7 @@ module(
             .hasText(`${filter.label} ${expectedLocalizedLabel}`);
         });
 
-        test('renders the correct applied filter string when filter uses operators with filter label', async function(assert) {
+        test('renders the provided applied filter string when filter uses operators with filter label', async function(assert) {
           const appliedFilterValue = '20';
           const appliedFilterKey = 'times_used';
           const appliedFilterLabel = 'is';
@@ -634,7 +517,7 @@ module(
             );
         });
 
-        test('renders the correct applied filter string when filter uses operators without filter label', async function(assert) {
+        test('renders the provided applied filter string when filter uses operators without filter label', async function(assert) {
           const appliedFilterValue = '20';
           const appliedFilterKey = 'times_used';
           const appliedOperatorOptionLabel = 'equal to';
@@ -680,7 +563,7 @@ module(
             );
         });
 
-        test('renders the correct applied filter string when filter key cannot be found', async function(assert) {
+        test('renders the provided applied filter string when filter key cannot be found', async function(assert) {
           const appliedFilterValue = 'new Bundle';
           const appliedFilters = {
             key: 'filter key',
@@ -697,6 +580,25 @@ module(
           `);
 
           assert.dom('.Polaris-Tag').hasText(appliedFilterValue);
+        });
+
+        test('renders a ul element containing an li element', async function(assert) {
+          const appliedFilterValue = 'new Bundle';
+          const appliedFilters = {
+            key: 'filter key',
+            value: appliedFilterValue,
+          };
+          this.set('appliedFilters', [appliedFilters]);
+          await render(hbs`
+            {{#polaris-resource-list/provider value=mockDefaultContext}}
+              {{polaris-resource-list/filter-control
+                filters=(array)
+                appliedFilters=appliedFilters
+              }}
+            {{/polaris-resource-list/provider}}
+          `);
+          assert.dom('ul').exists({ count: 1 });
+          assert.dom('li').exists({ count: 1 });
         });
       }
     );
@@ -730,5 +632,166 @@ module(
         assert.ok(this.get('wasAdditionalActionClicked'));
       });
     });
+
+    module('focused', () => {
+      test('passes its value to focus of TextField', async function(assert) {
+        await render(hbs`
+          {{#polaris-resource-list/provider value=mockDefaultContext}}
+            {{polaris-resource-list/filter-control
+              focused=true
+            }}
+          {{/polaris-resource-list/provider}}
+        `);
+
+        // Using qunit-dom's `isFocused` assertion on the text field's input
+        // fails, saying that the document body is active, so we check the
+        // text field wrapper for the focus class instead.
+        assert
+          .dom('[data-test-text-field-wrapper]')
+          .hasClass('Polaris-TextField--focus');
+      });
+    });
+
+    module(
+      'filters',
+      {
+        beforeEach() {
+          this.set('mockFilters', mockFilters);
+        },
+      },
+      function() {
+        test('renders no <FilterCreator/> if there are no filters', async function(assert) {
+          await render(hbs`
+            {{#polaris-resource-list/provider value=mockDefaultContext}}
+              {{polaris-resource-list/filter-control}}
+            {{/polaris-resource-list/provider}}
+          `);
+
+          assert.dom('[data-test-connected-item="left"]').doesNotExist();
+        });
+
+        test('renders <FilterCreator/> if there is filters', async function(assert) {
+          await render(hbs`
+            {{#polaris-resource-list/provider value=mockDefaultContext}}
+              {{polaris-resource-list/filter-control
+                filters=mockFilters
+              }}
+            {{/polaris-resource-list/provider}}
+          `);
+
+          assert.dom('[data-test-id="filter-activator"]').exists();
+        });
+
+        test('renders <FilterCreator/> with filters', async function(assert) {
+          let receivedFilters = null;
+          this.owner.register(
+            'component:polaris-resource-list/filter-control/filter-creator',
+            FilterCreatorComponent.extend({
+              init() {
+                this._super(...arguments);
+                receivedFilters = this.get('filters');
+              },
+            })
+          );
+          await render(hbs`
+            {{#polaris-resource-list/provider value=mockDefaultContext}}
+              {{polaris-resource-list/filter-control
+                filters=mockFilters
+              }}
+            {{/polaris-resource-list/provider}}
+          `);
+
+          assert.equal(receivedFilters, mockFilters);
+        });
+      }
+    );
+
+    module('onSearchBlur()', function() {
+      test('calls onSearchBlur when onBlur is triggered', async function(assert) {
+        await render(hbs`
+          {{#polaris-resource-list/provider value=mockDefaultContext}}
+            {{polaris-resource-list/filter-control
+              onSearchBlur=(action (mut wasOnSearchBlurCalled) true)
+            }}
+          {{/polaris-resource-list/provider}}
+        `);
+
+        await focus('[data-test-text-field-input]');
+        await blur('[data-test-text-field-input]');
+
+        assert.ok(this.get('wasOnSearchBlurCalled'));
+      });
+    });
+
+    module('onSearchChange()', function() {
+      test('calls onSearchChange with the new searchValue when onChange is triggered', async function(assert) {
+        const newSearchValue = 'new search value';
+        await render(hbs`
+          {{#polaris-resource-list/provider value=mockDefaultContext}}
+            {{polaris-resource-list/filter-control
+              onSearchChange=(action (mut newSearchValue))
+            }}
+          {{/polaris-resource-list/provider}}
+        `);
+
+        await fillIn('.Polaris-TextField input', newSearchValue);
+
+        assert.equal(this.get('newSearchValue'), newSearchValue);
+      });
+    });
+
+    module(
+      'onFiltersChange()',
+      {
+        beforeEach() {
+          this.setProperties({
+            mockFilters,
+            mockAppliedFilters,
+          });
+        },
+      },
+      function() {
+        test('gets call with the new filter when FilterCreator.onAddFilter is triggered', async function(assert) {
+          const newFilter = {
+            key: 'filterKey2',
+            value: 'new value',
+          };
+
+          await render(hbs`
+            {{#polaris-resource-list/provider value=mockDefaultContext}}
+              {{polaris-resource-list/filter-control
+                filters=mockFilters
+                appliedFilters=mockAppliedFilters
+                onFiltersChange=(action (mut newAppliedFilters))
+              }}
+            {{/polaris-resource-list/provider}}
+          `);
+
+          await triggerAddFilter(newFilter);
+
+          assert.deepEqual(this.get('newAppliedFilters'), [
+            ...mockAppliedFilters,
+            newFilter,
+          ]);
+        });
+
+        test('does not get call if the new filter already exist when FilterCreator.onAddFilter is triggered', async function(assert) {
+          const newFilter = mockAppliedFilters[0];
+          await render(hbs`
+            {{#polaris-resource-list/provider value=mockDefaultContext}}
+              {{polaris-resource-list/filter-control
+                filters=mockFilters
+                appliedFilters=mockAppliedFilters
+                onFiltersChange=(action (mut wasOnFiltersChangeCalled) true)
+              }}
+            {{/polaris-resource-list/provider}}
+          `);
+
+          await triggerAddFilter(newFilter);
+
+          assert.notOk(this.get('wasOnFiltersChangeCalled'));
+        });
+      }
+    );
   }
 );

--- a/tests/integration/components/polaris-resource-list/filter-control/filter-creator-test.js
+++ b/tests/integration/components/polaris-resource-list/filter-control/filter-creator-test.js
@@ -231,7 +231,7 @@ module(
     });
 
     module('filters', function() {
-      test('has the correct options prop when popover is active', async function(assert) {
+      test('sets the options when popover is active', async function(assert) {
         this.setProperties({
           filters,
           resourceName,
@@ -318,7 +318,7 @@ module(
         assert.equal(filterValueSelector.get('value'), undefined);
       });
 
-      test('updates value correctly when user selects a filter value', async function(assert) {
+      test('updates value with provided string when user selects a filter value', async function(assert) {
         this.setProperties({
           filters,
           resourceName,

--- a/tests/integration/components/polaris-resource-list/filter-control/filter-value-selector-test.js
+++ b/tests/integration/components/polaris-resource-list/filter-control/filter-value-selector-test.js
@@ -460,7 +460,7 @@ module(
             assert.dom('[data-test-select="operator"]').doesNotExist();
           });
 
-          test('calls onFilterKeyChange when the filter key was changed', async function(assert) {
+          test('calls onChange when the filter key was changed', async function(assert) {
             await render(hbs`
               {{polaris-resource-list/filter-control/filter-value-selector
                 filter=filter


### PR DESCRIPTION
Adds support for `alternateTool` to `polaris-resource-list`, improves handling of loading state, improves item link handling on click events, and updates the resource list subcomponents with the tweaks from Polaris v3.10.0.