### PR TITLE
Update text style to Polaris v3.10.0

### DIFF
--- a/addon/components/polaris-text-style.js
+++ b/addon/components/polaris-text-style.js
@@ -15,8 +15,8 @@ const variationElement = (variation) => {
   switch (variation) {
     case variationValue.code:
       return 'code';
+
     case variationValue.strong:
-      return 'b';
     case variationValue.positive:
     case variationValue.negative:
     case variationValue.subdued:

--- a/addon/templates/components/polaris-text-style.hbs
+++ b/addon/templates/components/polaris-text-style.hbs
@@ -1,26 +1,29 @@
-{{!-- NOTE: This is a bit hacky, but needed to support dynamically rendering different tag based on variation --}}
-{{#if (eq elementTagName "span")}}
-  <span data-test-text-style={{dataTestTextStyle}} class={{textStyleClasses}}>
-    {{#if hasBlock}}
-      {{yield}}
-    {{else}}
-      {{text}}
-    {{/if}}
-  </span>
-{{else if (eq elementTagName "b")}}
-  <b data-test-text-style={{dataTestTextStyle}} class={{textStyleClasses}}>
-    {{#if hasBlock}}
-      {{yield}}
-    {{else}}
-      {{text}}
-    {{/if}}
-  </b>
-{{else if (eq elementTagName "code")}}
-  <code data-test-text-style={{dataTestTextStyle}} class={{textStyleClasses}}>
-    {{#if hasBlock}}
-      {{yield}}
-    {{else}}
-      {{text}}
-    {{/if}}
-  </code>
-{{/if}}
+{{!--
+  Unfortunately we can't pass tagName to this wrapper element
+  and need to use two different paths as below. This is because
+  Glimmer will reuse the component instance even if elementTagName
+  changes, which will break because tagName cannot be updated on a
+  component instance once that instance has been created :sadface:
+--}}
+{{#with (component "wrapper-element"
+  class=textStyleClasses
+  data-test-text-style=dataTestTextStyle
+) as |wrapperElementComponent|}}
+  {{#if (eq elementTagName "code")}}
+    {{#component wrapperElementComponent tagName="code"}}
+      {{#if hasBlock}}
+        {{yield}}
+      {{else}}
+        {{text}}
+      {{/if}}
+    {{/component}}
+  {{else}}
+    {{#component wrapperElementComponent tagName="span"}}
+      {{#if hasBlock}}
+        {{yield}}
+      {{else}}
+        {{text}}
+      {{/if}}
+    {{/component}}
+  {{/if}}
+{{/with}}

--- a/tests/integration/components/polaris-text-style-test.js
+++ b/tests/integration/components/polaris-text-style-test.js
@@ -126,8 +126,8 @@ module('Integration | Component | polaris text style', function(hooks) {
       );
     assert.equal(
       find(textStyleSelector).tagName,
-      'B',
-      'strong variation - is rendered as a b tag'
+      'SPAN',
+      'strong variation - is rendered as a span tag'
     );
 
     this.set('variation', 'subdued');


### PR DESCRIPTION
Updates the elements used so that `span` is now used when `variation` is `'strong'`, and DRYs up the template slightly by using `wrapper-element`.