### PR TITLE
Add support for choice-list extra component aka renderChildren

### DIFF
--- a/addon/components/polaris-choice-list.js
+++ b/addon/components/polaris-choice-list.js
@@ -53,7 +53,7 @@ export default Component.extend({
    *  - label
    *  - disabled
    *  - helpText
-   *  - extra (Polaris's renderChildren equivalent)
+   *  - childComponent (Polaris's renderChildren equivalent)
    *
    * @property choices
    * @public
@@ -113,13 +113,13 @@ export default Component.extend({
   titleHidden: false,
 
   /**
-   * Component to render children with a choice.
+   * Component to render a child component for a choice.
    *
    * @type {Component}
-   * @property extra
+   * @property childComponent
    * @public
    */
-  extra: null,
+  childComponent: null,
 
   /**
    * Callback when the selected choices change

--- a/addon/components/polaris-choice-list.js
+++ b/addon/components/polaris-choice-list.js
@@ -3,7 +3,7 @@ import { get, computed } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { isEmpty } from '@ember/utils';
 import ObjectProxy from '@ember/object/proxy';
-import { errorId } from '@smile-io/ember-polaris/utils/id';
+import { errorId } from '../utils/id';
 import layout from '../templates/components/polaris-choice-list';
 
 // Wrapper class to add an `isSelected` flag to the supplied choices.
@@ -53,7 +53,7 @@ export default Component.extend({
    *  - label
    *  - disabled
    *  - helpText
-   *  - renderChildren (not implemented yet)
+   *  - extra (Polaris's renderChildren equivalent)
    *
    * @property choices
    * @public
@@ -111,6 +111,15 @@ export default Component.extend({
    * @default false
    */
   titleHidden: false,
+
+  /**
+   * Component to render children with a choice.
+   *
+   * @type {Component}
+   * @property extra
+   * @public
+   */
+  extra: null,
 
   /**
    * Callback when the selected choices change

--- a/addon/components/polaris-choice-list.js
+++ b/addon/components/polaris-choice-list.js
@@ -113,15 +113,6 @@ export default Component.extend({
   titleHidden: false,
 
   /**
-   * Component to render a child component for a choice.
-   *
-   * @type {Component}
-   * @property childComponent
-   * @public
-   */
-  childComponent: null,
-
-  /**
    * Callback when the selected choices change
    *
    * @property onChange

--- a/addon/templates/components/polaris-choice-list.hbs
+++ b/addon/templates/components/polaris-choice-list.hbs
@@ -18,9 +18,9 @@
         onChange=(action "updateSelectedChoices" choice)
       }}
 
-      {{#if choice.extra}}
+      {{#if choice.childComponent}}
         <div class="Polaris-ChoiceList__ChoiceChildren">
-          {{component choice.extra choice=choice}}
+          {{component choice.childComponent isSelected=choice.isSelected}}
         </div>
       {{/if}}
     </li>

--- a/addon/templates/components/polaris-choice-list.hbs
+++ b/addon/templates/components/polaris-choice-list.hbs
@@ -17,6 +17,12 @@
         checked=choice.isSelected
         onChange=(action "updateSelectedChoices" choice)
       }}
+
+      {{#if choice.extra}}
+        <div class="Polaris-ChoiceList__ChoiceChildren">
+          {{component choice.extra choice=choice}}
+        </div>
+      {{/if}}
     </li>
   {{/each}}
 </ul>

--- a/docs/choice-list.md
+++ b/docs/choice-list.md
@@ -56,3 +56,24 @@ Multiple choice list (checkboxes) with title:
   onChange=(action (mut selected))
 }}
 ```
+
+Render childComponents for a choice
+
+```hbs
+{{polaris-choice-list
+  title="Choose from these options"
+  choices=(array
+    (hash
+      label="Option 1"
+      value="one"
+    )
+    (hash
+      label="Option 2"
+      value="two"
+      childComponent=(component "polaris-text-field" ...)
+    )
+  )
+  selected=selected
+  onChange=(action (mut selected))
+}}
+```

--- a/tests/integration/components/polaris-choice-list-test.js
+++ b/tests/integration/components/polaris-choice-list-test.js
@@ -643,7 +643,7 @@ module('Integration | Component | polaris-choice-list', function(hooks) {
     this.owner.register(
       'component:dummy-component',
       Component.extend({
-        layout: hbs`{{choice.label}}`,
+        layout: hbs`{{isSelected}}`,
         'data-test-dummy-component': true,
       })
     );
@@ -658,15 +658,15 @@ module('Integration | Component | polaris-choice-list', function(hooks) {
           (hash
             label="option2"
             value="two"
-            extra=(component "dummy-component")
+            childComponent=(component "dummy-component")
           )
         )
-        selected=selected
+        selected="two"
       }}
     `);
 
     assert
       .dom('[data-test-dummy-component]')
-      .hasText('option2', 'renders choice extra component');
+      .hasText('true', 'renders choice extra component');
   });
 });

--- a/tests/integration/components/polaris-choice-list-test.js
+++ b/tests/integration/components/polaris-choice-list-test.js
@@ -4,6 +4,7 @@ import { render, findAll, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 import MockSvgJarComponent from '../../mocks/components/svg-jar';
+import Component from '@ember/component';
 
 const choiceListSelector = '[data-test-choice-list]';
 const choicesWrapperSelector = '[data-test-choice-list-choices]';
@@ -636,5 +637,36 @@ module('Integration | Component | polaris-choice-list', function(hooks) {
     this.set('selected', ['two']);
 
     assert.dom('.Polaris-RadioButton__Input:checked').hasValue('two');
+  });
+
+  test('it supports choice children components aka renderChildren', async function(assert) {
+    this.owner.register(
+      'component:dummy-component',
+      Component.extend({
+        layout: hbs`{{choice.label}}`,
+        'data-test-dummy-component': true,
+      })
+    );
+
+    await render(hbs`
+      {{polaris-choice-list
+        choices=(array
+          (hash
+            label="option1"
+            value="one"
+          )
+          (hash
+            label="option2"
+            value="two"
+            extra=(component "dummy-component")
+          )
+        )
+        selected=selected
+      }}
+    `);
+
+    assert
+      .dom('[data-test-dummy-component]')
+      .hasText('option2', 'renders choice extra component');
   });
 });


### PR DESCRIPTION
### What's here

This adds support for an `extra` component to be used for `polaris-choice-list` choices aka `renderChildren` in react world