### PR TITLE
Fix rendering choice-list child components

### DIFF
--- a/addon/components/polaris-choice-list.js
+++ b/addon/components/polaris-choice-list.js
@@ -54,6 +54,7 @@ export default Component.extend({
    *  - disabled
    *  - helpText
    *  - childComponent (Polaris's renderChildren equivalent)
+   *  - alwaysRenderChildComponent
    *
    * @property choices
    * @public

--- a/addon/components/polaris-choice-list.js
+++ b/addon/components/polaris-choice-list.js
@@ -56,6 +56,8 @@ export default Component.extend({
    *  - childComponent (Polaris's renderChildren equivalent)
    *  - alwaysRenderChildComponent
    *
+   * TODO try to find a nicer API for React's `renderChildren`
+   *
    * @property choices
    * @public
    * @type {Array}

--- a/addon/templates/components/polaris-choice-list.hbs
+++ b/addon/templates/components/polaris-choice-list.hbs
@@ -18,9 +18,14 @@
         onChange=(action "updateSelectedChoices" choice)
       }}
 
-      {{#if choice.childComponent}}
+      {{#if
+        (and
+          choice.childComponent
+          (or choice.isSelected choice.alwaysRenderChildComponent)
+        )
+      }}
         <div class="Polaris-ChoiceList__ChoiceChildren">
-          {{component choice.childComponent isSelected=choice.isSelected}}
+          {{component choice.childComponent}}
         </div>
       {{/if}}
     </li>

--- a/docs/choice-list.md
+++ b/docs/choice-list.md
@@ -57,7 +57,7 @@ Multiple choice list (checkboxes) with title:
 }}
 ```
 
-Render childComponents for a choice
+Render childComponent for a selected choice
 
 ```hbs
 {{polaris-choice-list
@@ -71,6 +71,29 @@ Render childComponents for a choice
       label="Option 2"
       value="two"
       childComponent=(component "polaris-text-field" ...)
+    )
+  )
+  selected=selected
+  onChange=(action (mut selected))
+}}
+```
+
+
+Always render childComponent for a choice
+
+```hbs
+{{polaris-choice-list
+  title="Choose from these options"
+  choices=(array
+    (hash
+      label="Option 1"
+      value="one"
+    )
+    (hash
+      label="Option 2"
+      value="two"
+      childComponent=(component "polaris-text-field" ...)
+      alwaysRenderChildComponent=true
     )
   )
   selected=selected

--- a/tests/integration/components/polaris-choice-list-test.js
+++ b/tests/integration/components/polaris-choice-list-test.js
@@ -643,10 +643,12 @@ module('Integration | Component | polaris-choice-list', function(hooks) {
     this.owner.register(
       'component:dummy-component',
       Component.extend({
-        layout: hbs`{{isSelected}}`,
+        layout: hbs``,
         'data-test-dummy-component': true,
       })
     );
+
+    this.set('selected', 'one');
 
     await render(hbs`
       {{polaris-choice-list
@@ -659,14 +661,27 @@ module('Integration | Component | polaris-choice-list', function(hooks) {
             label="option2"
             value="two"
             childComponent=(component "dummy-component")
+            alwaysRenderChildComponent=alwaysRenderChildComponent
           )
         )
-        selected="two"
+        selected=selected
       }}
     `);
 
     assert
       .dom('[data-test-dummy-component]')
-      .hasText('true', 'renders choice extra component');
+      .doesNotExist('does not render choice childComponent, when not selected');
+
+    this.set('selected', 'two');
+    assert
+      .dom('[data-test-dummy-component]')
+      .exists('renders choice childComponent component, when selected');
+
+    this.setProperties({ selected: 'one', alwaysRenderChildComponent: true });
+    assert
+      .dom('[data-test-dummy-component]')
+      .exists(
+        'renders choice childComponent component, even when not selected if alwaysRenderChildComponent is true'
+      );
   });
 });


### PR DESCRIPTION
### What's here

This is a follow up on #318 
Found out that with #318, we'll always render the wrapping `Polaris-ChoiceList__ChoiceChildren` div when there's a `childComponent` for a choice, which cause some extra spacing.

This:
- changes so that by default we render the `childComponent` only when the choice is selected
- adds an extra `alwaysRenderChildComponent` property, which when `true` will always render the `childComponent`