### PR TITLE
Add skeleton thumbnail component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 - [#295](https://github.com/smile-io/ember-polaris/pull/295) [INTERNAL] Upgrade to Ember CLI `3.8.1`
 - [#296](https://github.com/smile-io/ember-polaris/pull/296) [INTERNAL] Update misc dependencies
+- [#315](https://github.com/smile-io/ember-polaris/pull/315) [FEATURE] Add `polaris-skeleton-thumbnail` component
 
 ### v4.0.2 (March 5, 2019)
 - [#284](https://github.com/smile-io/ember-polaris/pull/284) [FIX] Fix infinite loop in `sticky-manager` service

--- a/addon/components/polaris-skeleton-thumbnail.js
+++ b/addon/components/polaris-skeleton-thumbnail.js
@@ -1,0 +1,36 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { capitalize } from '@ember/string';
+
+const allowedSizes = ['small', 'medium', 'large'];
+
+export default Component.extend({
+  classNames: ['Polaris-SkeletonThumbnail'],
+  classNameBindings: ['sizeClass'],
+
+  /**
+   * Size of the thumbnail
+   *
+   * @property size
+   * @type {String}
+   * @default 'medium'
+   * @public
+   */
+  size: 'medium',
+
+  /**
+   * Class to apply the thumbnail size.
+   *
+   * @property sizeClass
+   * @type {String}
+   * @private
+   */
+  sizeClass: computed('size', function() {
+    let size = this.get('size');
+    if (allowedSizes.indexOf(size) === -1) {
+      size = 'medium';
+    }
+
+    return `Polaris-SkeletonThumbnail--size${capitalize(size)}`;
+  }).readOnly(),
+});

--- a/app/components/polaris-skeleton-thumbnail.js
+++ b/app/components/polaris-skeleton-thumbnail.js
@@ -1,0 +1,3 @@
+export {
+  default,
+} from '@smile-io/ember-polaris/components/polaris-skeleton-thumbnail';

--- a/tests/integration/components/polaris-skeleton-thumbnail-test.js
+++ b/tests/integration/components/polaris-skeleton-thumbnail-test.js
@@ -1,0 +1,37 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | polaris skeleton thumbnail', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    await render(hbs`{{polaris-skeleton-thumbnail}}`);
+
+    assert.dom('div.Polaris-SkeletonThumbnail').exists({ count: 1 });
+  });
+
+  test('it applies the correct size class', async function(assert) {
+    await render(hbs`{{polaris-skeleton-thumbnail size=size}}`);
+
+    assert
+      .dom('div.Polaris-SkeletonThumbnail')
+      .hasClass('Polaris-SkeletonThumbnail--sizeMedium');
+
+    this.set('size', 'small');
+    assert
+      .dom('div.Polaris-SkeletonThumbnail')
+      .hasClass('Polaris-SkeletonThumbnail--sizeSmall');
+
+    this.set('size', 'large');
+    assert
+      .dom('div.Polaris-SkeletonThumbnail')
+      .hasClass('Polaris-SkeletonThumbnail--sizeLarge');
+
+    this.set('size', 'something invalid');
+    assert
+      .dom('div.Polaris-SkeletonThumbnail')
+      .hasClass('Polaris-SkeletonThumbnail--sizeMedium');
+  });
+});


### PR DESCRIPTION
Adds the Polaris [`SkeletonThumbnail` component](https://github.com/Shopify/polaris-react/blob/bba36af2ad10ba9626bba168b52e2e9222ac4c60/src/components/SkeletonThumbnail/SkeletonThumbnail.tsx) as it stands in v3.10.0.