### PR TITLE
Remove event object from button mouse action handler invocations

### DIFF
--- a/addon/components/polaris-button.js
+++ b/addon/components/polaris-button.js
@@ -415,4 +415,14 @@ export default Component.extend({
     let ariaPressed = this.get('ariaPressed');
     return isPresent(ariaPressed) ? String(ariaPressed) : null;
   }).readOnly(),
+
+  actions: {
+    /**
+     * Helper to invoke passed-in actions without passing the
+     * button element's event object as the first parameter.
+     */
+    invokeMouseAction(actionName) {
+      return this.get(actionName)();
+    },
+  },
 });

--- a/addon/templates/components/polaris-button.hbs
+++ b/addon/templates/components/polaris-button.hbs
@@ -52,9 +52,9 @@
       data-test-id={{dataTestId}}
       id={{id}}
       type={{type}}
-      onclick={{action onClick}}
-      onfocus={{action onFocus}}
-      onblur={{action onBlur}}
+      onclick={{action "invokeMouseAction" "onClick"}}
+      onfocus={{action "invokeMouseAction" "onFocus"}}
+      onblur={{action "invokeMouseAction" "onBlur"}}
       onkeydown={{action onKeyDown}}
       onkeyup={{action onKeyUp}}
       onkeypress={{action onKeyPress}}

--- a/tests/integration/components/polaris-button-test.js
+++ b/tests/integration/components/polaris-button-test.js
@@ -243,6 +243,14 @@ module('Integration | Component | polaris-button', function(hooks) {
         assert.equal(clickCount, 1);
       });
 
+      test('does not receive any params when the button is clicked', async function(assert) {
+        await render(
+          hbs`{{polaris-button onClick=(action (mut invocationParam))}}`
+        );
+        await click('button');
+        assert.equal(this.get('invocationParam'), undefined);
+      });
+
       test('is called when the link is clicked', async function(assert) {
         let clickCount = 0;
         this.set('incrementClickCount', () => clickCount++);
@@ -251,6 +259,14 @@ module('Integration | Component | polaris-button', function(hooks) {
         `);
         await click('[data-polaris-unstyled]');
         assert.equal(clickCount, 1);
+      });
+
+      test('does not receive any params when the link is clicked', async function(assert) {
+        await render(
+          hbs`{{polaris-button onClick=(action (mut invocationParam)) url="#"}}`
+        );
+        await click('[data-polaris-unstyled]');
+        assert.equal(this.get('invocationParam'), undefined);
       });
     });
 


### PR DESCRIPTION
https://github.com/smile-io/ember-polaris/pull/291 inadvertently changed the interface for `polaris-button`, such that the mouse event object was passed to the `onClick`, `onFocus` and `onBlur` actions on invocation, which it never was before my refactor. This change removes the erroneous event object, fixing the signature for `onClick`, `onFocus` and `onBlur` :+1: