### PR TITLE
Fix spinner icon paths

### DIFF
--- a/addon/components/polaris-spinner.js
+++ b/addon/components/polaris-spinner.js
@@ -11,8 +11,8 @@ const allowedSizes = ['small', 'large'];
 const defaultSize = 'large';
 
 const spinnerSVGSources = {
-  small: '/@smile-io/ember-polaris/illustrations/spinner-small.svg',
-  large: '/@smile-io/ember-polaris/illustrations/spinner-large.svg',
+  small: '/@smile-io/ember-polaris/images/spinner-small.svg',
+  large: '/@smile-io/ember-polaris/images/spinner-large.svg',
 };
 
 export default Component.extend({


### PR DESCRIPTION
Spinner icons are under `/images/` not `/illustrations/` 😝 