### PR TITLE
Make text field "focus" property writeable

### DIFF
--- a/addon/components/polaris-text-field.js
+++ b/addon/components/polaris-text-field.js
@@ -558,7 +558,7 @@ export default Component.extend({
 
   focus: computed('focused', function() {
     return this.get('focused') || false;
-  }).readOnly(),
+  }),
 
   setInput() {
     this.set('input', document.querySelector(`[id='${this.get('id')}']`));


### PR DESCRIPTION
Saw a couple of `Cannot set read-only property "focus" on object` errors logged for one of our apps. `focus` is part of the component's `State` in the React implementation so seems like it should be writeable...