### PR TITLE
Upgrade tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ jobs:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
     - stage: 'Additional Tests'
-      env: EMBER_TRY_SCENARIO=ember-lts-3.8
+      env: EMBER_TRY_SCENARIO=ember-3.10
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "8"
+  - '8'
 
 sudo: false
 dist: trusty
@@ -27,8 +27,8 @@ jobs:
   include:
     # runs linting and tests with current locked deps
 
-    - stage: "Tests"
-      name: "Tests"
+    - stage: 'Tests'
+      name: 'Tests'
       script:
         - yarn lint:hbs
         - yarn lint:js
@@ -36,9 +36,8 @@ jobs:
 
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
-    - stage: "Additional Tests"
-      env: EMBER_TRY_SCENARIO=ember-lts-2.18
-    - env: EMBER_TRY_SCENARIO=ember-lts-3.4
+    - stage: 'Additional Tests'
+      env: EMBER_TRY_SCENARIO=ember-lts-3.8
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary

--- a/addon/components/component-proxy.js
+++ b/addon/components/component-proxy.js
@@ -1,6 +1,6 @@
-import { compileTemplate as compile } from '@ember/template-compilation';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
+import { compileTemplate as compile } from '@ember/template-compilation';
 import { assign } from '@ember/polyfills';
 
 // Renders a named component with a passed-in hash of properties.

--- a/addon/components/component-proxy.js
+++ b/addon/components/component-proxy.js
@@ -1,8 +1,7 @@
+import { compileTemplate as compile } from '@ember/template-compilation';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-// import { compileTemplate } from '@ember/template-compilation';
 import { assign } from '@ember/polyfills';
-import Ember from 'ember';
 
 // Renders a named component with a passed-in hash of properties.
 // This effectively allows us to spread/splat a props hash onto
@@ -29,10 +28,7 @@ export default Component.extend({
       'propsString'
     );
 
-    // Disable linting for this line because the recommended way of importing
-    // results in a "Could not find module `@ember/template-compilation`" error ¯\_(ツ)_/¯
-    // eslint-disable-next-line ember/new-module-imports
-    return Ember.HTMLBars.compile(`
+    return compile(`
       {{#if hasBlock}}
         {{#component "${componentName}"${propsString}}}
           {{yield}}

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -12,24 +12,10 @@ module.exports = function() {
       useYarn: true,
       scenarios: [
         {
-          name: 'ember-lts-2.18',
-          env: {
-            EMBER_OPTIONAL_FEATURES: JSON.stringify({
-              'jquery-integration': true,
-            }),
-          },
+          name: 'ember-lts-3.8',
           npm: {
             devDependencies: {
-              '@ember/jquery': '^0.5.1',
-              'ember-source': '~2.18.0',
-            },
-          },
-        },
-        {
-          name: 'ember-lts-3.4',
-          npm: {
-            devDependencies: {
-              'ember-source': '~3.4.0',
+              'ember-source': '~3.8.0',
             },
           },
         },

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -12,10 +12,10 @@ module.exports = function() {
       useYarn: true,
       scenarios: [
         {
-          name: 'ember-lts-3.8',
+          name: 'ember-3.10',
           npm: {
             devDependencies: {
-              'ember-source': '~3.8.0',
+              'ember-source': '~3.10.0',
             },
           },
         },

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-load-initializers": "^2.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-native-dom-helpers": "^0.6.2",
     "ember-qunit": "^4.4.1",
     "ember-resolver": "^5.1.3",
     "ember-source": "~3.10.2",

--- a/tests/integration/components/polaris-banner-test.js
+++ b/tests/integration/components/polaris-banner-test.js
@@ -1,19 +1,8 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { click, render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { find, click } from 'ember-native-dom-helpers';
+import { module, test } from 'qunit';
 import MockSvgJarComponent from '../../mocks/components/svg-jar';
-
-moduleForComponent(
-  'polaris-banner',
-  'Integration | Component | polaris banner',
-  {
-    integration: true,
-
-    beforeEach() {
-      this.register('component:svg-jar', MockSvgJarComponent);
-    },
-  }
-);
 
 const bannerSelector = 'div.Polaris-Banner';
 const iconSelector = 'div.Polaris-Banner__Ribbon > span.Polaris-Icon';
@@ -23,430 +12,422 @@ const contentSelector = 'div.Polaris-Banner__Content';
 const dismissSelector = 'div.Polaris-Banner__Dismiss';
 const actionsSelector = 'div.Polaris-Banner__Actions';
 
-test('it renders correctly in basic usage', function(assert) {
-  this.render(hbs`{{polaris-banner}}`);
+module('Integration | Component | polaris banner', function(hooks) {
+  setupRenderingTest(hooks);
 
-  let banner = find(bannerSelector);
-  assert.ok(banner, 'inline-mode - banner exists');
-  assert.equal(
-    banner.textContent.trim(),
-    '',
-    'inline-mode - banner is empty, by default'
-  );
-  assert.equal(banner.tabIndex, '0', 'inline-mode - has correct tabIndex');
-  assert.equal(
-    banner.getAttribute('role'),
-    'status',
-    'inline-mode - has correct role attribute'
-  );
-  assert.equal(
-    banner.getAttribute('aria-live'),
-    'polite',
-    'inline-mode - has correct aria-live attribute'
-  );
+  hooks.beforeEach(function() {
+    this.actions = {};
+    this.send = (actionName, ...args) =>
+      this.actions[actionName].apply(this, args);
+  });
 
-  let bannerIcon = find(iconSelector, banner);
-  let iconSvg = find('svg', iconSelector);
-  assert.ok(bannerIcon, 'inline-mode - has icon');
-  assert.ok(
-    bannerIcon.classList.contains('Polaris-Icon--colorInkLighter'),
-    'inline-mode - icon has inkLighter color'
-  );
-  assert.ok(
-    bannerIcon.classList.contains('Polaris-Icon--hasBackdrop'),
-    'inline-mode - icon has backdrop'
-  );
-  assert.equal(
-    iconSvg.dataset.iconSource,
-    'polaris/flag',
-    'inline-mode - default icon is polaris/flag'
-  );
+  hooks.beforeEach(function() {
+    this.owner.register('component:svg-jar', MockSvgJarComponent);
+  });
 
-  // Template block usage:
-  this.render(hbs`
-    {{#polaris-banner}}
-      template block text
-    {{/polaris-banner}}
-  `);
+  test('it renders correctly in basic usage', async function(assert) {
+    await render(hbs`{{polaris-banner}}`);
 
-  banner = find(bannerSelector);
-  assert.ok(banner, 'block-mode - banner exists');
-  assert.equal(
-    banner.textContent.trim(),
-    'template block text',
-    'block-mode - banner has correct content'
-  );
-});
+    let banner = assert.dom(bannerSelector);
+    banner.exists('inline-mode - banner exists');
+    banner.hasText('', 'inline-mode - banner is empty, by default');
+    banner.hasAttribute('tabIndex', '0', 'inline-mode - has correct tabIndex');
+    banner.hasAttribute(
+      'role',
+      'status',
+      'inline-mode - has correct role attribute'
+    );
+    banner.hasAttribute(
+      'aria-live',
+      'polite',
+      'inline-mode - has correct aria-live attribute'
+    );
 
-test('it renders banner heading correctly', function(assert) {
-  let title = 'Your shipping label is ready to print.';
+    let bannerIcon = assert.dom(`${bannerSelector} ${iconSelector}`);
 
-  this.render(hbs`{{polaris-banner title=title}}`);
+    bannerIcon.exists('inline-mode - has icon');
+    bannerIcon.hasClass(
+      'Polaris-Icon--colorInkLighter',
+      'inline-mode - icon has inkLighter color'
+    );
+    bannerIcon.hasClass(
+      'Polaris-Icon--hasBackdrop',
+      'inline-mode - icon has backdrop'
+    );
 
-  let banner = find(bannerSelector);
-  let heading = find(headingSelector, banner);
-  assert.notOk(heading, 'banner without title - no heading rendered');
-  assert.notOk(
-    banner.getAttribute('aria-labelledby'),
-    'banner without title - no aria-labelledby for banner'
-  );
+    assert
+      .dom(`${iconSelector} svg`)
+      .hasAttribute(
+        'data-icon-source',
+        'polaris/flag',
+        'inline-mode - default icon is polaris/flag'
+      );
 
-  this.set('title', title);
+    // Template block usage:
+    await render(hbs`
+      {{#polaris-banner}}
+        template block text
+      {{/polaris-banner}}
+    `);
 
-  heading = find(headingSelector, banner);
-  let headingTitle = find(headingTitleSelector, heading);
-  assert.ok(heading, 'banner with title - heading rendered');
-  assert.equal(
-    headingTitle.textContent.trim(),
-    title,
-    'banner with title - has correct title'
-  );
-  assert.ok(
-    banner.hasAttribute('aria-labelledby'),
-    'banner with title - has aria-labelledby attribute'
-  );
-  assert.equal(
-    banner.getAttribute('aria-labelledby'),
-    heading.getAttribute('id'),
-    "banner with title - has the banner's aria-labelledby as the heading Id"
-  );
-});
+    banner = assert.dom(bannerSelector);
+    banner.exists('block-mode - banner exists');
+    banner.hasText(
+      'template block text',
+      'block-mode - banner has correct content'
+    );
+  });
 
-test('it handles banner content correctly', function(assert) {
-  let contentText =
-    'Use your finance report to get detailed information about your business.';
+  test('it renders banner heading correctly', async function(assert) {
+    await render(hbs`{{polaris-banner title=title}}`);
 
-  this.render(hbs`{{polaris-banner text=contentText}}`);
+    let bannerHeadingSelector = `${bannerSelector} ${headingSelector}`;
+    let banner = assert.dom(bannerSelector);
+    let heading = assert.dom(bannerHeadingSelector);
 
-  let banner = find(bannerSelector);
-  let content = find(contentSelector, banner);
-  assert.notOk(content, 'banner without content - no content rendered');
-  assert.notOk(
-    banner.getAttribute('aria-describedby'),
-    'banner without content - no aria-describedby for banner'
-  );
+    heading.doesNotExist('banner without title - no heading rendered');
+    banner.doesNotHaveAttribute(
+      'aria-labelledby',
+      'banner without title - no aria-labelledby for banner'
+    );
 
-  this.set('contentText', contentText);
+    let title = 'Your shipping label is ready to print.';
+    this.set('title', title);
 
-  content = find(contentSelector, banner);
-  assert.ok(content, 'banner with content - content rendered');
-  assert.equal(
-    content.textContent.trim(),
-    contentText,
-    'banner with content - has correct content'
-  );
-  assert.ok(
-    banner.hasAttribute('aria-describedby'),
-    'banner with content - has aria-describedby attribute'
-  );
-  assert.equal(
-    banner.getAttribute('aria-describedby'),
-    content.getAttribute('id'),
-    "banner with content - has the banner's aria-describedby as the content Id"
-  );
+    heading.exists('banner with title - heading rendered');
+    assert
+      .dom(`${headingSelector} ${headingTitleSelector}`)
+      .hasText(title, 'banner with title - has correct title');
 
-  // Block-mode
-  this.render(hbs`
-    {{#polaris-banner}}
-      <p>{{contentText}}</p>
-    {{/polaris-banner}}
-  `);
+    banner.hasAttribute(
+      'aria-labelledby',
+      this.element.querySelector(bannerHeadingSelector).getAttribute('id'),
+      "banner with title - has the banner's aria-labelledby as the heading Id"
+    );
+  });
 
-  banner = find(bannerSelector);
-  content = find(contentSelector, banner);
-  assert.ok(content, 'banner with content (block) - content rendered');
-  assert.equal(
-    content.textContent.trim(),
-    contentText,
-    'banner with content (block) - has correct content'
-  );
-  assert.ok(
-    banner.hasAttribute('aria-describedby'),
-    'banner with content (block) - has aria-describedby attribute'
-  );
-  assert.equal(
-    banner.getAttribute('aria-describedby'),
-    content.getAttribute('id'),
-    "banner with content (block) - has the banner's aria-describedby as the content Id"
-  );
-});
+  test('it handles banner content correctly', async function(assert) {
+    let contentText =
+      'Use your finance report to get detailed information about your business.';
 
-test('it handles banner status correctly', function(assert) {
-  this.render(hbs`{{polaris-banner status=status}}`);
+    await render(hbs`{{polaris-banner text=contentText}}`);
 
-  let banner = find(bannerSelector);
-  banner.classList.forEach((bannerClass) =>
-    assert.notOk(
-      /Polaris-Banner--status/.test(bannerClass),
+    let bannerContentSelector = `${bannerSelector} ${contentSelector}`;
+    let banner = assert.dom(bannerSelector);
+    let content = assert.dom(bannerContentSelector);
+    content.doesNotExist('banner without content - no content rendered');
+
+    banner.doesNotHaveAttribute(
+      'aria-describedby',
+      'banner without content - no aria-describedby for banner'
+    );
+
+    this.set('contentText', contentText);
+
+    content.exists('banner with content - content rendered');
+    content.hasText(contentText, 'banner with content - has correct content');
+
+    banner.hasAttribute(
+      'aria-describedby',
+      this.element.querySelector(bannerContentSelector).getAttribute('id'),
+      "banner with content - has the banner's aria-describedby as the content Id"
+    );
+
+    // Block-mode
+    await render(hbs`
+      {{#polaris-banner}}
+        <p>{{contentText}}</p>
+      {{/polaris-banner}}
+    `);
+
+    banner = assert.dom(bannerSelector);
+    content = assert.dom(bannerContentSelector);
+    content.exists('banner with content (block) - content rendered');
+    content.hasText(
+      contentText,
+      'banner with content (block) - has correct content'
+    );
+
+    banner.hasAttribute(
+      'aria-describedby',
+      this.element.querySelector(bannerContentSelector).getAttribute('id'),
+      "banner with content (block) - has the banner's aria-describedby as the content Id"
+    );
+  });
+
+  test('it handles banner status correctly', async function(assert) {
+    await render(hbs`{{polaris-banner status=status}}`);
+
+    let banner = assert.dom(bannerSelector);
+    banner.doesNotHaveClass(
+      'Polaris-Banner--status',
       'banner without status - has no status class'
-    )
-  );
+    );
 
-  let bannerIcon = find(iconSelector, banner);
-  let iconSvg = find('svg', iconSelector);
+    let bannerIcon = assert.dom(`${bannerSelector} ${iconSelector}`);
+    let iconSvg = assert.dom(`${iconSelector} svg`);
 
-  this.set('status', 'success');
-  assert.ok(
-    banner.classList.contains('Polaris-Banner--statusSuccess'),
-    'banner with success status - has correct class'
-  );
-  assert.equal(
-    banner.getAttribute('role'),
-    'status',
-    'banner with success status - has correct role attribute'
-  );
-  assert.ok(
-    bannerIcon.classList.contains('Polaris-Icon--colorGreenDark'),
-    'banner with success status - has greenDark icon color'
-  );
-  assert.equal(
-    iconSvg.dataset.iconSource,
-    'polaris/circle-check-mark',
-    'banner with success status - has icon polaris/circle-check-mark'
-  );
+    this.set('status', 'success');
+    banner.hasClass(
+      'Polaris-Banner--statusSuccess',
+      'banner with success status - has correct class'
+    );
 
-  this.set('status', 'info');
-  assert.ok(
-    banner.classList.contains('Polaris-Banner--statusInfo'),
-    'banner with info status - has correct class'
-  );
-  assert.equal(
-    banner.getAttribute('role'),
-    'status',
-    'banner with info status - has correct role attribute'
-  );
-  assert.ok(
-    bannerIcon.classList.contains('Polaris-Icon--colorTealDark'),
-    'banner with info status - has tealDark icon color'
-  );
-  assert.equal(
-    iconSvg.dataset.iconSource,
-    'polaris/circle-information',
-    'banner with info status - has icon polaris/circle-information'
-  );
+    banner.hasAttribute(
+      'role',
+      'status',
+      'banner with success status - has correct role attribute'
+    );
+    bannerIcon.hasClass(
+      'Polaris-Icon--colorGreenDark',
+      'banner with success status - has greenDark icon color'
+    );
 
-  this.set('status', 'warning');
-  assert.ok(
-    banner.classList.contains('Polaris-Banner--statusWarning'),
-    'banner with warning status - has correct class'
-  );
-  assert.equal(
-    banner.getAttribute('role'),
-    'alert',
-    'banner with warning status - has correct role attribute'
-  );
-  assert.ok(
-    bannerIcon.classList.contains('Polaris-Icon--colorYellowDark'),
-    'banner with warning status - has yellowDark icon color'
-  );
-  assert.equal(
-    iconSvg.dataset.iconSource,
-    'polaris/circle-alert',
-    'banner with warning status - has icon polaris/circle-alert'
-  );
+    iconSvg.hasAttribute(
+      'data-icon-source',
+      'polaris/circle-check-mark',
+      'banner with success status - has icon polaris/circle-check-mark'
+    );
 
-  this.set('status', 'critical');
-  assert.ok(
-    banner.classList.contains('Polaris-Banner--statusCritical'),
-    'banner with critical status - has correct class'
-  );
-  assert.equal(
-    banner.getAttribute('role'),
-    'alert',
-    'banner with critical status - has correct role attribute'
-  );
-  assert.ok(
-    bannerIcon.classList.contains('Polaris-Icon--colorRedDark'),
-    'banner with critical status - has redDark icon color'
-  );
-  assert.equal(
-    iconSvg.dataset.iconSource,
-    'polaris/circle-barred',
-    'banner with critical status - has icon polaris/circle-barred'
-  );
-});
+    this.set('status', 'info');
+    banner.hasClass(
+      'Polaris-Banner--statusInfo',
+      'banner with info status - has correct class'
+    );
 
-test('it handles dismissable banner correctly', function(assert) {
-  this.render(hbs`{{polaris-banner}}`);
+    banner.hasAttribute(
+      'role',
+      'status',
+      'banner with info status - has correct role attribute'
+    );
+    bannerIcon.hasClass(
+      'Polaris-Icon--colorTealDark',
+      'banner with info status - has tealDark icon color'
+    );
 
-  let banner = find(bannerSelector);
-  let dismissWrapper = find(dismissSelector, banner);
-  assert.notOk(
-    banner.classList.contains('Polaris-Banner--hasDismiss'),
-    'banner non-dismissable - does not have dismissable class'
-  );
-  assert.notOk(
-    dismissWrapper,
-    'banner non-dismissable - does not render the dismiss element'
-  );
+    iconSvg.hasAttribute(
+      'data-icon-source',
+      'polaris/circle-information',
+      'banner with info status - has icon polaris/circle-information'
+    );
 
-  let dismissed = false;
-  this.on('dismiss', () => (dismissed = true));
+    this.set('status', 'warning');
+    banner.hasClass(
+      'Polaris-Banner--statusWarning',
+      'banner with warning status - has correct class'
+    );
 
-  this.render(hbs`{{polaris-banner onDismiss=(action "dismiss")}}`);
+    banner.hasAttribute(
+      'role',
+      'alert',
+      'banner with warning status - has correct role attribute'
+    );
+    bannerIcon.hasClass(
+      'Polaris-Icon--colorYellowDark',
+      'banner with warning status - has yellowDark icon color'
+    );
 
-  banner = find(bannerSelector);
-  dismissWrapper = find(dismissSelector, banner);
-  let dismissBtn = find(
-    'button.Polaris-Button.Polaris-Button--plain.Polaris-Button--iconOnly',
-    dismissWrapper
-  );
-  assert.ok(
-    banner.classList.contains('Polaris-Banner--hasDismiss'),
-    'banner dismissable - has dismissable class'
-  );
-  assert.ok(
-    dismissWrapper,
-    'banner dismissable - does render the dismiss element'
-  );
-  assert.ok(dismissBtn, 'banner dismissable - has correct dismiss button');
-  assert.equal(
-    dismissBtn.getAttribute('aria-label'),
-    'Dismiss notification',
-    'banner dismissable - dismiss button has correct aria-label'
-  );
+    iconSvg.hasAttribute(
+      'data-icon-source',
+      'polaris/circle-alert',
+      'banner with warning status - has icon polaris/circle-alert'
+    );
 
-  click(dismissBtn);
+    this.set('status', 'critical');
+    banner.hasClass(
+      'Polaris-Banner--statusCritical',
+      'banner with critical status - has correct class'
+    );
 
-  assert.ok(dismissed, 'banner dismissable - fires dismiss action');
-});
+    banner.hasAttribute(
+      'role',
+      'alert',
+      'banner with critical status - has correct role attribute'
+    );
+    bannerIcon.hasClass(
+      'Polaris-Icon--colorRedDark',
+      'banner with critical status - has redDark icon color'
+    );
 
-test('it supports `action` and `secondaryAction`', function(assert) {
-  this.render(hbs`{{polaris-banner text="Some content text"}}`);
-
-  let banner = find(bannerSelector);
-  let content = find(contentSelector, banner);
-  let actions = find(actionsSelector, content);
-  assert.notOk(
-    actions,
-    'banner without actions - does not render the actions container'
-  );
-
-  let mainActionFired = false;
-  this.on('mainAction', () => (mainActionFired = true));
-
-  let secActionFired = false;
-  this.on('secAction', () => (secActionFired = true));
-
-  this.render(hbs`{{polaris-banner
-    secondaryAction=(hash text="View" onAction=(action "secAction"))
-  }}`);
-
-  banner = find(bannerSelector);
-  content = find(contentSelector, banner);
-  actions = find(actionsSelector, content);
-  assert.notOk(
-    actions,
-    'banner with `secondaryAction` only - does not render the actions container'
-  );
-
-  this.render(hbs`{{polaris-banner
-    action=(hash text="Edit" onAction=(action "mainAction"))
-  }}`);
-
-  banner = find(bannerSelector);
-  content = find(contentSelector, banner);
-  actions = find(actionsSelector, content);
-  let btnGroup = find('div.Polaris-ButtonGroup', actions);
-  let actionBtn = find(
-    'div.Polaris-ButtonGroup__Item > div.Polaris-Banner__PrimaryAction > button.Polaris-Button.Polaris-Button--outline',
-    btnGroup
-  );
-  let secondaryActionBtn = find(
-    'div.Polaris-ButtonGroup__Item > button.Polaris-Banner__SecondaryAction',
-    btnGroup
-  );
-  assert.ok(actions, 'banner with `action` only - renders actions container');
-  assert.ok(actionBtn, 'banner with `action` only - renders `action` button');
-  assert.notOk(
-    secondaryActionBtn,
-    'banner with `action` only - does not render `secondaryAction` button'
-  );
-
-  this.setProperties({
-    mainActionLoading: true,
-    mainActionDisabled: false,
+    iconSvg.hasAttribute(
+      'data-icon-source',
+      'polaris/circle-barred',
+      'banner with critical status - has icon polaris/circle-barred'
+    );
   });
-  this.render(hbs`{{polaris-banner
-    action=(hash
-      text="Edit"
-      loading=mainActionLoading
-      disabled=mainActionDisabled
-      onAction=(action "mainAction")
-    )
-    secondaryAction=(hash
-      text="View"
-      onAction=(action "secAction")
-    )
-  }}`);
 
-  banner = find(bannerSelector);
-  content = find(contentSelector, banner);
-  actions = find(actionsSelector, content);
-  btnGroup = find('div.Polaris-ButtonGroup', actions);
-  actionBtn = find(
-    'div.Polaris-ButtonGroup__Item > div.Polaris-Banner__PrimaryAction > button.Polaris-Button.Polaris-Button--outline',
-    btnGroup
-  );
-  secondaryActionBtn = find(
-    'div.Polaris-ButtonGroup__Item > button.Polaris-Banner__SecondaryAction',
-    btnGroup
-  );
-  assert.ok(actionBtn, 'banner with actions - renders `action` button');
-  assert.ok(
-    actionBtn.classList.contains('Polaris-Button--loading'),
-    'banner with actions - `action` button starts in loading state'
-  );
+  test('it handles dismissable banner correctly', async function(assert) {
+    await render(hbs`{{polaris-banner}}`);
 
-  this.setProperties({
-    mainActionLoading: false,
-    mainActionDisabled: true,
+    let banner = assert.dom(bannerSelector);
+    let dismissWrapper = assert.dom(`${bannerSelector} ${dismissSelector}`);
+
+    banner.hasNoClass(
+      'Polaris-Banner--hasDismiss',
+      'banner non-dismissable - does not have dismissable class'
+    );
+
+    dismissWrapper.doesNotExist(
+      'banner non-dismissable - does not render the dismiss element'
+    );
+
+    let dismissed = false;
+    this.actions.dismiss = () => (dismissed = true);
+
+    await render(hbs`{{polaris-banner onDismiss=(action "dismiss")}}`);
+
+    banner = assert.dom(bannerSelector);
+    dismissWrapper = assert.dom(`${bannerSelector} ${dismissSelector}`);
+    let dismissBtnSelector = `${bannerSelector} ${dismissSelector} button.Polaris-Button.Polaris-Button--plain.Polaris-Button--iconOnly`;
+    let dismissBtn = assert.dom(dismissBtnSelector);
+    banner.hasClass(
+      'Polaris-Banner--hasDismiss',
+      'banner dismissable - has dismissable class'
+    );
+
+    dismissWrapper.exists(
+      'banner dismissable - does render the dismiss element'
+    );
+    dismissBtn.exists('banner dismissable - has correct dismiss button');
+
+    dismissBtn.hasAttribute(
+      'aria-label',
+      'Dismiss notification',
+      'banner dismissable - dismiss button has correct aria-label'
+    );
+
+    await click(dismissBtnSelector);
+
+    assert.ok(dismissed, 'banner dismissable - fires dismiss action');
   });
-  assert.notOk(
-    actionBtn.classList.contains('Polaris-Button--loading'),
-    'banner with actions - `action` button exits loading state'
-  );
-  assert.ok(
-    actionBtn.disabled,
-    'banner with actions - `action` button becomes disabled'
-  );
-  assert.equal(
-    actionBtn.textContent.trim(),
-    'Edit',
-    'banner with actions - renders correct `action` button text'
-  );
 
-  assert.ok(
-    secondaryActionBtn,
-    'banner with actions - renders `secondaryAction` button'
-  );
-  assert.equal(
-    secondaryActionBtn.textContent.trim(),
-    'View',
-    'banner with actions - renders correct `secondaryAction` button text'
-  );
+  test('it supports `action` and `secondaryAction`', async function(assert) {
+    await render(hbs`{{polaris-banner text="Some content text"}}`);
 
-  this.set('mainActionDisabled', false);
-  click(actionBtn);
+    let bannerContentSelector = `${bannerSelector} ${contentSelector}`;
+    let bannerActionsSelector = `${bannerContentSelector} ${actionsSelector}`;
 
-  assert.ok(
-    mainActionFired,
-    "banner with actions - clicking `action` button - trigger `action`'s action"
-  );
-  assert.notOk(
-    secActionFired,
-    "banner with actions - clicking `action` button - does not trigger `secondaryAction`'s action"
-  );
+    let actions = assert.dom(bannerActionsSelector);
 
-  mainActionFired = false;
-  click(secondaryActionBtn);
+    actions.doesNotExist(
+      'banner without actions - does not render the actions container'
+    );
 
-  assert.ok(
-    secActionFired,
-    "banner with actions - clicking `secondaryAction` button - trigger `secondaryAction`'s action"
-  );
-  assert.notOk(
-    mainActionFired,
-    "banner with actions - clicking `secondaryAction` button - does not trigger `action`'s action"
-  );
+    let mainActionFired = false;
+    this.actions.mainAction = () => (mainActionFired = true);
+
+    let secActionFired = false;
+    this.actions.secAction = () => (secActionFired = true);
+
+    await render(hbs`{{polaris-banner
+      secondaryAction=(hash text="View" onAction=(action "secAction"))
+    }}`);
+
+    actions = assert.dom(`${bannerContentSelector} ${actionsSelector}`);
+
+    actions.doesNotExist(
+      'banner with `secondaryAction` only - does not render the actions container'
+    );
+
+    await render(hbs`{{polaris-banner
+      action=(hash text="Edit" onAction=(action "mainAction"))
+    }}`);
+
+    actions = assert.dom(bannerActionsSelector);
+
+    let btnGroupSelector = `${actionsSelector} div.Polaris-ButtonGroup`;
+    let actionBtnSelector = `${btnGroupSelector} div.Polaris-ButtonGroup__Item > div.Polaris-Banner__PrimaryAction > button.Polaris-Button.Polaris-Button--outline`;
+
+    let secondaryActionBtnSelector = `${btnGroupSelector} div.Polaris-ButtonGroup__Item > button.Polaris-Banner__SecondaryAction`;
+
+    actions.exists('banner with `action` only - renders actions container');
+    assert
+      .dom(actionBtnSelector)
+      .exists('banner with `action` only - renders `action` button');
+
+    assert
+      .dom(secondaryActionBtnSelector)
+      .doesNotExist(
+        'banner with `action` only - does not render `secondaryAction` button'
+      );
+
+    this.setProperties({
+      mainActionLoading: true,
+      mainActionDisabled: false,
+    });
+
+    await render(hbs`{{polaris-banner
+      action=(hash
+        text="Edit"
+        loading=mainActionLoading
+        disabled=mainActionDisabled
+        onAction=(action "mainAction")
+      )
+      secondaryAction=(hash
+        text="View"
+        onAction=(action "secAction")
+      )
+    }}`);
+
+    actions = assert.dom(actionsSelector);
+
+    let actionBtn = assert.dom(actionBtnSelector);
+
+    let secondaryActionBtn = assert.dom(secondaryActionBtnSelector);
+
+    actionBtn.exists('banner with actions - renders `action` button');
+    actionBtn.hasClass(
+      'Polaris-Button--loading',
+      'banner with actions - `action` button starts in loading state'
+    );
+
+    this.setProperties({
+      mainActionLoading: false,
+      mainActionDisabled: true,
+    });
+    actionBtn.hasNoClass(
+      'Polaris-Button--loading',
+      'banner with actions - `action` button exits loading state'
+    );
+
+    actionBtn.isDisabled(
+      'banner with actions - `action` button becomes disabled'
+    );
+    actionBtn.hasText(
+      'Edit',
+      'banner with actions - renders correct `action` button text'
+    );
+
+    secondaryActionBtn.exists(
+      'banner with actions - renders `secondaryAction` button'
+    );
+    secondaryActionBtn.hasText(
+      'View',
+      'banner with actions - renders correct `secondaryAction` button text'
+    );
+
+    this.set('mainActionDisabled', false);
+    await click(actionBtnSelector);
+
+    assert.ok(
+      mainActionFired,
+      "banner with actions - clicking `action` button - trigger `action`'s action"
+    );
+    assert.notOk(
+      secActionFired,
+      "banner with actions - clicking `action` button - does not trigger `secondaryAction`'s action"
+    );
+
+    mainActionFired = false;
+    await click(secondaryActionBtnSelector);
+
+    assert.ok(
+      secActionFired,
+      "banner with actions - clicking `secondaryAction` button - trigger `secondaryAction`'s action"
+    );
+    assert.notOk(
+      mainActionFired,
+      "banner with actions - clicking `secondaryAction` button - does not trigger `action`'s action"
+    );
+  });
 });

--- a/tests/integration/components/polaris-button-group-test.js
+++ b/tests/integration/components/polaris-button-group-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { findAll, find, focus, blur, render } from '@ember/test-helpers';
+import { findAll, focus, blur, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
@@ -22,78 +22,64 @@ module('Integration | Component | polaris button group', function(hooks) {
       {{/polaris-button-group}}
     `);
 
-    const buttonGroups = findAll(buttonGroupSelector);
-    assert.equal(buttonGroups.length, 1, 'renders one button group');
+    assert
+      .dom(buttonGroupSelector)
+      .exists({ count: 1 }, 'renders one button group');
 
-    const buttons = findAll(buttonSelector);
-    assert.equal(
-      buttons.length,
-      2,
-      'renders the correct number of wrapped buttons'
-    );
+    assert
+      .dom(buttonSelector)
+      .exists({ count: 2 }, 'renders the correct number of wrapped buttons');
   });
 
   test('it renders the correct HTML with segmented attribute', async function(assert) {
     this.set('segmented', true);
     await render(hbs`{{polaris-button-group segmented=segmented}}`);
 
-    const buttonGroup = find(buttonGroupSelector);
-    assert
-      .dom(buttonGroup)
-      .hasClass(
-        'Polaris-ButtonGroup--segmented',
-        'segmented=true - adds the segmented class'
-      );
+    const buttonGroup = assert.dom(buttonGroupSelector);
+    buttonGroup.hasClass(
+      'Polaris-ButtonGroup--segmented',
+      'segmented=true - adds the segmented class'
+    );
 
     this.set('segmented', false);
-    assert
-      .dom(buttonGroup)
-      .hasNoClass(
-        'Polaris-ButtonGroup--segmented',
-        'segmented=true - does not add the segmented class'
-      );
+    buttonGroup.hasNoClass(
+      'Polaris-ButtonGroup--segmented',
+      'segmented=true - does not add the segmented class'
+    );
   });
 
   test('it renders the correct HTML with fullWidth attribute', async function(assert) {
     this.set('fullWidth', true);
     await render(hbs`{{polaris-button-group fullWidth=fullWidth}}`);
 
-    const buttonGroup = find(buttonGroupSelector);
-    assert
-      .dom(buttonGroup)
-      .hasClass(
-        'Polaris-ButtonGroup--fullWidth',
-        'fullWidth=true - adds the fullWidth class'
-      );
+    const buttonGroup = assert.dom(buttonGroupSelector);
+    buttonGroup.hasClass(
+      'Polaris-ButtonGroup--fullWidth',
+      'fullWidth=true - adds the fullWidth class'
+    );
 
     this.set('fullWidth', false);
-    assert
-      .dom(buttonGroup)
-      .hasNoClass(
-        'Polaris-ButtonGroup--fullWidth',
-        'fullWidth=false - does not add the fullWidth class'
-      );
+    buttonGroup.hasNoClass(
+      'Polaris-ButtonGroup--fullWidth',
+      'fullWidth=false - does not add the fullWidth class'
+    );
   });
 
   test('it renders the correct HTML with connectedTop attribute', async function(assert) {
     this.set('connectedTop', true);
     await render(hbs`{{polaris-button-group connectedTop=connectedTop}}`);
 
-    const buttonGroup = find(buttonGroupSelector);
-    assert
-      .dom(buttonGroup)
-      .hasClass(
-        'Polaris-ButtonGroup--connectedTop',
-        'connectedTop=true - adds the connectedTop class'
-      );
+    const buttonGroup = assert.dom(buttonGroupSelector);
+    buttonGroup.hasClass(
+      'Polaris-ButtonGroup--connectedTop',
+      'connectedTop=true - adds the connectedTop class'
+    );
 
     this.set('connectedTop', false);
-    assert
-      .dom(buttonGroup)
-      .hasNoClass(
-        'Polaris-ButtonGroup--connectedTop',
-        'connectedTop=false - does not add the connectedTop class'
-      );
+    buttonGroup.hasNoClass(
+      'Polaris-ButtonGroup--connectedTop',
+      'connectedTop=false - does not add the connectedTop class'
+    );
   });
 
   test('it renders the correct HTML in block usage', async function(assert) {
@@ -109,13 +95,14 @@ module('Integration | Component | polaris button group', function(hooks) {
       {{/polaris-button-group}}
     `);
 
-    const buttonGroupItems = findAll(buttonGroupItemSelector);
-    assert.equal(
-      buttonGroupItems.length,
-      3,
+    let buttonGroupItems = assert.dom(buttonGroupItemSelector);
+
+    buttonGroupItems.exists(
+      { count: 3 },
       'renders the correct number of button group items'
     );
 
+    buttonGroupItems = findAll(buttonGroupItemSelector);
     // Check the first item.
     let buttonGroupItem = buttonGroupItems[0];
     assert
@@ -171,30 +158,24 @@ module('Integration | Component | polaris button group', function(hooks) {
       {{/polaris-button-group}}
     `);
 
-    const buttonGroupItem = find(buttonGroupItemSelector);
-    assert.ok(buttonGroupItem, 'renders the button group item');
+    const buttonGroupItem = assert.dom(buttonGroupItemSelector);
+    buttonGroupItem.exists('renders the button group item');
 
-    assert
-      .dom(buttonGroupItem)
-      .hasNoClass(
-        'Polaris-ButtonGroup__Item--focused',
-        'before focus - group item does not have focused class'
-      );
+    buttonGroupItem.hasNoClass(
+      'Polaris-ButtonGroup__Item--focused',
+      'before focus - group item does not have focused class'
+    );
 
     await focus('.Polaris-Button');
-    assert
-      .dom(buttonGroupItem)
-      .hasClass(
-        'Polaris-ButtonGroup__Item--focused',
-        'after focus - group item has focused class'
-      );
+    buttonGroupItem.hasClass(
+      'Polaris-ButtonGroup__Item--focused',
+      'after focus - group item has focused class'
+    );
 
     await blur('.Polaris-Button');
-    assert
-      .dom(buttonGroupItem)
-      .hasNoClass(
-        'Polaris-ButtonGroup__Item--focused',
-        'after blur - group item does not have focused class'
-      );
+    buttonGroupItem.hasNoClass(
+      'Polaris-ButtonGroup__Item--focused',
+      'after blur - group item does not have focused class'
+    );
   });
 });

--- a/tests/integration/components/polaris-callout-card-test.js
+++ b/tests/integration/components/polaris-callout-card-test.js
@@ -1,236 +1,221 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { click, findAll, render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { findAll, click } from 'ember-native-dom-helpers';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
-moduleForComponent(
-  'polaris-callout-card',
-  'Integration | Component | polaris callout card',
-  {
-    integration: true,
-  }
-);
+module('Integration | Component | polaris callout card', function(hooks) {
+  setupRenderingTest(hooks);
 
-const calloutCardSelector = buildNestedSelector(
-  'div.Polaris-Card',
-  'div.Polaris-CalloutCard__Container',
-  'div.Polaris-Card__Section',
-  'div.Polaris-CalloutCard'
-);
-const calloutCardContentSelector = buildNestedSelector(
-  calloutCardSelector,
-  'div.Polaris-CalloutCard__Content'
-);
-const calloutCardContentHeadingSelector = buildNestedSelector(
-  calloutCardContentSelector,
-  'div.Polaris-CalloutCard__Title',
-  'h2.Polaris-Heading'
-);
-const calloutCardContentTextSelector = buildNestedSelector(
-  calloutCardContentSelector,
-  'div.Polaris-TextContainer'
-);
-const calloutCardButtonWrapperSelector = buildNestedSelector(
-  calloutCardContentSelector,
-  'div.Polaris-CalloutCard__Buttons'
-);
-const calloutCardImageSelector = buildNestedSelector(
-  calloutCardSelector,
-  'img.Polaris-CalloutCard__Image'
-);
-
-test('it renders the correct HTML in inline form without secondary action', function(assert) {
-  this.render(hbs`
-    {{polaris-callout-card
-      title="This is an inline callout card"
-      text="Without a secondary action"
-      illustration="http://www.somewhere.com/some-image.jpg"
-      primaryAction=(hash
-        text="Primary action here"
-        onAction=(action (mut primaryActionFired) true)
-      )
-    }}
-  `);
-
-  const calloutCards = findAll(calloutCardSelector);
-  assert.equal(calloutCards.length, 1, 'renders one callout card');
-
-  const headings = findAll(calloutCardContentHeadingSelector);
-  assert.equal(headings.length, 1, 'renders one heading');
-  assert.equal(
-    headings[0].textContent.trim(),
-    'This is an inline callout card',
-    'renders the correct heading'
+  const calloutCardSelector = buildNestedSelector(
+    'div.Polaris-Card',
+    'div.Polaris-CalloutCard__Container',
+    'div.Polaris-Card__Section',
+    'div.Polaris-CalloutCard'
+  );
+  const calloutCardContentSelector = buildNestedSelector(
+    calloutCardSelector,
+    'div.Polaris-CalloutCard__Content'
+  );
+  const calloutCardContentHeadingSelector = buildNestedSelector(
+    calloutCardContentSelector,
+    'div.Polaris-CalloutCard__Title',
+    'h2.Polaris-Heading'
+  );
+  const calloutCardContentTextSelector = buildNestedSelector(
+    calloutCardContentSelector,
+    'div.Polaris-TextContainer'
+  );
+  const calloutCardButtonWrapperSelector = buildNestedSelector(
+    calloutCardContentSelector,
+    'div.Polaris-CalloutCard__Buttons'
+  );
+  const calloutCardImageSelector = buildNestedSelector(
+    calloutCardSelector,
+    'img.Polaris-CalloutCard__Image'
   );
 
-  const texts = findAll(calloutCardContentTextSelector);
-  assert.equal(texts.length, 1, 'renders one text container');
-  assert.equal(
-    texts[0].textContent.trim(),
-    'Without a secondary action',
-    'renders the correct text'
-  );
+  test('it renders the correct HTML in inline form without secondary action', async function(assert) {
+    await render(hbs`
+      {{polaris-callout-card
+        title="This is an inline callout card"
+        text="Without a secondary action"
+        illustration="http://www.somewhere.com/some-image.jpg"
+        primaryAction=(hash
+          text="Primary action here"
+          onAction=(action (mut primaryActionFired) true)
+        )
+      }}
+    `);
 
-  const buttonWrappers = findAll(calloutCardButtonWrapperSelector);
-  assert.equal(buttonWrappers.length, 1, 'renders one button wrapper');
+    assert
+      .dom(calloutCardSelector)
+      .exists({ count: 1 }, 'renders one callout card');
 
-  const buttonSelector = buildNestedSelector(
-    calloutCardButtonWrapperSelector,
-    'button.Polaris-Button'
-  );
-  const buttons = findAll(buttonSelector);
-  assert.equal(buttons.length, 1, 'renders one button');
-  assert.equal(
-    buttons[0].textContent.trim(),
-    'Primary action here',
-    'renders the correct button text'
-  );
+    const headings = assert.dom(calloutCardContentHeadingSelector);
+    headings.exists({ count: 1 }, 'renders one heading');
+    headings.hasText(
+      'This is an inline callout card',
+      'renders the correct heading'
+    );
 
-  const images = findAll(calloutCardImageSelector);
-  assert.equal(images.length, 1, 'renders one image');
+    const texts = assert.dom(calloutCardContentTextSelector);
+    texts.exists({ count: 1 }, 'renders one text container');
+    texts.hasText('Without a secondary action', 'renders the correct text');
 
-  const image = images[0];
-  assert.equal(
-    image.src,
-    'http://www.somewhere.com/some-image.jpg',
-    'renders the correct image'
-  );
-  assert.equal(image.alt, '', 'renders an empty image title');
-});
+    assert
+      .dom(calloutCardButtonWrapperSelector)
+      .exists({ count: 1 }, 'renders one button wrapper');
 
-test('it renders the correct HTML in block form with secondary action', function(assert) {
-  this.render(hbs`
-    {{#polaris-callout-card
-      title="This is a block callout card"
-      illustration="http://www.somewhere.com/some-image.jpg"
-      primaryAction=(hash
-        text="Primary action here"
-        onAction=(action (mut primaryActionFired) true)
-      )
-      secondaryAction=(hash
-        text="Secondary action here"
-        onAction=(action (mut secondaryActionFired) true)
-      )
-    }}
-      With a secondary action
-    {{/polaris-callout-card}}
-  `);
+    const buttonSelector = buildNestedSelector(
+      calloutCardButtonWrapperSelector,
+      'button.Polaris-Button'
+    );
+    const buttons = assert.dom(buttonSelector);
+    buttons.exists({ count: 1 }, 'renders one button');
+    buttons.hasText('Primary action here', 'renders the correct button text');
 
-  const calloutCards = findAll(calloutCardSelector);
-  assert.equal(calloutCards.length, 1, 'renders one callout card');
+    const images = assert.dom(calloutCardImageSelector);
+    images.exists({ count: 1 }, 'renders one image');
 
-  const headings = findAll(calloutCardContentHeadingSelector);
-  assert.equal(headings.length, 1, 'renders one heading');
-  assert.equal(
-    headings[0].textContent.trim(),
-    'This is a block callout card',
-    'renders the correct heading'
-  );
-
-  const texts = findAll(calloutCardContentTextSelector);
-  assert.equal(texts.length, 1, 'renders one text container');
-  assert.equal(
-    texts[0].textContent.trim(),
-    'With a secondary action',
-    'renders the correct text'
-  );
-
-  const buttonWrappers = findAll(calloutCardButtonWrapperSelector);
-  assert.equal(buttonWrappers.length, 1, 'renders one button wrapper');
-
-  const buttonSelector = buildNestedSelector(
-    calloutCardButtonWrapperSelector,
-    'div.Polaris-ButtonGroup',
-    'div.Polaris-ButtonGroup__Item',
-    'button.Polaris-Button'
-  );
-  const buttons = findAll(buttonSelector);
-  assert.equal(buttons.length, 2, 'renders two buttons');
-
-  let button = buttons[0];
-  assert.equal(
-    button.textContent.trim(),
-    'Primary action here',
-    'renders the correct primary button text'
-  );
-  assert.notOk(
-    button.classList.contains('Polaris-Button--plain'),
-    'renders normal primary button'
-  );
-
-  button = buttons[1];
-  assert.equal(
-    button.textContent.trim(),
-    'Secondary action here',
-    'renders the correct secondary button text'
-  );
-  assert.ok(
-    button.classList.contains('Polaris-Button--plain'),
-    'renders plain secondary button'
-  );
-
-  const images = findAll(calloutCardImageSelector);
-  assert.equal(images.length, 1, 'renders one image');
-
-  const image = images[0];
-  assert.equal(
-    image.src,
-    'http://www.somewhere.com/some-image.jpg',
-    'renders the correct image'
-  );
-  assert.equal(image.alt, '', 'renders an empty image title');
-});
-
-test('it handles actions correctly', function(assert) {
-  this.setProperties({
-    primaryActionFired: false,
-    secondaryActionFired: false,
+    images.hasAttribute(
+      'src',
+      'http://www.somewhere.com/some-image.jpg',
+      'renders the correct image'
+    );
+    images.hasAttribute('alt', '', 'renders an empty image title');
   });
 
-  this.render(hbs`
-    {{polaris-callout-card
-      primaryAction=(hash
-        text="Primary"
-        onAction=(action (mut primaryActionFired) true)
-      )
-      secondaryAction=(hash
-        text="Secondary"
-        onAction=(action (mut secondaryActionFired) true)
-      )
-    }}
-  `);
+  test('it renders the correct HTML in block form with secondary action', async function(assert) {
+    await render(hbs`
+      {{#polaris-callout-card
+        title="This is a block callout card"
+        illustration="http://www.somewhere.com/some-image.jpg"
+        primaryAction=(hash
+          text="Primary action here"
+          onAction=(action (mut primaryActionFired) true)
+        )
+        secondaryAction=(hash
+          text="Secondary action here"
+          onAction=(action (mut secondaryActionFired) true)
+        )
+      }}
+        With a secondary action
+      {{/polaris-callout-card}}
+    `);
 
-  // Fire the primary action.
-  click('button.Polaris-Button:first-of-type');
-  assert.ok(
-    this.get('primaryActionFired'),
-    'after firing primary action - primary action has fired'
-  );
-  assert.notOk(
-    this.get('secondaryActionFired'),
-    'after firing primary action - secondary action has not fired'
-  );
+    assert
+      .dom(calloutCardSelector)
+      .exists({ count: 1 }, 'renders one callout card');
 
-  click('button.Polaris-Button.Polaris-Button--plain');
-  assert.ok(
-    this.get('secondaryActionFired'),
-    'after firing secondary action - secondary action has been fired'
-  );
-});
+    const headings = assert.dom(calloutCardContentHeadingSelector);
+    headings.exists({ count: 1 }, 'renders one heading');
+    headings.hasText(
+      'This is a block callout card',
+      'renders the correct heading'
+    );
 
-test('it is dismissed', function(assert) {
-  this.render(hbs`
-    {{polaris-callout-card
-      primaryAction=(hash
-        text="Primary"
-        onAction=(action (mut primaryActionFired) true)
-      )
-      onDismiss=(action (mut wasOnDismissCalled) true)
-    }}
-  `);
+    const texts = assert.dom(calloutCardContentTextSelector);
+    texts.exists({ count: 1 }, 'renders one text container');
+    texts.hasText('With a secondary action', 'renders the correct text');
 
-  assert.dom('.Polaris-Button').exists({ count: 2 });
+    assert
+      .dom(calloutCardButtonWrapperSelector)
+      .exists({ count: 1 }, 'renders one button wrapper');
 
-  click('.Polaris-Button');
-  assert.ok(this.get('wasOnDismissCalled'));
+    const buttonSelector = buildNestedSelector(
+      calloutCardButtonWrapperSelector,
+      'div.Polaris-ButtonGroup',
+      'div.Polaris-ButtonGroup__Item',
+      'button.Polaris-Button'
+    );
+    const buttons = findAll(buttonSelector);
+    assert.equal(buttons.length, 2, 'renders two buttons');
+
+    let button = buttons[0];
+    assert
+      .dom(button)
+      .hasText(
+        'Primary action here',
+        'renders the correct primary button text'
+      );
+    assert
+      .dom(button)
+      .hasNoClass('Polaris-Button--plain', 'renders normal primary button');
+
+    button = buttons[1];
+    assert
+      .dom(button)
+      .hasText(
+        'Secondary action here',
+        'renders the correct secondary button text'
+      );
+    assert
+      .dom(button)
+      .hasClass('Polaris-Button--plain', 'renders plain secondary button');
+
+    const images = assert.dom(calloutCardImageSelector);
+    images.exists({ count: 1 }, 'renders one image');
+
+    images.hasAttribute(
+      'src',
+      'http://www.somewhere.com/some-image.jpg',
+      'renders the correct image'
+    );
+    images.hasAttribute('alt', '', 'renders an empty image title');
+  });
+
+  test('it handles actions correctly', async function(assert) {
+    this.setProperties({
+      primaryActionFired: false,
+      secondaryActionFired: false,
+    });
+
+    await render(hbs`
+      {{polaris-callout-card
+        primaryAction=(hash
+          text="Primary"
+          onAction=(action (mut primaryActionFired) true)
+        )
+        secondaryAction=(hash
+          text="Secondary"
+          onAction=(action (mut secondaryActionFired) true)
+        )
+      }}
+    `);
+
+    // Fire the primary action.
+    await click('button.Polaris-Button:first-of-type');
+    assert.ok(
+      this.get('primaryActionFired'),
+      'after firing primary action - primary action has fired'
+    );
+    assert.notOk(
+      this.get('secondaryActionFired'),
+      'after firing primary action - secondary action has not fired'
+    );
+
+    await click('button.Polaris-Button.Polaris-Button--plain');
+    assert.ok(
+      this.get('secondaryActionFired'),
+      'after firing secondary action - secondary action has been fired'
+    );
+  });
+
+  test('it is dismissed', async function(assert) {
+    await render(hbs`
+      {{polaris-callout-card
+        primaryAction=(hash
+          text="Primary"
+          onAction=(action (mut primaryActionFired) true)
+        )
+        onDismiss=(action (mut wasOnDismissCalled) true)
+      }}
+    `);
+
+    assert.dom('.Polaris-Button').exists({ count: 2 });
+
+    await click('.Polaris-Button');
+    assert.ok(this.get('wasOnDismissCalled'));
+  });
 });

--- a/tests/integration/components/polaris-caption-test.js
+++ b/tests/integration/components/polaris-caption-test.js
@@ -1,46 +1,35 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { find } from 'ember-native-dom-helpers';
 
-moduleForComponent(
-  'polaris-caption',
-  'Integration | Component | polaris caption',
-  {
-    integration: true,
-  }
-);
+module('Integration | Component | polaris caption', function(hooks) {
+  setupRenderingTest(hooks);
 
-const caption = 'Received April 21, 2017';
-const componentSelector = 'p.Polaris-Caption';
+  const caption = 'Received April 21, 2017';
+  const componentSelector = 'p.Polaris-Caption';
 
-test('it renders the correct HTML with inline usage', function(assert) {
-  this.set('text', caption);
-  this.render(hbs`{{polaris-caption text=text}}`);
+  test('it renders the correct HTML with inline usage', async function(assert) {
+    this.set('text', caption);
+    await render(hbs`{{polaris-caption text=text}}`);
 
-  const captionNode = find(componentSelector);
+    const captionNode = assert.dom(componentSelector);
 
-  assert.ok(captionNode, 'it renders the caption');
-  assert.equal(
-    captionNode.textContent.trim(),
-    caption,
-    'it renders the correct caption text'
-  );
-});
+    captionNode.exists('it renders the caption');
+    captionNode.hasText(caption, 'it renders the correct caption text');
+  });
 
-test('it renders the correct HTML with block usage', function(assert) {
-  this.set('caption', caption);
-  this.render(hbs`
-    {{#polaris-caption}}
-      {{caption}}
-    {{/polaris-caption}}
-  `);
+  test('it renders the correct HTML with block usage', async function(assert) {
+    this.set('caption', caption);
+    await render(hbs`
+      {{#polaris-caption}}
+        {{caption}}
+      {{/polaris-caption}}
+    `);
 
-  const captionNode = find(componentSelector);
+    const captionNode = assert.dom(componentSelector);
 
-  assert.ok(captionNode, 'it renders the caption');
-  assert.equal(
-    captionNode.textContent.trim(),
-    caption,
-    'it renders the correct caption text'
-  );
+    captionNode.exists('it renders the caption');
+    captionNode.hasText(caption, 'it renders the correct caption text');
+  });
 });

--- a/tests/integration/components/polaris-card-test.js
+++ b/tests/integration/components/polaris-card-test.js
@@ -31,14 +31,10 @@ module('Integration | Component | polaris card', function(hooks) {
       {{/polaris-card}}
     `);
 
-    const cards = findAll(cardSelector);
-    assert.equal(
-      cards.length,
-      1,
-      'one section, basic usage - renders one card'
-    );
-    assert.notOk(
-      cards[0].classList.contains('Polaris-Card--subdued'),
+    let card = assert.dom(cardSelector);
+    card.exists({ count: 1 }, 'one section, basic usage - renders one card');
+    card.hasNoClass(
+      'Polaris-Card--subdued',
       'one section, basic usage - does not apply subdued class'
     );
 
@@ -46,27 +42,23 @@ module('Integration | Component | polaris card', function(hooks) {
       headerSelector,
       'h2.Polaris-Heading'
     );
-    const headings = findAll(headingSelector);
-    assert.equal(
-      headings.length,
-      1,
+    const heading = assert.dom(headingSelector);
+    heading.exists(
+      { count: 1 },
       'one section, basic usage - renders one heading'
     );
-    assert.equal(
-      headings[0].textContent.trim(),
+    heading.hasText(
       'This is the card title',
       'one section, basic usage - renders correct heading text'
     );
 
     const unsectionedParagraphSelector = buildNestedSelector(cardSelector, 'p');
-    const unsectionedParagraphs = findAll(unsectionedParagraphSelector);
-    assert.equal(
-      unsectionedParagraphs.length,
-      1,
+    const unsectionedParagraphs = assert.dom(unsectionedParagraphSelector);
+    unsectionedParagraphs.exists(
+      { count: 1 },
       'one section, basic usage - renders one unsectioned paragraph'
     );
-    assert.equal(
-      unsectionedParagraphs[0].textContent.trim(),
+    unsectionedParagraphs.hasText(
       'This is the card content',
       'one section, basic usage - renders correct unsectioned paragraph text'
     );
@@ -82,14 +74,13 @@ module('Integration | Component | polaris card', function(hooks) {
       sectionSelector,
       'p'
     );
-    const sectionedParagraphs = findAll(sectionedParagraphSelector);
-    assert.equal(
-      sectionedParagraphs.length,
-      1,
+    const sectionedParagraphs = assert.dom(sectionedParagraphSelector);
+
+    sectionedParagraphs.exists(
+      { count: 1 },
       'one section, basic usage - renders one sectioned paragraph'
     );
-    assert.equal(
-      sectionedParagraphs[0].textContent.trim(),
+    sectionedParagraphs.hasText(
       'This is the card content',
       'one section, basic usage - renders correct sectioned paragraph text'
     );
@@ -102,12 +93,12 @@ module('Integration | Component | polaris card', function(hooks) {
     `);
 
     const subduedCardSelector = 'div.Polaris-Card.Polaris-Card--subdued';
-    const subduedCards = findAll(subduedCardSelector);
-    assert.equal(
-      subduedCards.length,
-      1,
-      'one section, subdued=true - renders one card with subdued class'
-    );
+    assert
+      .dom(subduedCardSelector)
+      .exists(
+        { count: 1 },
+        'one section, subdued=true - renders one card with subdued class'
+      );
 
     // Multiple sections.
     await render(hbs`
@@ -302,10 +293,9 @@ module('Integration | Component | polaris card', function(hooks) {
       'div.Polaris-Stack__Item.Polaris-Stack__Item--fill',
       'h2.Polaris-Heading'
     );
-    const headings = findAll(headingSelector);
-    assert.equal(headings.length, 1, 'renders one heading');
-    assert.equal(
-      headings[0].textContent.trim(),
+    const headings = assert.dom(headingSelector);
+    headings.exists({ count: 1 }, 'renders one heading');
+    headings.hasText(
       'This is a card with actions',
       'renders correct heading content'
     );
@@ -324,21 +314,15 @@ module('Integration | Component | polaris card', function(hooks) {
       3,
       'renders the correct number of action buttons'
     );
-    assert.equal(
-      actionButtons[0].textContent.trim(),
-      'Action 1',
-      'first action button - renders correct content'
-    );
-    assert.equal(
-      actionButtons[1].textContent.trim(),
-      'Action 2',
-      'second action button - renders correct content'
-    );
-    assert.equal(
-      actionButtons[2].textContent.trim(),
-      'Action 3',
-      'third action button - renders correct content'
-    );
+    assert
+      .dom(actionButtons[0])
+      .hasText('Action 1', 'first action button - renders correct content');
+    assert
+      .dom(actionButtons[1])
+      .hasText('Action 2', 'second action button - renders correct content');
+    assert
+      .dom(actionButtons[2])
+      .hasText('Action 3', 'third action button - renders correct content');
 
     // Check clicking the buttons.
     await click(actionButtons[0]);
@@ -366,10 +350,12 @@ module('Integration | Component | polaris card', function(hooks) {
       false,
       'clicking disabled third action button - does not invoke third action handler'
     );
-    assert.ok(
-      actionButtons[2].classList.contains('Polaris-Button--disabled'),
-      'third action is a disabled header action - disabled class'
-    );
+    assert
+      .dom(actionButtons[2])
+      .hasClass(
+        'Polaris-Button--disabled',
+        'third action is a disabled header action - disabled class'
+      );
   });
 
   test('it allows section header customization', async function(assert) {
@@ -401,24 +387,24 @@ module('Integration | Component | polaris card', function(hooks) {
       1,
       'renders one section header title'
     );
-    assert.equal(
-      sectionHeaderTitles[0].textContent.trim(),
-      'Custom section title',
-      'renders the correct section header title'
-    );
+    assert
+      .dom(sectionHeaderTitles[0])
+      .hasText(
+        'Custom section title',
+        'renders the correct section header title'
+      );
 
     const sectionHeaderContentSelector = buildNestedSelector(
       sectionHeaderSelector,
       'p'
     );
-    const sectionHeaderContents = findAll(sectionHeaderContentSelector);
-    assert.equal(
-      sectionHeaderContents.length,
-      1,
+    const sectionHeaderContents = assert.dom(sectionHeaderContentSelector);
+
+    sectionHeaderContents.exists(
+      { count: 1 },
       'renders custom section header content'
     );
-    assert.equal(
-      sectionHeaderContents[0].textContent.trim(),
+    sectionHeaderContents.hasText(
       'Custom section content',
       'renders the correct custom section header content'
     );

--- a/tests/integration/components/polaris-choice-test.js
+++ b/tests/integration/components/polaris-choice-test.js
@@ -1,7 +1,8 @@
 import Component from '@ember/component';
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { findAll, find } from 'ember-native-dom-helpers';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 import MockSvgJarComponent from '../../mocks/components/svg-jar';
 
@@ -15,465 +16,441 @@ const TestLabelComponent = Component.extend({
   text: 'test label component',
 });
 
-moduleForComponent(
-  'polaris-choice',
-  'Integration | Component | polaris choice',
-  {
-    integration: true,
+module('Integration | Component | polaris choice', function(hooks) {
+  setupRenderingTest(hooks);
 
-    beforeEach() {
-      this.register('component:svg-jar', MockSvgJarComponent);
-      this.register('component:test-label', TestLabelComponent);
-    },
-  }
-);
+  hooks.beforeEach(function() {
+    this.owner.register('component:svg-jar', MockSvgJarComponent);
+    this.owner.register('component:test-label', TestLabelComponent);
+  });
 
-const labelSelector = 'label.Polaris-Choice';
-const controlSelector = buildNestedSelector(
-  labelSelector,
-  'span.Polaris-Choice__Control'
-);
-const labelContentSelector = buildNestedSelector(
-  labelSelector,
-  'span.Polaris-Choice__Label'
-);
-
-// When an error or help text are passed into the choice component,
-// they get rendered in a description div alongside the label;
-// both get wrapped up in one containing div.
-const withDescriptionWrapperSelector = buildNestedSelector(
-  'div.choice-with-description-wrapper',
-  'div'
-);
-const labelWithDescriptionSelector = buildNestedSelector(
-  withDescriptionWrapperSelector,
-  labelSelector
-);
-const controlWithDescriptionSelector = buildNestedSelector(
-  withDescriptionWrapperSelector,
-  controlSelector
-);
-const labelContentWithDescriptionSelector = buildNestedSelector(
-  withDescriptionWrapperSelector,
-  labelContentSelector
-);
-
-const descriptionSelector = buildNestedSelector(
-  withDescriptionWrapperSelector,
-  'div.Polaris-Choice__Descriptions'
-);
-const helpTextSelector = buildNestedSelector(
-  descriptionSelector,
-  'div.Polaris-Choice__HelpText'
-);
-const errorSelector = buildNestedSelector(
-  descriptionSelector,
-  'div.Polaris-Choice__Error'
-);
-const errorIconSelector = buildNestedSelector(
-  errorSelector,
-  'div.Polaris-InlineError',
-  'div.Polaris-InlineError__Icon',
-  'span.Polaris-Icon',
-  'svg'
-);
-
-test('it renders the correct HTML when no error or helpText are provided', function(assert) {
-  this.render(hbs`
-    {{#polaris-choice inputId="test-choice" label="This is my label"}}
-      <span class="test-control">This is a test control</span>
-    {{/polaris-choice}}
-  `);
-
-  const labels = findAll(labelSelector);
-  assert.equal(labels.length, 1, 'renders one label');
-  assert.equal(
-    labels[0].attributes['for'].textContent.trim(),
-    'test-choice',
-    'renders the label with the correct `for` attribute'
+  const labelSelector = 'label.Polaris-Choice';
+  const controlSelector = buildNestedSelector(
+    labelSelector,
+    'span.Polaris-Choice__Control'
+  );
+  const labelContentSelector = buildNestedSelector(
+    labelSelector,
+    'span.Polaris-Choice__Label'
   );
 
-  const testControlSelector = buildNestedSelector(
-    controlSelector,
-    'span.test-control'
+  // When an error or help text are passed into the choice component,
+  // they get rendered in a description div alongside the label;
+  // both get wrapped up in one containing div.
+  const withDescriptionWrapperSelector = buildNestedSelector(
+    'div.choice-with-description-wrapper',
+    'div'
   );
-  const testControls = findAll(testControlSelector);
-  assert.equal(testControls.length, 1, 'renders one control');
-  assert.equal(
-    testControls[0].textContent.trim(),
-    'This is a test control',
-    'renders the control correctly'
+  const labelWithDescriptionSelector = buildNestedSelector(
+    withDescriptionWrapperSelector,
+    labelSelector
+  );
+  const controlWithDescriptionSelector = buildNestedSelector(
+    withDescriptionWrapperSelector,
+    controlSelector
+  );
+  const labelContentWithDescriptionSelector = buildNestedSelector(
+    withDescriptionWrapperSelector,
+    labelContentSelector
   );
 
-  const labelContents = findAll(labelContentSelector);
-  assert.equal(labelContents.length, 1, 'renders one label content wrapper');
-  assert.equal(
-    labelContents[0].textContent.trim(),
-    'This is my label',
-    'renders the label text correctly'
+  const descriptionSelector = buildNestedSelector(
+    withDescriptionWrapperSelector,
+    'div.Polaris-Choice__Descriptions'
   );
-});
+  const helpTextSelector = buildNestedSelector(
+    descriptionSelector,
+    'div.Polaris-Choice__HelpText'
+  );
+  const errorSelector = buildNestedSelector(
+    descriptionSelector,
+    'div.Polaris-Choice__Error'
+  );
+  const errorIconSelector = buildNestedSelector(
+    errorSelector,
+    'div.Polaris-InlineError',
+    'div.Polaris-InlineError__Icon',
+    'span.Polaris-Icon',
+    'svg'
+  );
 
-test('it renders the correct HTML when helpText is provided', function(assert) {
-  this.render(hbs`
-    <div class="choice-with-description-wrapper">
-      {{#polaris-choice
-        inputId="helpful-test-choice"
-        label="This is my label for a control with help text"
-        helpText="This is some help text"
-      }}
-        <span class="helpful-test-control">This is a test control with help text</span>
+  test('it renders the correct HTML when no error or helpText are provided', async function(assert) {
+    await render(hbs`
+      {{#polaris-choice inputId="test-choice" label="This is my label"}}
+        <span class="test-control">This is a test control</span>
       {{/polaris-choice}}
-    </div>
-  `);
+    `);
 
-  const labels = findAll(labelWithDescriptionSelector);
-  assert.equal(labels.length, 1, 'renders one label');
-  assert.equal(
-    labels[0].attributes['for'].textContent.trim(),
-    'helpful-test-choice',
-    'renders the label with the correct `for` attribute'
-  );
+    const labels = assert.dom(labelSelector);
+    labels.exists({ count: 1 }, 'renders one label');
+    labels.hasAttribute(
+      'for',
+      'test-choice',
+      'renders the label with the correct `for` attribute'
+    );
 
-  const testControlSelector = buildNestedSelector(
-    controlWithDescriptionSelector,
-    'span.helpful-test-control'
-  );
-  const testControls = findAll(testControlSelector);
-  assert.equal(testControls.length, 1, 'renders one control');
-  assert.equal(
-    testControls[0].textContent.trim(),
-    'This is a test control with help text',
-    'renders the control correctly'
-  );
+    const testControlSelector = buildNestedSelector(
+      controlSelector,
+      'span.test-control'
+    );
+    const testControls = assert.dom(testControlSelector);
+    testControls.exists({ count: 1 }, 'renders one control');
+    testControls.hasText(
+      'This is a test control',
+      'renders the control correctly'
+    );
 
-  const labelContents = findAll(labelContentWithDescriptionSelector);
-  assert.equal(labelContents.length, 1, 'renders one label content wrapper');
-  assert.equal(
-    labelContents[0].textContent.trim(),
-    'This is my label for a control with help text',
-    'renders the label text correctly'
-  );
+    const labelContents = assert.dom(labelContentSelector);
+    labelContents.exists({ count: 1 }, 'renders one label content wrapper');
+    labelContents.hasText(
+      'This is my label',
+      'renders the label text correctly'
+    );
+  });
 
-  // Check the help text rendering.
-  const helpTexts = findAll(helpTextSelector);
-  assert.equal(helpTexts.length, 1, 'renders one help text');
-  // assert.equal(helpTexts[0].id, 'helpful-test-choiceHelpText'); TODO: figure out why ID isn't being set
-  assert.equal(
-    helpTexts[0].textContent.trim(),
-    'This is some help text',
-    'renders the correct help text'
-  );
-});
+  test('it renders the correct HTML when helpText is provided', async function(assert) {
+    await render(hbs`
+      <div class="choice-with-description-wrapper">
+        {{#polaris-choice
+          inputId="helpful-test-choice"
+          label="This is my label for a control with help text"
+          helpText="This is some help text"
+        }}
+          <span class="helpful-test-control">This is a test control with help text</span>
+        {{/polaris-choice}}
+      </div>
+    `);
 
-test('it renders the correct HTML when an error is provided', function(assert) {
-  this.render(hbs`
-    <div class="choice-with-description-wrapper">
-      {{#polaris-choice
-        inputId="error-test-choice"
-        label="This is my label for a control with an error"
+    const labels = assert.dom(labelWithDescriptionSelector);
+    labels.exists({ count: 1 }, 'renders one label');
+    labels.hasAttribute(
+      'for',
+      'helpful-test-choice',
+      'renders the label with the correct `for` attribute'
+    );
+
+    const testControlSelector = buildNestedSelector(
+      controlWithDescriptionSelector,
+      'span.helpful-test-control'
+    );
+    const testControls = assert.dom(testControlSelector);
+    testControls.exists({ count: 1 }, 'renders one control');
+    testControls.hasText(
+      'This is a test control with help text',
+      'renders the control correctly'
+    );
+
+    const labelContents = assert.dom(labelContentWithDescriptionSelector);
+    labelContents.exists({ count: 1 }, 'renders one label content wrapper');
+    labelContents.hasText(
+      'This is my label for a control with help text',
+      'renders the label text correctly'
+    );
+
+    // Check the help text rendering.
+    const helpTexts = assert.dom(helpTextSelector);
+    helpTexts.exists({ count: 1 }, 'renders one help text');
+    // assert.equal(helpTexts[0].id, 'helpful-test-choiceHelpText'); TODO: figure out why ID isn't being set
+    helpTexts.hasText(
+      'This is some help text',
+      'renders the correct help text'
+    );
+  });
+
+  test('it renders the correct HTML when an error is provided', async function(assert) {
+    await render(hbs`
+      <div class="choice-with-description-wrapper">
+        {{#polaris-choice
+          inputId="error-test-choice"
+          label="This is my label for a control with an error"
+          error="This is an error message"
+        }}
+          <span class="error-test-control">This is a test control with an error</span>
+        {{/polaris-choice}}
+      </div>
+    `);
+
+    const labels = assert.dom(labelWithDescriptionSelector);
+    labels.exists({ count: 1 }, 'renders one label');
+    labels.hasAttribute(
+      'for',
+      'error-test-choice',
+      'renders the label with the correct `for` attribute'
+    );
+
+    const testControlSelector = buildNestedSelector(
+      controlWithDescriptionSelector,
+      'span.error-test-control'
+    );
+    const testControls = assert.dom(testControlSelector);
+    testControls.exists({ count: 1 }, 'renders one control');
+    testControls.hasText(
+      'This is a test control with an error',
+      'renders the control correctly'
+    );
+
+    const labelContents = assert.dom(labelContentWithDescriptionSelector);
+    labelContents.exists({ count: 1 }, 'renders one label content wrapper');
+    labelContents.hasText(
+      'This is my label for a control with an error',
+      'renders the label text correctly'
+    );
+
+    // Check the error rendering.
+    const errors = assert.dom(errorSelector);
+    errors.exists({ count: 1 }, 'renders one error');
+    // assert.equal(errors[0].id, 'error-test-choiceError'); TODO: figure out why ID isn't being set
+    errors.hasText(
+      'This is an error message',
+      'renders the correct error text'
+    );
+
+    const errorIcons = assert.dom(errorIconSelector);
+    errorIcons.exists({ count: 1 }, 'renders one error icon');
+    errorIcons.hasAttribute(
+      'data-icon-source',
+      'polaris/alert',
+      'renders the correct error icon'
+    );
+  });
+
+  test('it handles the labelHidden attribute correctly', async function(assert) {
+    this.set('labelHidden', true);
+    await render(hbs`
+      {{polaris-choice
+        inputId="hidden-label-test-choice"
+        label="This is my hidden label"
+        labelHidden=labelHidden
+      }}
+    `);
+
+    let label = assert.dom(labelSelector);
+    label.exists('without description - renders the label');
+    label.hasClass(
+      'Polaris-Choice--labelHidden',
+      'without description - applies labelHidden class when labelHidden true'
+    );
+
+    this.set('labelHidden', false);
+    label.hasNoClass(
+      'Polaris-Choice--labelHidden',
+      'without description - does not apply labelHidden class when labelHidden false'
+    );
+
+    await render(hbs`
+      {{polaris-choice
+        inputId="hidden-label-test-choice-with-error"
+        label="This is my hidden label with an error"
+        labelHidden=labelHidden
         error="This is an error message"
       }}
-        <span class="error-test-control">This is a test control with an error</span>
-      {{/polaris-choice}}
-    </div>
-  `);
+    `);
 
-  const labels = findAll(labelWithDescriptionSelector);
-  assert.equal(labels.length, 1, 'renders one label');
-  assert.equal(
-    labels[0].attributes['for'].textContent.trim(),
-    'error-test-choice',
-    'renders the label with the correct `for` attribute'
-  );
+    label = assert.dom(labelSelector);
+    label.exists('with description - renders the label');
+    label.hasNoClass(
+      'Polaris-Choice--labelHidden',
+      'with description - does not apply labelHidden class when labelHidden false'
+    );
 
-  const testControlSelector = buildNestedSelector(
-    controlWithDescriptionSelector,
-    'span.error-test-control'
-  );
-  const testControls = findAll(testControlSelector);
-  assert.equal(testControls.length, 1, 'renders one control');
-  assert.equal(
-    testControls[0].textContent.trim(),
-    'This is a test control with an error',
-    'renders the control correctly'
-  );
-
-  const labelContents = findAll(labelContentWithDescriptionSelector);
-  assert.equal(labelContents.length, 1, 'renders one label content wrapper');
-  assert.equal(
-    labelContents[0].textContent.trim(),
-    'This is my label for a control with an error',
-    'renders the label text correctly'
-  );
-
-  // Check the error rendering.
-  const errors = findAll(errorSelector);
-  assert.equal(errors.length, 1, 'renders one error');
-  // assert.equal(errors[0].id, 'error-test-choiceError'); TODO: figure out why ID isn't being set
-  assert.equal(
-    errors[0].textContent.trim(),
-    'This is an error message',
-    'renders the correct error text'
-  );
-
-  const errorIcons = findAll(errorIconSelector);
-  assert.equal(errorIcons.length, 1, 'renders one error icon');
-  assert.equal(
-    errorIcons[0].dataset.iconSource,
-    'polaris/alert',
-    'renders the correct error icon'
-  );
-});
-
-test('it handles the labelHidden attribute correctly', function(assert) {
-  this.set('labelHidden', true);
-  this.render(hbs`
-    {{polaris-choice
-      inputId="hidden-label-test-choice"
-      label="This is my hidden label"
-      labelHidden=labelHidden
-    }}
-  `);
-
-  let label = find(labelSelector);
-  assert.ok(label, 'without description - renders the label');
-  assert.ok(
-    label.classList.contains('Polaris-Choice--labelHidden'),
-    'without description - applies labelHidden class when labelHidden true'
-  );
-
-  this.set('labelHidden', false);
-  assert.notOk(
-    label.classList.contains('Polaris-Choice--labelHidden'),
-    'without description - does not apply labelHidden class when labelHidden false'
-  );
-
-  this.render(hbs`
-    {{polaris-choice
-      inputId="hidden-label-test-choice-with-error"
-      label="This is my hidden label with an error"
-      labelHidden=labelHidden
-      error="This is an error message"
-    }}
-  `);
-
-  label = find(labelSelector);
-  assert.ok(label, 'with description - renders the label');
-  assert.notOk(
-    label.classList.contains('Polaris-Choice--labelHidden'),
-    'with description - does not apply labelHidden class when labelHidden false'
-  );
-
-  this.set('labelHidden', true);
-  assert.ok(
-    label.classList.contains('Polaris-Choice--labelHidden'),
-    'with description - applies labelHidden class when labelHidden true'
-  );
-});
-
-test('it handles label components correctly when no description is present', function(assert) {
-  this.setProperties({
-    label: null,
-    labelComponent: 'test-label',
+    this.set('labelHidden', true);
+    label.hasClass(
+      'Polaris-Choice--labelHidden',
+      'with description - applies labelHidden class when labelHidden true'
+    );
   });
 
-  this.render(hbs`
-    {{polaris-choice
-      label=label
-      labelComponent=labelComponent
-    }}
-  `);
+  test('it handles label components correctly when no description is present', async function(assert) {
+    this.setProperties({
+      label: null,
+      labelComponent: 'test-label',
+    });
 
-  let labelContent = find(labelContentSelector);
-  assert.ok(labelContent, 'renders the label');
+    await render(hbs`
+      {{polaris-choice
+        label=label
+        labelComponent=labelComponent
+      }}
+    `);
 
-  const labelComponentSelector = buildNestedSelector(
-    labelContentSelector,
-    'div.test-label-component'
-  );
-  let labelComponent = find(labelComponentSelector);
-  assert.ok(
-    labelComponent,
-    'with label component string - renders the label component'
-  );
-  assert.equal(
-    labelContent.textContent.trim(),
-    'test label component',
-    'with label component string - renders the correct label content'
-  );
+    let labelContent = assert.dom(labelContentSelector);
+    labelContent.exists('renders the label');
 
-  this.set('label', 'literal label');
-  assert.equal(
-    labelContent.textContent.trim(),
-    'test label component',
-    'with label component string and label - renders the correct label content'
-  );
+    const labelComponentSelector = buildNestedSelector(
+      labelContentSelector,
+      'div.test-label-component'
+    );
+    let labelComponent = assert.dom(labelComponentSelector);
 
-  this.set('labelComponent', null);
-  assert.equal(
-    labelContent.textContent.trim(),
-    'literal label',
-    'with label - renders the correct label content'
-  );
+    labelComponent.exists(
+      'with label component string - renders the label component'
+    );
+    labelContent.hasText(
+      'test label component',
+      'with label component string - renders the correct label content'
+    );
 
-  this.setProperties({
-    label: null,
-    useLabelComponent: true,
-  });
-  this.render(hbs`
-    {{polaris-choice
-      label=label
-      labelComponent=(if useLabelComponent (
-        component "test-label" text="test label component from component closure"
-      ))
-    }}
-  `);
+    this.set('label', 'literal label');
+    labelContent.hasText(
+      'test label component',
+      'with label component string and label - renders the correct label content'
+    );
 
-  labelContent = find(labelContentSelector);
-  assert.ok(labelContent, 'renders the label');
+    this.set('labelComponent', null);
+    labelContent.hasText(
+      'literal label',
+      'with label - renders the correct label content'
+    );
 
-  labelComponent = find(labelComponentSelector);
-  assert.ok(
-    labelComponent,
-    'with label component closure - renders the label component'
-  );
-  assert.equal(
-    labelContent.textContent.trim(),
-    'test label component from component closure',
-    'with label component closure - renders the correct label content'
-  );
+    this.setProperties({
+      label: null,
+      useLabelComponent: true,
+    });
+    await render(hbs`
+      {{polaris-choice
+        label=label
+        labelComponent=(if useLabelComponent (
+          component "test-label" text="test label component from component closure"
+        ))
+      }}
+    `);
 
-  this.set('label', 'literal label');
-  assert.equal(
-    labelContent.textContent.trim(),
-    'test label component from component closure',
-    'with label component closure and label - renders the correct label content'
-  );
+    labelContent = assert.dom(labelContentSelector);
+    assert.ok(labelContent, 'renders the label');
 
-  this.set('useLabelComponent', false);
-  assert.equal(
-    labelContent.textContent.trim(),
-    'literal label',
-    'with label - renders the correct label content'
-  );
-});
+    labelComponent = assert.dom(labelComponentSelector);
+    assert.ok(
+      labelComponent,
+      'with label component closure - renders the label component'
+    );
+    labelContent.hasText(
+      'test label component from component closure',
+      'with label component closure - renders the correct label content'
+    );
 
-test('it handles label components correctly when a description is supplied', function(assert) {
-  this.setProperties({
-    label: null,
-    labelComponent: 'test-label',
+    this.set('label', 'literal label');
+    labelContent.hasText(
+      'test label component from component closure',
+      'with label component closure and label - renders the correct label content'
+    );
+
+    this.set('useLabelComponent', false);
+    labelContent.hasText(
+      'literal label',
+      'with label - renders the correct label content'
+    );
   });
 
-  this.render(hbs`
-    {{polaris-choice
-      label=label
-      labelComponent=labelComponent
-      description="testing label components"
-    }}
-  `);
+  test('it handles label components correctly when a description is supplied', async function(assert) {
+    this.setProperties({
+      label: null,
+      labelComponent: 'test-label',
+    });
 
-  let labelContent = find(labelContentSelector);
-  assert.ok(labelContent, 'renders the label');
+    await render(hbs`
+      {{polaris-choice
+        label=label
+        labelComponent=labelComponent
+        description="testing label components"
+      }}
+    `);
 
-  const labelComponentSelector = buildNestedSelector(
-    labelContentSelector,
-    'div.test-label-component'
-  );
-  let labelComponent = find(labelComponentSelector);
-  assert.ok(
-    labelComponent,
-    'with label component string - renders the label component'
-  );
-  assert.equal(
-    labelContent.textContent.trim(),
-    'test label component',
-    'with label component string - renders the correct label content'
-  );
+    let labelContent = assert.dom(labelContentSelector);
+    assert.ok(labelContent, 'renders the label');
 
-  this.set('label', 'literal label');
-  assert.equal(
-    labelContent.textContent.trim(),
-    'test label component',
-    'with label component string and label - renders the correct label content'
-  );
+    const labelComponentSelector = buildNestedSelector(
+      labelContentSelector,
+      'div.test-label-component'
+    );
+    let labelComponent = assert.dom(labelComponentSelector);
+    assert.ok(
+      labelComponent,
+      'with label component string - renders the label component'
+    );
+    labelContent.hasText(
+      'test label component',
+      'with label component string - renders the correct label content'
+    );
 
-  this.set('labelComponent', null);
-  assert.equal(
-    labelContent.textContent.trim(),
-    'literal label',
-    'with label - renders the correct label content'
-  );
+    this.set('label', 'literal label');
+    labelContent.hasText(
+      'test label component',
+      'with label component string and label - renders the correct label content'
+    );
 
-  this.setProperties({
-    label: null,
-    useLabelComponent: true,
+    this.set('labelComponent', null);
+    labelContent.hasText(
+      'literal label',
+      'with label - renders the correct label content'
+    );
+
+    this.setProperties({
+      label: null,
+      useLabelComponent: true,
+    });
+    await render(hbs`
+      {{polaris-choice
+        label=label
+        labelComponent=(if useLabelComponent (
+          component "test-label" text="test label component from component closure"
+        ))
+      }}
+    `);
+
+    labelContent = assert.dom(labelContentSelector);
+    assert.ok(labelContent, 'renders the label');
+
+    labelComponent = assert.dom(labelComponentSelector);
+    assert.ok(
+      labelComponent,
+      'with label component closure - renders the label component'
+    );
+    labelContent.hasText(
+      'test label component from component closure',
+      'with label component closure - renders the correct label content'
+    );
+
+    this.set('label', 'literal label');
+    labelContent.hasText(
+      'test label component from component closure',
+      'with label component closure and label - renders the correct label content'
+    );
+
+    this.set('useLabelComponent', false);
+    labelContent.hasText(
+      'literal label',
+      'with label - renders the correct label content'
+    );
   });
-  this.render(hbs`
-    {{polaris-choice
-      label=label
-      labelComponent=(if useLabelComponent (
-        component "test-label" text="test label component from component closure"
-      ))
-    }}
-  `);
 
-  labelContent = find(labelContentSelector);
-  assert.ok(labelContent, 'renders the label');
+  test('it handles the disabled attribute correctly', async function(assert) {
+    let disabledClass = 'Polaris-Choice--disabled';
 
-  labelComponent = find(labelComponentSelector);
-  assert.ok(
-    labelComponent,
-    'with label component closure - renders the label component'
-  );
-  assert.equal(
-    labelContent.textContent.trim(),
-    'test label component from component closure',
-    'with label component closure - renders the correct label content'
-  );
+    this.set('disabled', true);
 
-  this.set('label', 'literal label');
-  assert.equal(
-    labelContent.textContent.trim(),
-    'test label component from component closure',
-    'with label component closure and label - renders the correct label content'
-  );
+    await render(hbs`
+      {{polaris-choice
+        inputId="disabled-test"
+        label="My label"
+        disabled=disabled
+      }}
+    `);
 
-  this.set('useLabelComponent', false);
-  assert.equal(
-    labelContent.textContent.trim(),
-    'literal label',
-    'with label - renders the correct label content'
-  );
-});
+    assert.dom(labelSelector).hasClass(disabledClass);
 
-test('it handles the disabled attribute correctly', function(assert) {
-  let disabledClass = 'Polaris-Choice--disabled';
+    this.set('disabled', false);
 
-  this.set('disabled', true);
+    assert.dom(labelSelector).hasNoClass(disabledClass);
+  });
 
-  this.render(hbs`
-    {{polaris-choice
-      inputId="disabled-test"
-      label="My label"
-      disabled=disabled
-    }}
-  `);
+  test('it allows passing a component as the helpText property', async function(assert) {
+    await render(hbs`
+      {{polaris-choice
+        inputId="help-text-component-test"
+        helpText=(component "polaris-icon" source="circle-check-mark")
+      }}
+    `);
 
-  assert.dom(labelSelector).hasClass(disabledClass);
-
-  this.set('disabled', false);
-
-  assert.dom(labelSelector).hasNoClass(disabledClass);
-});
-
-test('it allows passing a component as the helpText property', function(assert) {
-  this.render(hbs`
-    {{polaris-choice
-      inputId="help-text-component-test"
-      helpText=(component "polaris-icon" source="circle-check-mark")
-    }}
-  `);
-
-  assert.dom('[data-test-icon]').exists({ count: 1 });
+    assert.dom('[data-test-icon]').exists({ count: 1 });
+  });
 });

--- a/tests/integration/components/polaris-color-picker-test.js
+++ b/tests/integration/components/polaris-color-picker-test.js
@@ -1,286 +1,316 @@
-import { moduleForComponent, test, skip } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { findAll, click } from 'ember-native-dom-helpers';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
-moduleForComponent(
-  'polaris-color-picker',
-  'Integration | Component | polaris color picker',
-  {
-    integration: true,
-  }
-);
+module('Integration | Component | polaris color picker', function(hooks) {
+  setupRenderingTest(hooks);
 
-const colorPickerSelector = 'div.Polaris-ColorPicker';
-const mainColorControlSelector = buildNestedSelector(
-  colorPickerSelector,
-  'div.Polaris-ColorPicker__MainColor'
-);
-const mainColorControlColorLayerSelector = buildNestedSelector(
-  mainColorControlSelector,
-  'div.Polaris-ColorPicker__ColorLayer'
-);
-const huePickerSelector = buildNestedSelector(
-  colorPickerSelector,
-  'div.Polaris-ColorPicker__HuePicker'
-);
-const alphaPickerSelector = buildNestedSelector(
-  colorPickerSelector,
-  'div.Polaris-ColorPicker__AlphaPicker'
-);
-const draggerSelector = buildNestedSelector(
-  'div.Polaris-ColorPicker__Slidable',
-  'div.Polaris-ColorPicker__Dragger'
-);
-
-test('it renders the correct HTML with default attributes', function(assert) {
-  this.set('color', {
-    hue: 40,
-    saturation: 0.5,
-    brightness: 0.8,
-  });
-  this.render(hbs`
-    {{polaris-color-picker
-      color=color
-    }}
-  `);
-
-  const colorPickers = findAll(colorPickerSelector);
-  assert.equal(colorPickers.length, 1, 'renders one color picker');
-
-  const mainColorControls = findAll(mainColorControlSelector);
-  assert.equal(mainColorControls.length, 1, 'renders one main color control');
-
-  // Check the background of the main color control.
-  const colorLayers = findAll(mainColorControlColorLayerSelector);
-  assert.equal(colorLayers.length, 1, 'renders one color layer');
-
-  const colorLayer = colorLayers[0];
-  assert.equal(
-    colorLayer.style.backgroundColor,
-    'rgb(255, 170, 0)',
-    'renders color layer with correct background color'
+  const colorPickerSelector = 'div.Polaris-ColorPicker';
+  const mainColorControlSelector = buildNestedSelector(
+    colorPickerSelector,
+    'div.Polaris-ColorPicker__MainColor'
+  );
+  const mainColorControlColorLayerSelector = buildNestedSelector(
+    mainColorControlSelector,
+    'div.Polaris-ColorPicker__ColorLayer'
+  );
+  const huePickerSelector = buildNestedSelector(
+    colorPickerSelector,
+    'div.Polaris-ColorPicker__HuePicker'
+  );
+  const alphaPickerSelector = buildNestedSelector(
+    colorPickerSelector,
+    'div.Polaris-ColorPicker__AlphaPicker'
+  );
+  const draggerSelector = buildNestedSelector(
+    'div.Polaris-ColorPicker__Slidable',
+    'div.Polaris-ColorPicker__Dragger'
   );
 
-  // Check the main color control's dragger.
-  const colorDraggers = findAll(draggerSelector, mainColorControls[0]);
-  assert.equal(
-    colorDraggers.length,
-    1,
-    'renders one dragger for the main color control'
-  );
-  assert.equal(
-    colorDraggers[0].style.transform,
-    'translate3d(80px, 32px, 0px)',
-    'renders color dragger in the correct position'
-  );
-
-  // Check the hue picker.
-  const huePickers = findAll(huePickerSelector);
-  assert.equal(huePickers.length, 1, 'renders one hue picker');
-
-  // Check the hue picker's dragger.
-  const hueDraggers = findAll(draggerSelector, huePickers[0]);
-  assert.equal(hueDraggers.length, 1, 'renders one dragger for the hue picker');
-  assert.equal(
-    hueDraggers[0].style.transform,
-    'translate3d(0px, 28px, 0px)',
-    'renders hue dragger in the correct position'
-  );
-
-  // Check no alpha picker is rendered.
-  const alphaPickers = findAll(alphaPickerSelector);
-  assert.equal(alphaPickers.length, 0, 'does not render an alpha picker');
-});
-
-test('it renders the correct HTML with allowAlpha set', function(assert) {
-  this.set('color', {
-    hue: 214,
-    saturation: 0.7,
-    brightness: 0.3,
-    alpha: 0.85,
-  });
-  this.render(hbs`
-    {{polaris-color-picker
-      color=color
-      allowAlpha=true
-    }}
-  `);
-
-  const colorPickers = findAll(colorPickerSelector);
-  assert.equal(colorPickers.length, 1, 'renders one color picker');
-
-  const mainColorControls = findAll(mainColorControlSelector);
-  assert.equal(mainColorControls.length, 1, 'renders one main color control');
-
-  // Check the background of the main color control.
-  const colorLayers = findAll(mainColorControlColorLayerSelector);
-  assert.equal(colorLayers.length, 1, 'renders one color layer');
-
-  const colorLayer = colorLayers[0];
-  assert.equal(
-    colorLayer.style.backgroundColor,
-    'rgba(0, 110, 255, 0.85)',
-    'renders color layer with correct background color'
-  );
-
-  // Check the main color control's dragger.
-  const colorDraggers = findAll(draggerSelector, mainColorControls[0]);
-  assert.equal(
-    colorDraggers.length,
-    1,
-    'renders one dragger for the main color control'
-  );
-  assert.equal(
-    colorDraggers[0].style.transform,
-    'translate3d(112px, 112px, 0px)',
-    'renders color dragger in the correct position'
-  );
-
-  // Check the hue picker.
-  const huePickers = findAll(huePickerSelector);
-  assert.equal(huePickers.length, 1, 'renders one hue picker');
-
-  // Check the hue picker's dragger.
-  const hueDraggers = findAll(draggerSelector, huePickers[0]);
-  assert.equal(hueDraggers.length, 1, 'renders one dragger for the hue picker');
-  assert.equal(
-    hueDraggers[0].style.transform,
-    'translate3d(0px, 93.25px, 0px)',
-    'renders hue dragger in the correct position'
-  );
-
-  // Check the alpha picker.
-  const alphaPickers = findAll(alphaPickerSelector);
-  assert.equal(alphaPickers.length, 1, 'renders one alpha picker');
-
-  // Check the alpha picker's dragger.
-  const alphaDraggers = findAll(draggerSelector, alphaPickers[0]);
-  assert.equal(
-    alphaDraggers.length,
-    1,
-    'renders one dragger for the alpha picker'
-  );
-  assert.equal(
-    alphaDraggers[0].style.transform,
-    'translate3d(0px, 33.25px, 0px)',
-    'renders alpha dragger in the correct position'
-  );
-});
-
-skip('it updates correctly when draggers are moved', function(assert) {
-  // This is skipped for now until we figure out the correct calculation of the click coordinates...
-  this.set('color', {
-    hue: 120,
-    saturation: 0.2,
-    brightness: 0.65,
-    alpha: 0.4,
-  });
-  this.render(hbs`
-    {{polaris-color-picker
-      color=color
-      allowAlpha=true
-      onChange=(action (mut color))
-    }}
-  `);
-
-  // Helpers.
-  const assertDraggerPosition = function(
-    dragger,
-    expectedX,
-    expectedY,
-    name,
-    label
-  ) {
-    assert.equal(
-      dragger.style.transform,
-      `translate3d(${expectedX}px, ${expectedY}px, 0px)`,
-      `${label} - renders ${name} dragger in the correct position`
-    );
-  };
-
-  const assertHsbaColor = function(
-    color,
-    hue,
-    saturation,
-    brightness,
-    alpha,
-    label
-  ) {
-    assert.equal(color.hue, hue, `${label} - has the correct hue`);
-    assert.equal(
-      color.saturation,
-      saturation,
-      `${label} - has the correct saturation`
-    );
-    assert.equal(
-      color.brightness,
-      brightness,
-      `${label} - has the correct brightness`
-    );
-    assert.equal(color.alpha, alpha, `${label} - has the correct alpha`);
-  };
-
-  const clickElementAtPosition = function(element, x, y) {
-    // Click an element some fractional distance across its width and height.
-    const { clientWidth: width, clientHeight: height } = element;
-    return click(element, {
-      clientX: x * width,
-      clientY: y * height,
+  test('it renders the correct HTML with default attributes', async function(assert) {
+    this.set('color', {
+      hue: 40,
+      saturation: 0.5,
+      brightness: 0.8,
     });
-  };
+    await render(hbs`
+      {{polaris-color-picker
+        color=color
+      }}
+    `);
 
-  // Grab the draggers to check their positions.
-  const [colorDragger, hueDragger, alphaDragger] = findAll(draggerSelector);
-  assertDraggerPosition(colorDragger, 32, 56, 'color', 'after initial render');
-  assertDraggerPosition(hueDragger, 0, 58, 'hue', 'after initial render');
-  assertDraggerPosition(alphaDragger, 0, 94, 'alpha', 'after initial render');
+    const colorPickers = assert.dom(colorPickerSelector);
+    colorPickers.exists({ count: 1 }, 'renders one color picker');
 
-  // Test moving the main color dragger.
-  clickElementAtPosition(colorDragger.parentNode, 0.25, 0.4);
-  assertDraggerPosition(
-    colorDragger,
-    40,
-    64,
-    'color',
-    'after moving color dragger'
-  );
-  assertHsbaColor(
-    this.get('color'),
-    120,
-    0.25,
-    0.6,
-    0.4,
-    'after moving color dragger'
-  );
+    const mainColorControls = assert.dom(mainColorControlSelector);
+    mainColorControls.exists({ count: 1 }, 'renders one main color control');
 
-  // Test moving the hue dragger.
-  clickElementAtPosition(hueDragger.parentNode, 0, 0.5);
-  assertDraggerPosition(hueDragger, 0, 80.5, 'hue', 'after moving hue dragger');
-  assertHsbaColor(
-    this.get('color'),
-    180,
-    0.25,
-    0.6,
-    0.4,
-    'after moving hue dragger'
-  );
+    // Check the background of the main color control.
+    const colorLayers = assert.dom(mainColorControlColorLayerSelector);
+    colorLayers.exists({ count: 1 }, 'renders one color layer');
 
-  // Test moving the alpha dragger.
-  clickElementAtPosition(alphaDragger.parentNode, 0, 0.5);
-  assertDraggerPosition(
-    alphaDragger,
-    0,
-    80.5,
-    'alpha',
-    'after moving alpha dragger'
-  );
-  assertHsbaColor(
-    this.get('color'),
-    180,
-    0.25,
-    0.6,
-    0.5,
-    'after moving alpha dragger'
-  );
+    colorLayers.hasStyle(
+      { backgroundColor: 'rgb(255, 170, 0)' },
+      'renders color layer with correct background color'
+    );
+
+    // Check the main color control's dragger.
+    const colorDraggers = assert.dom(
+      `${mainColorControlSelector} ${draggerSelector}`
+    );
+    colorDraggers.exists(
+      { count: 1 },
+      'renders one dragger for the main color control'
+    );
+
+    colorDraggers.hasStyle(
+      { transform: 'matrix(1, 0, 0, 1, 80, 32)' },
+      'renders color dragger in the correct position'
+    );
+
+    // Check the hue picker.
+    const huePickers = assert.dom(huePickerSelector);
+    huePickers.exists({ count: 1 }, 'renders one hue picker');
+
+    // Check the hue picker's dragger.
+    const hueDraggers = assert.dom(`${huePickerSelector} ${draggerSelector}`);
+    hueDraggers.exists({ count: 1 }, 'renders one dragger for the hue picker');
+
+    hueDraggers.hasStyle(
+      { transform: 'matrix(1, 0, 0, 1, 0, 28)' },
+      'renders hue dragger in the correct position'
+    );
+
+    // Check no alpha picker is rendered.
+    const alphaPickers = assert.dom(alphaPickerSelector);
+    alphaPickers.doesNotExist('does not render an alpha picker');
+  });
+
+  test('it renders the correct HTML with allowAlpha set', async function(assert) {
+    this.set('color', {
+      hue: 214,
+      saturation: 0.7,
+      brightness: 0.3,
+      alpha: 0.85,
+    });
+
+    await render(hbs`
+      {{polaris-color-picker
+        color=color
+        allowAlpha=true
+      }}
+    `);
+
+    const colorPickers = assert.dom(colorPickerSelector);
+    colorPickers.exists({ count: 1 }, 'renders one color picker');
+
+    const mainColorControls = assert.dom(mainColorControlSelector);
+    mainColorControls.exists({ count: 1 }, 'renders one main color control');
+
+    // Check the background of the main color control.
+    const colorLayers = assert.dom(mainColorControlColorLayerSelector);
+    colorLayers.exists({ count: 1 }, 'renders one color layer');
+
+    colorLayers.hasStyle(
+      { backgroundColor: 'rgba(0, 110, 255, 0.85)' },
+      'renders color layer with correct background color'
+    );
+
+    // Check the main color control's dragger.
+    const colorDraggers = assert.dom(
+      `.Polaris-ColorPicker__MainColor ${draggerSelector}`
+    );
+
+    colorDraggers.exists(
+      { count: 1 },
+      'renders one dragger for the main color control'
+    );
+
+    const getTransform = (elem) => find(elem.target).style.transform;
+
+    assert.equal(
+      getTransform(colorDraggers),
+      'translate3d(112px, 112px, 0px)',
+      'renders color dragger in the correct position'
+    );
+
+    // Check the hue picker.
+    const huePickers = assert.dom(huePickerSelector);
+    huePickers.exists({ count: 1 }, 'renders one hue picker');
+
+    // Check the hue picker's dragger.
+    const hueDraggers = assert.dom(`${huePickerSelector} ${draggerSelector}`);
+
+    hueDraggers.exists({ count: 1 }, 'renders one dragger for the hue picker');
+
+    assert.equal(
+      getTransform(hueDraggers),
+      'translate3d(0px, 93.25px, 0px)',
+      'renders hue dragger in the correct position'
+    );
+
+    // Check the alpha picker.
+    const alphaPickers = assert.dom(alphaPickerSelector);
+    alphaPickers.exists({ count: 1 }, 'renders one alpha picker');
+
+    // Check the alpha picker's dragger.
+    const alphaDraggers = assert.dom(
+      `${alphaPickerSelector} ${draggerSelector}`
+    );
+
+    alphaDraggers.exists(
+      { count: 1 },
+      'renders one dragger for the alpha picker'
+    );
+
+    assert.equal(
+      getTransform(alphaDraggers),
+      'translate3d(0px, 33.25px, 0px)',
+      'renders alpha dragger in the correct position'
+    );
+  });
+
+  test('it updates correctly when draggers are moved', async function(assert) {
+    assert.expect(18);
+    const getTransform = (elem) => find(elem).style.transform;
+
+    this.set('color', {
+      hue: 120,
+      saturation: 0.2,
+      brightness: 0.65,
+      alpha: 0.4,
+    });
+
+    await render(hbs`
+      {{polaris-color-picker
+        color=color
+        allowAlpha=true
+        onChange=(action (mut color))
+      }}
+    `);
+
+    // Helpers.
+    const assertDraggerPosition = function(
+      dragger,
+      expectedX,
+      expectedY,
+      name,
+      label
+    ) {
+      assert.equal(
+        getTransform(dragger),
+        `translate3d(${expectedX}px, ${expectedY}px, 0px)`,
+        `${label} - renders ${name} dragger in the correct position`
+      );
+    };
+
+    const assertHsbaColor = function(color, colorValue, label) {
+      let { hue, saturation, brightness, alpha } = colorValue;
+
+      assert.equal(
+        parseInt(color.hue),
+        parseInt(hue),
+        `${label} - has the correct hue`
+      );
+      assert.equal(
+        parseInt(color.saturation),
+        parseInt(saturation),
+        `${label} - has the correct saturation`
+      );
+      assert.equal(
+        parseInt(color.brightness),
+        parseInt(brightness),
+        `${label} - has the correct brightness`
+      );
+      assert.equal(
+        parseInt(color.alpha),
+        parseInt(alpha),
+        `${label} - has the correct alpha`
+      );
+    };
+
+    const clickElementAtPosition = async function(element, x, y) {
+      // Click an element some fractional distance across its width and height.
+      const { left, top } = element.parentNode.getBoundingClientRect();
+
+      return await click(element.parentNode, {
+        clientX: x + left,
+        clientY: y + top,
+        which: 1,
+      });
+    };
+
+    // Grab the draggers to check their positions.
+    const [colorDragger, hueDragger, alphaDragger] = findAll(draggerSelector);
+
+    assertDraggerPosition(
+      colorDragger,
+      32,
+      56,
+      'color',
+      'after initial render'
+    );
+    assertDraggerPosition(hueDragger, 0, 58, 'hue', 'after initial render');
+    assertDraggerPosition(alphaDragger, 0, 94, 'alpha', 'after initial render');
+
+    // Test moving the main color dragger.
+    await clickElementAtPosition(colorDragger, 100, 100);
+    assertDraggerPosition(
+      colorDragger,
+      100,
+      100,
+      'color',
+      'after moving color dragger'
+    );
+
+    assertHsbaColor(
+      this.get('color'),
+      { hue: 120, saturation: 0.625, brightness: 0.375, alpha: 0.4 },
+      'after moving color dragger'
+    );
+
+    // Test moving the hue dragger.
+    await clickElementAtPosition(hueDragger, 0, 90);
+
+    assertDraggerPosition(
+      hueDragger,
+      0,
+      90.5746,
+      'hue',
+      'after moving hue dragger'
+    );
+
+    assertHsbaColor(
+      this.get('color'),
+      {
+        alpha: 0.4,
+        brightness: 0.375,
+        hue: 206.87,
+        saturation: 0.625,
+      },
+      'after moving hue dragger'
+    );
+
+    // Test moving the alpha dragger.
+    await clickElementAtPosition(alphaDragger, 0, 70);
+    assertDraggerPosition(
+      alphaDragger,
+      0,
+      70.4254,
+      'alpha',
+      'after moving alpha dragger'
+    );
+    assertHsbaColor(
+      this.get('color'),
+      {
+        alpha: 0.57,
+        brightness: 0.375,
+        hue: 206.87,
+        saturation: 0.625,
+      },
+      'after moving alpha dragger'
+    );
+  });
 });

--- a/tests/integration/components/polaris-color-picker-test.js
+++ b/tests/integration/components/polaris-color-picker-test.js
@@ -1,4 +1,4 @@
-import { module, test } from 'qunit';
+import { module, skip, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
@@ -172,7 +172,7 @@ module('Integration | Component | polaris color picker', function(hooks) {
     );
   });
 
-  test('it updates correctly when draggers are moved', async function(assert) {
+  skip('it updates correctly when draggers are moved', async function(assert) {
     assert.expect(18);
     const getTransform = (elem) => find(elem).style.transform;
 

--- a/tests/integration/components/polaris-color-picker-test.js
+++ b/tests/integration/components/polaris-color-picker-test.js
@@ -260,7 +260,7 @@ module('Integration | Component | polaris color picker', function(hooks) {
     assertDraggerPosition(
       colorDragger,
       100,
-      100,
+      99.75,
       'color',
       'after moving color dragger'
     );

--- a/tests/integration/components/polaris-date-picker-test.js
+++ b/tests/integration/components/polaris-date-picker-test.js
@@ -1,492 +1,484 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { findAll, find, click } from 'ember-native-dom-helpers';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 import MockSvgJarComponent from '../../mocks/components/svg-jar';
 
-moduleForComponent(
-  'polaris-date-picker',
-  'Integration | Component | polaris date picker',
-  {
-    integration: true,
+module('Integration | Component | polaris date picker', function(hooks) {
+  setupRenderingTest(hooks);
 
-    beforeEach() {
-      this.register('component:svg-jar', MockSvgJarComponent);
-    },
-  }
-);
-
-const DAY_SELECTED_CLASS = 'Polaris-DatePicker__Day--selected';
-const DAY_DISABLED_CLASS = 'Polaris-DatePicker__Day--disabled';
-const DAY_IN_RANGE_CLASS = 'Polaris-DatePicker__Day--inRange';
-const DAY_IS_TODAY_CLASS = 'Polaris-DatePicker__Day--today';
-
-const DAYS_PER_WEEK = 7;
-
-const MONTHS = [
-  'January',
-  'February',
-  'March',
-  'April',
-  'May',
-  'June',
-  'July',
-  'August',
-  'September',
-  'October',
-  'November',
-  'December',
-];
-
-const MONTH = 1;
-const YEAR = 2018;
-const MONTH_NAME = 'February';
-const START_DATE = 'Wed Feb 07 2018 00:00:00 GMT-0500 (EST)';
-const END_DATE = 'Wed Feb 07 2018 00:00:00 GMT-0500 (EST)';
-
-const container = '[data-test-date-picker]';
-const header = '[data-test-date-picker-header]';
-const monthContainer = '[data-test-date-picker-month-container]';
-const monthBody = '[data-test-date-picker-month]';
-const monthTitle = '[data-test-date-picker-title]';
-const weekdaysHeader = '[data-test-date-picker-week-heading]';
-const weekday = '[data-test-date-picker-weekday]';
-const week = '[data-test-date-picker-week]';
-const day = '[data-test-date-picker-day]';
-const dayEmpty = '[data-test-date-picker-day-empty]';
-
-const headerSelector = buildNestedSelector(container, header);
-
-const headerPrevBtnSelector = `${header} button:first-of-type`;
-
-const headerNextBtnSelector = `${header} button:last-of-type`;
-
-const monthSelector = buildNestedSelector(container, monthContainer);
-
-const monthBodySelector = buildNestedSelector(monthContainer, monthBody);
-
-const monthTitleSelector = buildNestedSelector(
-  monthContainer,
-  monthBody,
-  monthTitle
-);
-
-const weekdaySelector = buildNestedSelector(
-  monthContainer,
-  monthBody,
-  weekdaysHeader,
-  weekday
-);
-
-const monthWeekSelector = buildNestedSelector(monthContainer, monthBody, week);
-
-const daySelector = buildNestedSelector(week, day);
-
-const dayEmptySelector = buildNestedSelector(week, dayEmpty);
-
-const daySelectedSelector = `.${DAY_SELECTED_CLASS}`;
-
-test('it renders the correct date-picker HTML', function(assert) {
-  /**
-   * Assertions made in this test are based
-   * off a set month of February 2018, with
-   * February 7th set as the selected date.
-   */
-  const FEB_2018_WEEKS = 5;
-  const FEB_2018_DAYS = 28;
-  const FEB_2018_DAYS_EMPTY = 7;
-
-  let selected = {
-    start: new Date(START_DATE),
-    end: new Date(END_DATE),
-  };
-
-  this.setProperties({ month: MONTH, year: YEAR, selected });
-
-  this.render(hbs`
-    {{polaris-date-picker
-      month=month
-      year=year
-      selected=selected
-    }}
-  `);
-
-  let containerEl = find(container);
-  assert.ok(containerEl, 'it renders the date picker component');
-
-  let headerEl = find(headerSelector);
-  assert.ok(headerEl, 'it renders the date picker header');
-
-  let headerPrevBtnEl = find(headerPrevBtnSelector);
-  let iconPrev = find('svg', headerPrevBtnEl);
-  assert.ok(headerPrevBtnSelector, 'it renders a `prev` button in the header');
-  assert.equal(
-    iconPrev.dataset.iconSource,
-    'polaris/arrow-left',
-    'it renders a left arrow icon as the `prev` button'
-  );
-
-  let headerNextBtnEl = find(headerNextBtnSelector);
-  let iconNext = find('svg', headerNextBtnEl);
-  assert.ok(headerNextBtnSelector, 'it renders a `next` button in the header');
-  assert.equal(
-    iconNext.dataset.iconSource,
-    'polaris/arrow-right',
-    'it renders a right arrow icon as the `next` button'
-  );
-
-  let monthTitleEl = find(monthTitleSelector);
-  let expectedTitle = `${MONTH_NAME} ${YEAR}`;
-  assert
-    .dom(monthTitleEl)
-    .hasText(
-      expectedTitle,
-      'it renders a title displaying the current month name and year'
-    );
-
-  let monthsEl = findAll(monthSelector);
-  assert.ok(monthsEl, 'it renders a single month container');
-
-  let monthBodyEls = findAll(monthBodySelector);
-  assert.equal(monthBodyEls.length, 1, 'it renders a single month body');
-
-  let weekdayEls = findAll(weekdaySelector);
-  let [sunday] = weekdayEls;
-  assert.equal(
-    weekdayEls.length,
-    DAYS_PER_WEEK,
-    'it renders 7 weekday labels in the weekday header'
-  );
-  assert
-    .dom(sunday)
-    .hasText('Su', 'it abbreviates the weekday names in the weekday header');
-
-  let weekEls = findAll(monthWeekSelector);
-  assert.equal(
-    weekEls.length,
-    FEB_2018_WEEKS,
-    'it renders 5 weeks for February 2018'
-  );
-
-  let dayEls = findAll(daySelector);
-  assert.equal(
-    dayEls.length,
-    FEB_2018_DAYS,
-    'it renders 28 days for February 2018'
-  );
-
-  let dayEmptyEls = findAll(dayEmptySelector);
-  assert.equal(
-    dayEmptyEls.length,
-    FEB_2018_DAYS_EMPTY,
-    'it renders 6 empty days for February 2018'
-  );
-
-  let selectedDay = find(daySelectedSelector);
-  assert
-    .dom(selectedDay)
-    .hasText('7', 'it renders February 7th as the selected date');
-});
-
-test('it calls a passed-in `onChange` action when a new date is chosen', function(assert) {
-  this.setProperties({
-    month: MONTH,
-    year: YEAR,
-    selected: null,
-    onChangeActionFired: false,
+  hooks.beforeEach(function() {
+    this.owner.register('component:svg-jar', MockSvgJarComponent);
   });
 
-  this.render(hbs`
-    {{polaris-date-picker
-      month=month
-      year=year
-      selected=selected
-      onChange=(action (mut onChangeActionFired) true)
-    }}
-  `);
+  const DAY_SELECTED_CLASS = 'Polaris-DatePicker__Day--selected';
+  const DAY_DISABLED_CLASS = 'Polaris-DatePicker__Day--disabled';
+  const DAY_IN_RANGE_CLASS = 'Polaris-DatePicker__Day--inRange';
+  const DAY_IS_TODAY_CLASS = 'Polaris-DatePicker__Day--today';
 
-  click(daySelector);
-  assert.ok(
-    this.get('onChangeActionFired'),
-    'onChange action is called when a day is clicked'
+  const DAYS_PER_WEEK = 7;
+
+  const MONTHS = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ];
+
+  const MONTH = 1;
+  const YEAR = 2018;
+  const MONTH_NAME = 'February';
+  const START_DATE = 'Wed Feb 07 2018 00:00:00 GMT-0500 (EST)';
+  const END_DATE = 'Wed Feb 07 2018 00:00:00 GMT-0500 (EST)';
+
+  const container = '[data-test-date-picker]';
+  const header = '[data-test-date-picker-header]';
+  const monthContainer = '[data-test-date-picker-month-container]';
+  const monthBody = '[data-test-date-picker-month]';
+  const monthTitle = '[data-test-date-picker-title]';
+  const weekdaysHeader = '[data-test-date-picker-week-heading]';
+  const weekday = '[data-test-date-picker-weekday]';
+  const week = '[data-test-date-picker-week]';
+  const day = '[data-test-date-picker-day]';
+  const dayEmpty = '[data-test-date-picker-day-empty]';
+
+  const headerSelector = buildNestedSelector(container, header);
+
+  const headerPrevBtnSelector = `${header} button:first-of-type`;
+
+  const headerNextBtnSelector = `${header} button:last-of-type`;
+
+  const monthSelector = buildNestedSelector(container, monthContainer);
+
+  const monthBodySelector = buildNestedSelector(monthContainer, monthBody);
+
+  const monthTitleSelector = buildNestedSelector(
+    monthContainer,
+    monthBody,
+    monthTitle
   );
-});
 
-test('it passes a `selected` range argument to the `onChange` action', function(assert) {
-  assert.expect(3);
+  const weekdaySelector = buildNestedSelector(
+    monthContainer,
+    monthBody,
+    weekdaysHeader,
+    weekday
+  );
 
-  this.setProperties({
-    month: MONTH,
-    year: YEAR,
-    selected: null,
-    onChangeActionFired: false,
-    onChange: (selected) => {
-      assert.ok(
-        selected.start,
-        '`onChange` receives a range with a `start` attribute'
+  const monthWeekSelector = buildNestedSelector(
+    monthContainer,
+    monthBody,
+    week
+  );
+
+  const daySelector = buildNestedSelector(week, day);
+
+  const dayEmptySelector = buildNestedSelector(week, dayEmpty);
+
+  const daySelectedSelector = `.${DAY_SELECTED_CLASS}`;
+
+  test('it renders the correct date-picker HTML', async function(assert) {
+    /**
+     * Assertions made in this test are based
+     * off a set month of February 2018, with
+     * February 7th set as the selected date.
+     */
+    const FEB_2018_WEEKS = 5;
+    const FEB_2018_DAYS = 28;
+    const FEB_2018_DAYS_EMPTY = 7;
+
+    let selected = {
+      start: new Date(START_DATE),
+      end: new Date(END_DATE),
+    };
+
+    this.setProperties({ month: MONTH, year: YEAR, selected });
+
+    await render(hbs`
+      {{polaris-date-picker
+        month=month
+        year=year
+        selected=selected
+      }}
+    `);
+
+    assert.dom(container).exists('it renders the date picker component');
+
+    assert.dom(headerSelector).exists('it renders the date picker header');
+
+    assert
+      .dom(headerPrevBtnSelector)
+      .exists('it renders a `prev` button in the header');
+
+    assert
+      .dom(`${headerPrevBtnSelector} svg`)
+      .hasAttribute(
+        'data-icon-source',
+        'polaris/arrow-left',
+        'it renders a left arrow icon as the `prev` button'
       );
-      assert.ok(
-        selected.end,
-        '`onChange` receives a range with an `end` attribute'
+
+    assert
+      .dom(headerNextBtnSelector)
+      .exists('it renders a `next` button in the header');
+
+    assert
+      .dom(`${headerNextBtnSelector} svg`)
+      .hasAttribute(
+        'data-icon-source',
+        'polaris/arrow-right',
+        'it renders a right arrow icon as the `next` button'
       );
-      this.set('onChangeActionFired', true);
-    },
-  });
 
-  this.render(hbs`
-    {{polaris-date-picker
-      month=month
-      year=year
-      selected=selected
-      onChange=(action onChange)
-    }}
-  `);
-
-  click(daySelector);
-  assert.ok(
-    this.get('onChangeActionFired'),
-    '`onChange` action sends up correct arguments'
-  );
-});
-
-test('it calls a passed-in `onMonthChange` action when next or prev btn clicked', function(assert) {
-  this.setProperties({
-    month: MONTH,
-    year: YEAR,
-    selected: null,
-    onMonthChangeActionFired: false,
-  });
-
-  this.render(hbs`
-    {{polaris-date-picker
-      month=month
-      year=year
-      selected=selected
-      onMonthChange=(action (mut onMonthChangeActionFired) true)
-    }}
-  `);
-
-  click(headerPrevBtnSelector);
-  assert.ok(
-    this.get('onMonthChangeActionFired'),
-    'onMonthChange action is called when `prev` button is clicked'
-  );
-
-  this.set('onMonthChangeActionFired', false);
-
-  click(headerNextBtnSelector);
-  assert.ok(
-    this.get('onMonthChangeActionFired'),
-    'onMonthChange action is called when `next` button is clicked'
-  );
-});
-
-test('it passes `month` and `year` arguments to the `onMonthChange` action', function(assert) {
-  assert.expect(3);
-
-  let expectedMonth = MONTH + 1;
-  let expectedYear = YEAR;
-
-  this.setProperties({
-    month: MONTH,
-    year: YEAR,
-    selected: null,
-    onMonthChangeActionFired: false,
-    onMonthChange: (month, year) => {
-      assert.equal(
-        month,
-        expectedMonth,
-        '`onMonthChange` receives the correct `month` argument'
+    assert
+      .dom(monthTitleSelector)
+      .hasText(
+        `${MONTH_NAME} ${YEAR}`,
+        'it renders a title displaying the current month name and year'
       );
-      assert.equal(
-        year,
-        expectedYear,
-        '`onMonthChange` receives the correct `year` argument'
+
+    assert.dom(monthSelector).exists('it renders a single month container');
+
+    assert
+      .dom(monthBodySelector)
+      .exists({ count: 1 }, 'it renders a single month body');
+
+    assert
+      .dom(weekdaySelector)
+      .exists(
+        { count: DAYS_PER_WEEK },
+        'it renders 7 weekday labels in the weekday header'
       );
-      this.set('onMonthChangeActionFired', true);
-    },
+
+    assert
+      .dom(weekdaySelector)
+      .hasText('Su', 'it abbreviates the weekday names in the weekday header');
+
+    assert
+      .dom(monthWeekSelector)
+      .exists(
+        { count: FEB_2018_WEEKS },
+        'it renders 5 weeks for February 2018'
+      );
+
+    assert
+      .dom(daySelector)
+      .exists({ count: FEB_2018_DAYS }, 'it renders 28 days for February 2018');
+
+    assert
+      .dom(dayEmptySelector)
+      .exists(
+        { count: FEB_2018_DAYS_EMPTY },
+        'it renders 6 empty days for February 2018'
+      );
+
+    assert
+      .dom(daySelectedSelector)
+      .hasText('7', 'it renders February 7th as the selected date');
   });
 
-  this.render(hbs`
-    {{polaris-date-picker
-      month=month
-      year=year
-      selected=selected
-      onMonthChange=(action onMonthChange)
-    }}
-  `);
+  test('it calls a passed-in `onChange` action when a new date is chosen', async function(assert) {
+    this.setProperties({
+      month: MONTH,
+      year: YEAR,
+      selected: null,
+      onChangeActionFired: false,
+    });
 
-  click(headerNextBtnSelector);
-  assert.ok(
-    this.get('onMonthChangeActionFired'),
-    '`onMonthChange` action sends up correct arguments'
-  );
-});
+    await render(hbs`
+      {{polaris-date-picker
+        month=month
+        year=year
+        selected=selected
+        onChange=(action (mut onChangeActionFired) true)
+      }}
+    `);
 
-test('it displays two months at a time when `multiMonth` is true', function(assert) {
-  this.setProperties({
-    month: MONTH,
-    year: YEAR,
-    selected: null,
-    multiMonth: true,
+    await click(daySelector);
+    assert.ok(
+      this.get('onChangeActionFired'),
+      'onChange action is called when a day is clicked'
+    );
   });
 
-  this.render(hbs`
-    {{polaris-date-picker
-      month=month
-      year=year
-      selected=selected
-      multiMonth=multiMonth
-    }}
-  `);
+  test('it passes a `selected` range argument to the `onChange` action', async function(assert) {
+    assert.expect(3);
 
-  let monthBodyEls = findAll(monthBodySelector);
-  assert.equal(
-    monthBodyEls.length,
-    2,
-    'it renders 2 months when `multiMonth` is true'
-  );
-});
+    this.setProperties({
+      month: MONTH,
+      year: YEAR,
+      selected: null,
+      onChangeActionFired: false,
+      onChange: (selected) => {
+        assert.ok(
+          selected.start,
+          '`onChange` receives a range with a `start` attribute'
+        );
+        assert.ok(
+          selected.end,
+          '`onChange` receives a range with an `end` attribute'
+        );
+        this.set('onChangeActionFired', true);
+      },
+    });
 
-test('it disables certain days when `disableDatesBefore` and `disableDatesAfter` values are passed in', function(assert) {
-  const DISABLE_BEFORE = new Date('Mon Feb 05 2018 00:00:00 GMT-0500 (EST)');
-  const DISABLE_AFTER = new Date('Mon Feb 12 2018 00:00:00 GMT-0500 (EST)');
-  const DISABLE_BEFORE_SELECTOR = '[aria-label="February 4 2018"]';
-  const DISABLE_AFTER_SELECTOR = '[aria-label="February 13 2018"]';
+    await render(hbs`
+      {{polaris-date-picker
+        month=month
+        year=year
+        selected=selected
+        onChange=(action onChange)
+      }}
+    `);
 
-  this.setProperties({
-    month: MONTH,
-    year: YEAR,
-    selected: null,
-    disableDatesBefore: DISABLE_BEFORE,
-    disableDatesAfter: DISABLE_AFTER,
+    await click(daySelector);
+    assert.ok(
+      this.get('onChangeActionFired'),
+      '`onChange` action sends up correct arguments'
+    );
   });
 
-  this.render(hbs`
-    {{polaris-date-picker
-      month=month
-      year=year
-      selected=selected
-      disableDatesBefore=disableDatesBefore
-      disableDatesAfter=disableDatesAfter
-    }}
-  `);
+  test('it calls a passed-in `onMonthChange` action when next or prev btn clicked', async function(assert) {
+    this.setProperties({
+      month: MONTH,
+      year: YEAR,
+      selected: null,
+      onMonthChangeActionFired: false,
+    });
 
-  let disabledBeforeDateEl = find(DISABLE_BEFORE_SELECTOR);
-  assert
-    .dom(disabledBeforeDateEl)
-    .hasClass(
-      DAY_DISABLED_CLASS,
-      'dates before `disableDatesBefore` have a disabled class'
+    await render(hbs`
+      {{polaris-date-picker
+        month=month
+        year=year
+        selected=selected
+        onMonthChange=(action (mut onMonthChangeActionFired) true)
+      }}
+    `);
+
+    await click(headerPrevBtnSelector);
+    assert.ok(
+      this.get('onMonthChangeActionFired'),
+      'onMonthChange action is called when `prev` button is clicked'
     );
 
-  let disabledAfterDateEl = find(DISABLE_AFTER_SELECTOR);
-  assert
-    .dom(disabledAfterDateEl)
-    .hasClass(
-      DAY_DISABLED_CLASS,
-      'dates after `disableDatesAfter` have a disabled class'
+    this.set('onMonthChangeActionFired', false);
+
+    await click(headerNextBtnSelector);
+    assert.ok(
+      this.get('onMonthChangeActionFired'),
+      'onMonthChange action is called when `next` button is clicked'
     );
-});
-
-test('it does not fire actions when disabled days are clicked', function(assert) {
-  const DISABLE_AFTER = new Date('Mon Feb 12 2018 00:00:00 GMT-0500 (EST)');
-  const DISABLE_AFTER_SELECTOR = '[aria-label="February 13 2018"]';
-
-  this.set('onChangeActionFired', false);
-
-  this.setProperties({
-    month: MONTH,
-    year: YEAR,
-    selected: null,
-    disableDatesAfter: DISABLE_AFTER,
-    onChange: () => {
-      this.set('onChangeActionFired', true);
-    },
   });
 
-  this.render(hbs`
-    {{polaris-date-picker
-      month=month
-      year=year
-      selected=selected
-      disableDatesAfter=disableDatesAfter
-      onChange=(action onChange)
-    }}
-  `);
+  test('it passes `month` and `year` arguments to the `onMonthChange` action', async function(assert) {
+    assert.expect(3);
 
-  click(DISABLE_AFTER_SELECTOR);
-  assert.notOk(
-    this.get('onChangeActionFired'),
-    'clicking disabled day did not fire `onChange` action'
-  );
-});
+    let expectedMonth = MONTH + 1;
+    let expectedYear = YEAR;
 
-test('it applies an `inRange` class to days between the selected range', function(assert) {
-  const RANGE_START = new Date('Mon Feb 05 2018 00:00:00 GMT-0500 (EST)');
-  const RANGE_END = new Date('Mon Feb 12 2018 00:00:00 GMT-0500 (EST)');
-  const IN_RANGE_SELECTOR = '[aria-label="February 7 2018"]';
+    this.setProperties({
+      month: MONTH,
+      year: YEAR,
+      selected: null,
+      onMonthChangeActionFired: false,
+      onMonthChange: (month, year) => {
+        assert.equal(
+          month,
+          expectedMonth,
+          '`onMonthChange` receives the correct `month` argument'
+        );
+        assert.equal(
+          year,
+          expectedYear,
+          '`onMonthChange` receives the correct `year` argument'
+        );
+        this.set('onMonthChangeActionFired', true);
+      },
+    });
 
-  this.setProperties({
-    month: MONTH,
-    year: YEAR,
-    selected: {
-      start: RANGE_START,
-      end: RANGE_END,
-    },
+    await render(hbs`
+      {{polaris-date-picker
+        month=month
+        year=year
+        selected=selected
+        onMonthChange=(action onMonthChange)
+      }}
+    `);
+
+    await click(headerNextBtnSelector);
+    assert.ok(
+      this.get('onMonthChangeActionFired'),
+      '`onMonthChange` action sends up correct arguments'
+    );
   });
 
-  this.render(hbs`
-    {{polaris-date-picker
-      month=month
-      year=year
-      selected=selected
-    }}
-  `);
+  test('it displays two months at a time when `multiMonth` is true', async function(assert) {
+    this.setProperties({
+      month: MONTH,
+      year: YEAR,
+      selected: null,
+      multiMonth: true,
+    });
 
-  let inRangeDayEl = find(IN_RANGE_SELECTOR);
-  assert
-    .dom(inRangeDayEl)
-    .hasClass(
-      DAY_IN_RANGE_CLASS,
-      'days within the provided range contain an `inRange` class'
-    );
-});
+    await render(hbs`
+      {{polaris-date-picker
+        month=month
+        year=year
+        selected=selected
+        multiMonth=multiMonth
+      }}
+    `);
 
-test('it applies a `today` class to the day representing the current day', function(assert) {
-  const TODAY = new Date();
-  const TODAY_MONTH = TODAY.getMonth();
-  const TODAY_DATE = TODAY.getDate();
-  const TODAY_YEAR = TODAY.getFullYear();
-  const TODAY_LABEL = `${MONTHS[TODAY_MONTH]} ${TODAY_DATE} ${TODAY_YEAR}`; // ex: 'February 9 2018'
-  const TODAY_SELECTOR = `[aria-label="Today ${TODAY_LABEL}"]`;
-
-  this.setProperties({
-    month: TODAY_MONTH,
-    year: TODAY_YEAR,
-    selected: null,
+    assert
+      .dom(monthBodySelector)
+      .exists({ count: 2 }, 'it renders 2 months when `multiMonth` is true');
   });
 
-  this.render(hbs`
-    {{polaris-date-picker
-      month=month
-      year=year
-      selected=selected
-    }}
-  `);
+  test('it disables certain days when `disableDatesBefore` and `disableDatesAfter` values are passed in', async function(assert) {
+    const DISABLE_BEFORE = new Date('Mon Feb 05 2018 00:00:00 GMT-0500 (EST)');
+    const DISABLE_AFTER = new Date('Mon Feb 12 2018 00:00:00 GMT-0500 (EST)');
+    const DISABLE_BEFORE_SELECTOR = '[aria-label="February 4 2018"]';
+    const DISABLE_AFTER_SELECTOR = '[aria-label="February 13 2018"]';
 
-  let todayEl = find(TODAY_SELECTOR);
-  assert
-    .dom(todayEl)
-    .hasClass(
-      DAY_IS_TODAY_CLASS,
-      'the day representing today contains a `today` class'
+    this.setProperties({
+      month: MONTH,
+      year: YEAR,
+      selected: null,
+      disableDatesBefore: DISABLE_BEFORE,
+      disableDatesAfter: DISABLE_AFTER,
+    });
+
+    await render(hbs`
+      {{polaris-date-picker
+        month=month
+        year=year
+        selected=selected
+        disableDatesBefore=disableDatesBefore
+        disableDatesAfter=disableDatesAfter
+      }}
+    `);
+
+    assert
+      .dom(DISABLE_BEFORE_SELECTOR)
+      .hasClass(
+        DAY_DISABLED_CLASS,
+        'dates before `disableDatesBefore` have a disabled class'
+      );
+
+    assert
+      .dom(DISABLE_AFTER_SELECTOR)
+      .hasClass(
+        DAY_DISABLED_CLASS,
+        'dates after `disableDatesAfter` have a disabled class'
+      );
+  });
+
+  test('it does not fire actions when disabled days are clicked', async function(assert) {
+    const DISABLE_AFTER = new Date('Mon Feb 12 2018 00:00:00 GMT-0500 (EST)');
+    const DISABLE_AFTER_SELECTOR = '[aria-label="February 13 2018"]';
+
+    this.set('onChangeActionFired', false);
+
+    this.setProperties({
+      month: MONTH,
+      year: YEAR,
+      selected: null,
+      disableDatesAfter: DISABLE_AFTER,
+      onChange: () => {
+        this.set('onChangeActionFired', true);
+      },
+    });
+
+    await render(hbs`
+      {{polaris-date-picker
+        month=month
+        year=year
+        selected=selected
+        disableDatesAfter=disableDatesAfter
+        onChange=(action onChange)
+      }}
+    `);
+
+    await click(DISABLE_AFTER_SELECTOR);
+    assert.notOk(
+      this.get('onChangeActionFired'),
+      'clicking disabled day did not fire `onChange` action'
     );
+  });
 
-  let todayEls = findAll(`.${DAY_IS_TODAY_CLASS}`);
-  assert.ok(
-    todayEls.length,
-    1,
-    'only a single day element contains a `today` class'
-  );
+  test('it applies an `inRange` class to days between the selected range', async function(assert) {
+    const RANGE_START = new Date('Mon Feb 05 2018 00:00:00 GMT-0500 (EST)');
+    const RANGE_END = new Date('Mon Feb 12 2018 00:00:00 GMT-0500 (EST)');
+    const IN_RANGE_SELECTOR = '[aria-label="February 7 2018"]';
+
+    this.setProperties({
+      month: MONTH,
+      year: YEAR,
+      selected: {
+        start: RANGE_START,
+        end: RANGE_END,
+      },
+    });
+
+    await render(hbs`
+      {{polaris-date-picker
+        month=month
+        year=year
+        selected=selected
+      }}
+    `);
+
+    assert
+      .dom(IN_RANGE_SELECTOR)
+      .hasClass(
+        DAY_IN_RANGE_CLASS,
+        'days within the provided range contain an `inRange` class'
+      );
+  });
+
+  test('it applies a `today` class to the day representing the current day', async function(assert) {
+    const TODAY = new Date();
+    const TODAY_MONTH = TODAY.getMonth();
+    const TODAY_DATE = TODAY.getDate();
+    const TODAY_YEAR = TODAY.getFullYear();
+    const TODAY_LABEL = `${MONTHS[TODAY_MONTH]} ${TODAY_DATE} ${TODAY_YEAR}`; // ex: 'February 9 2018'
+    const TODAY_SELECTOR = `[aria-label="Today ${TODAY_LABEL}"]`;
+
+    this.setProperties({
+      month: TODAY_MONTH,
+      year: TODAY_YEAR,
+      selected: null,
+    });
+
+    await render(hbs`
+      {{polaris-date-picker
+        month=month
+        year=year
+        selected=selected
+      }}
+    `);
+
+    assert
+      .dom(TODAY_SELECTOR)
+      .hasClass(
+        DAY_IS_TODAY_CLASS,
+        'the day representing today contains a `today` class'
+      );
+
+    assert
+      .dom(`.${DAY_IS_TODAY_CLASS}`)
+      .exists(
+        { count: 1 },
+        'only a single day element contains a `today` class'
+      );
+  });
 });

--- a/tests/integration/components/polaris-description-list-test.js
+++ b/tests/integration/components/polaris-description-list-test.js
@@ -1,6 +1,7 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { findAll } from 'ember-native-dom-helpers';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 import Component from '@ember/component';
 
@@ -17,140 +18,128 @@ const stubDescriptionComponent = Component.extend({
   classNames: [stubDescriptionClass],
 });
 
-moduleForComponent(
-  'polaris-description-list',
-  'Integration | Component | polaris description list',
-  {
-    integration: true,
+module('Integration | Component | polaris description list', function(hooks) {
+  setupRenderingTest(hooks);
 
-    beforeEach() {
-      this.register('component:stub-term-component', stubTermComponent);
-      this.register(
-        'component:stub-description-component',
-        stubDescriptionComponent
-      );
+  hooks.beforeEach(function() {
+    this.owner.register('component:stub-term-component', stubTermComponent);
+    this.owner.register(
+      'component:stub-description-component',
+      stubDescriptionComponent
+    );
+  });
+
+  const items = [
+    {
+      term: 'First term',
+      description: 'First description',
     },
-  }
-);
+    {
+      term: 'Second term',
+      description: 'Second description',
+    },
+    {
+      term: 'Third term',
+      description: 'Third description',
+    },
+  ];
 
-const items = [
-  {
-    term: 'First term',
-    description: 'First description',
-  },
-  {
-    term: 'Second term',
-    description: 'Second description',
-  },
-  {
-    term: 'Third term',
-    description: 'Third description',
-  },
-];
+  const componentSelector = 'dl.Polaris-DescriptionList';
+  const listItemsTermsSelector = buildNestedSelector(componentSelector, 'dt');
 
-const componentSelector = 'dl.Polaris-DescriptionList';
-const listItemsTermsSelector = buildNestedSelector(componentSelector, 'dt');
-
-/**
- * This selector also tests that each description
- * is rendered directly after a term.
- */
-const listItemsDescriptionsSelector = buildNestedSelector(
-  componentSelector,
-  'dt + dd'
-);
-
-test('it renders the correct HTML when items are passed in', function(assert) {
-  this.set('items', items);
-  this.render(hbs`{{polaris-description-list items=items}}`);
-
-  const descriptionListComponent = findAll(componentSelector);
-  assert.equal(
-    descriptionListComponent.length,
-    1,
-    'it renders a description list component'
+  /**
+   * This selector also tests that each description
+   * is rendered directly after a term.
+   */
+  const listItemsDescriptionsSelector = buildNestedSelector(
+    componentSelector,
+    'dt + dd'
   );
 
-  const itemsTerms = findAll(listItemsTermsSelector);
-  const itemsLength = items.length;
-  assert.equal(
-    itemsTerms.length,
-    itemsLength,
-    'it renders the correct number of terms within the list'
-  );
+  test('it renders the correct HTML when items are passed in', async function(assert) {
+    const itemsLength = items.length;
 
-  const itemsDescriptions = findAll(listItemsDescriptionsSelector);
-  assert.equal(
-    itemsDescriptions.length,
-    itemsLength,
-    'it renders the correct number of descriptions following terms'
-  );
-});
+    this.set('items', items);
+    await render(hbs`{{polaris-description-list items=items}}`);
 
-test('it renders items with explicit `termComponent` and `descriptionComponent` attributes', function(assert) {
-  this.render(hbs`
-    {{polaris-description-list
-      items=(array
-        (hash
-          termComponent=(component "stub-term-component")
-          descriptionComponent=(component "stub-description-component")
+    assert
+      .dom(componentSelector)
+      .exists({ count: 1 }, 'it renders a description list component');
+
+    assert
+      .dom(listItemsTermsSelector)
+      .exists(
+        { count: itemsLength },
+        'it renders the correct number of terms within the list'
+      );
+
+    assert
+      .dom(listItemsDescriptionsSelector)
+      .exists(
+        { count: itemsLength },
+        'it renders the correct number of descriptions following terms'
+      );
+  });
+
+  test('it renders items with explicit `termComponent` and `descriptionComponent` attributes', async function(assert) {
+    await render(hbs`
+      {{polaris-description-list
+        items=(array
+          (hash
+            termComponent=(component "stub-term-component")
+            descriptionComponent=(component "stub-description-component")
+          )
         )
-      )
-    }}
-  `);
+      }}
+    `);
 
-  const descriptionListComponent = findAll(componentSelector);
-  assert.equal(
-    descriptionListComponent.length,
-    1,
-    'it renders a description list component'
-  );
+    assert
+      .dom(componentSelector)
+      .exists({ count: 1 }, 'it renders a description list component');
 
-  const termComponent = findAll(stubTermSelector);
-  assert.equal(
-    termComponent.length,
-    1,
-    'it renders a component passed as a `termComponent` attribute'
-  );
+    assert
+      .dom(stubTermSelector)
+      .exists(
+        { count: 1 },
+        'it renders a component passed as a `termComponent` attribute'
+      );
 
-  const descriptionComponent = findAll(stubDescriptionSelector);
-  assert.equal(
-    descriptionComponent.length,
-    1,
-    'it renders a component passed as a `descriptionComponent` attribute'
-  );
-});
+    assert
+      .dom(stubDescriptionSelector)
+      .exists(
+        { count: 1 },
+        'it renders a component passed as a `descriptionComponent` attribute'
+      );
+  });
 
-test('it renders items with `term` and `description` components', function(assert) {
-  this.render(hbs`
-    {{polaris-description-list
-      items=(array
-        (hash
-          term=(component "stub-term-component")
-          description=(component "stub-description-component")
+  test('it renders items with `term` and `description` components', async function(assert) {
+    await render(hbs`
+      {{polaris-description-list
+        items=(array
+          (hash
+            term=(component "stub-term-component")
+            description=(component "stub-description-component")
+          )
         )
-      )
-    }}
-  `);
+      }}
+    `);
 
-  const descriptionListComponent = findAll(componentSelector);
-  assert.equal(
-    descriptionListComponent.length,
-    1,
-    'it renders a description list component'
-  );
+    assert
+      .dom(componentSelector)
+      .exists({ count: 1 }, 'it renders a description list component');
 
-  const termComponent = findAll(stubTermSelector);
-  assert.equal(
-    termComponent.length,
-    1,
-    'it renders a component passed as a `termComponent` attribute'
-  );
+    assert
+      .dom(stubTermSelector)
+      .exists(
+        { count: 1 },
+        'it renders a component passed as a `termComponent` attribute'
+      );
 
-  const descriptionComponent = findAll(stubDescriptionSelector);
-  assert.equal(
-    descriptionComponent.length,
-    1,
-    'it renders a component passed as a `descriptionComponent` attribute'
-  );
+    assert
+      .dom(stubDescriptionSelector)
+      .exists(
+        { count: 1 },
+        'it renders a component passed as a `descriptionComponent` attribute'
+      );
+  });
 });

--- a/tests/integration/components/polaris-display-text-test.js
+++ b/tests/integration/components/polaris-display-text-test.js
@@ -1,49 +1,46 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { findAll, find } from 'ember-native-dom-helpers';
 
-moduleForComponent(
-  'polaris-display-text',
-  'Integration | Component | polaris display text',
-  {
-    integration: true,
-  }
-);
+module('Integration | Component | polaris display text', function(hooks) {
+  setupRenderingTest(hooks);
 
-test('it renders the correct HTML', function(assert) {
-  // Inline form with defaults.
-  this.render(hbs`{{polaris-display-text text="This is some text"}}`);
+  test('it renders the correct HTML', async function(assert) {
+    // Inline form with defaults.
+    await render(hbs`{{polaris-display-text text="This is some text"}}`);
 
-  let displayTextSelector =
-    'p.Polaris-DisplayText.Polaris-DisplayText--sizeMedium';
-  assert.equal(
-    findAll(displayTextSelector).length,
-    1,
-    'inline with defaults - renders one display text paragraph'
-  );
-  assert.equal(
-    find(displayTextSelector).innerText,
-    'This is some text',
-    'inline with defaults - renders correct text'
-  );
+    let displayText = assert.dom(
+      'p.Polaris-DisplayText.Polaris-DisplayText--sizeMedium'
+    );
 
-  // Block form with element and size specified.
-  this.render(hbs`
-    {{#polaris-display-text tagName="h3" size="extraLarge"}}
-      This is some BIG text
-    {{/polaris-display-text}}
-  `);
+    displayText.exists(
+      { count: 1 },
+      'inline with defaults - renders one display text paragraph'
+    );
+    displayText.hasText(
+      'This is some text',
+      'inline with defaults - renders correct text'
+    );
 
-  displayTextSelector =
-    'h3.Polaris-DisplayText.Polaris-DisplayText--sizeExtraLarge';
-  assert.equal(
-    findAll(displayTextSelector).length,
-    1,
-    'block with customisation - renders one display text paragraph'
-  );
-  assert.equal(
-    find(displayTextSelector).innerText,
-    'This is some BIG text',
-    'block with customisation - renders correct text'
-  );
+    // Block form with element and size specified.
+    await render(hbs`
+      {{#polaris-display-text tagName="h3" size="extraLarge"}}
+        This is some BIG text
+      {{/polaris-display-text}}
+    `);
+
+    displayText = assert.dom(
+      'h3.Polaris-DisplayText.Polaris-DisplayText--sizeExtraLarge'
+    );
+
+    displayText.exists(
+      { count: 1 },
+      'block with customisation - renders one display text paragraph'
+    );
+    displayText.hasText(
+      'This is some BIG text',
+      'block with customisation - renders correct text'
+    );
+  });
 });

--- a/tests/integration/components/polaris-drop-zone-test.js
+++ b/tests/integration/components/polaris-drop-zone-test.js
@@ -3,7 +3,6 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, triggerEvent, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { capitalize, htmlSafe } from '@ember/string';
-import { selectFiles } from 'ember-native-dom-helpers';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 import MockSvgJarComponent from '../../mocks/components/svg-jar';
 import MockEvent from '@smile-io/ember-polaris/test-support/mock-drop-zone-event';
@@ -100,33 +99,30 @@ module('Integration | Component | polaris-drop-zone', function(hooks) {
     await render(hbs`{{polaris-drop-zone}}`);
 
     // Defaults
-    assert.dom(dropZoneSelector).exists('has Polaris-DropZone class');
-    assert
-      .dom(dropZoneSelector)
-      .hasClass('Polaris-DropZone--hasOutline', 'has outline class');
-    assert
-      .dom(dropZoneSelector)
-      .hasClass(
-        'Polaris-DropZone--sizeExtraLarge',
-        'has extra large size class'
-      );
+    const dropZone = assert.dom(dropZoneSelector);
+    dropZone.exists('has Polaris-DropZone class');
+    dropZone.hasClass('Polaris-DropZone--hasOutline', 'has outline class');
+    dropZone.hasClass(
+      'Polaris-DropZone--sizeExtraLarge',
+      'has extra large size class'
+    );
 
     assert.dom(containerSelector).exists('has the DropZone container element');
 
-    assert.dom(inputSelector).exists('has the input element hidden');
-    assert
-      .dom(inputSelector)
-      .hasAttribute(
-        'autocomplete',
-        'off',
-        'input element has attribute autocomplete `off`'
-      );
-    assert
-      .dom(inputSelector)
-      .hasAttribute('multiple', '', 'input element has attribute multiple');
-    assert
-      .dom(inputSelector)
-      .hasAttribute('type', 'file', 'input element has attribute type `file`');
+    const input = assert.dom(inputSelector);
+
+    input.exists('has the input element hidden');
+    input.hasAttribute(
+      'autocomplete',
+      'off',
+      'input element has attribute autocomplete `off`'
+    );
+    input.hasAttribute('multiple', '', 'input element has attribute multiple');
+    input.hasAttribute(
+      'type',
+      'file',
+      'input element has attribute type `file`'
+    );
   });
 
   test('it supports `outline` property', async function(assert) {
@@ -136,17 +132,14 @@ module('Integration | Component | polaris-drop-zone', function(hooks) {
 
     await render(hbs`{{polaris-drop-zone outline=outline}}`);
 
-    assert
-      .dom(dropZoneSelector)
-      .hasClass('Polaris-DropZone--hasOutline', 'has outline class');
+    const dropZone = assert.dom(dropZoneSelector);
+    dropZone.hasClass('Polaris-DropZone--hasOutline', 'has outline class');
 
     this.set('outline', false);
-    assert
-      .dom(dropZoneSelector)
-      .doesNotHaveClass(
-        'Polaris-DropZone--hasOutline',
-        'if `outline` is false, it does not have  outline class'
-      );
+    dropZone.doesNotHaveClass(
+      'Polaris-DropZone--hasOutline',
+      'if `outline` is false, it does not have  outline class'
+    );
   });
 
   test('it supports `disabled` property', async function(assert) {
@@ -154,29 +147,24 @@ module('Integration | Component | polaris-drop-zone', function(hooks) {
 
     await render(hbs`{{polaris-drop-zone disabled=disabled}}`);
 
-    assert
-      .dom(dropZoneSelector)
-      .doesNotHaveAttribute(
-        'aria-disabled',
-        'if `disabled` is not provided, dropzone does not have `aria-label` attribute'
-      );
-    assert
-      .dom(inputSelector)
-      .isNotDisabled(
-        'if `disabled` is not provided, input does not have `disabled` attribute'
-      );
+    const dropZone = assert.dom(dropZoneSelector);
+    const input = assert.dom(inputSelector);
+
+    dropZone.doesNotHaveAttribute(
+      'aria-disabled',
+      'if `disabled` is not provided, dropzone does not have `aria-label` attribute'
+    );
+    input.isNotDisabled(
+      'if `disabled` is not provided, input does not have `disabled` attribute'
+    );
 
     this.set('disabled', true);
-    assert
-      .dom(dropZoneSelector)
-      .hasAttribute(
-        'aria-disabled',
-        'true',
-        '`aria-disabled` attribute set, if `disabled` is true'
-      );
-    assert
-      .dom(inputSelector)
-      .isDisabled('if `disabled` is true, input is disabled');
+    dropZone.hasAttribute(
+      'aria-disabled',
+      'true',
+      '`aria-disabled` attribute set, if `disabled` is true'
+    );
+    input.isDisabled('if `disabled` is true, input is disabled');
   });
 
   test('it supports `accept` property', async function(assert) {
@@ -184,17 +172,14 @@ module('Integration | Component | polaris-drop-zone', function(hooks) {
 
     await render(hbs`{{polaris-drop-zone accept=accept}}`);
 
-    assert
-      .dom(inputSelector)
-      .doesNotHaveAttribute(
-        'accept',
-        'if `accept` is not provided, input does not have `accept` attribute'
-      );
+    const input = assert.dom(inputSelector);
+    input.doesNotHaveAttribute(
+      'accept',
+      'if `accept` is not provided, input does not have `accept` attribute'
+    );
 
     this.set('accept', 'image/*');
-    assert
-      .dom(inputSelector)
-      .hasAttribute('accept', 'image/*', '`accept` attribute properly set');
+    input.hasAttribute('accept', 'image/*', '`accept` attribute properly set');
   });
 
   test('it supports `error` && `errorOverlayText` properties', async function(assert) {
@@ -206,23 +191,21 @@ module('Integration | Component | polaris-drop-zone', function(hooks) {
     );
     await triggerEvent(dropZoneSelector, 'dragenter', event);
 
-    assert
-      .dom(dropZoneSelector)
-      .doesNotHaveClass(
-        'Polaris-DropZone--hasError',
-        'if `error` is not provided, dropzone does not have error class'
-      );
+    const dropZone = assert.dom(dropZoneSelector);
+
+    dropZone.doesNotHaveClass(
+      'Polaris-DropZone--hasError',
+      'if `error` is not provided, dropzone does not have error class'
+    );
 
     this.setProperties({
       error: true,
       errorOverlayText: 'Something went haywire!',
     });
-    assert
-      .dom(dropZoneSelector)
-      .hasClass(
-        'Polaris-DropZone--hasError',
-        'if `error` is true, dropzone has error class'
-      );
+    dropZone.hasClass(
+      'Polaris-DropZone--hasError',
+      'if `error` is true, dropzone has error class'
+    );
     assert
       .dom(dropZoneOverlayTextSelector)
       .hasText(
@@ -1050,7 +1033,7 @@ module('Integration | Component | polaris-drop-zone', function(hooks) {
 
       // Test that selecting files triggers onDrop
       await render(hbs`{{polaris-drop-zone onDrop=(action drop)}}`);
-      selectFiles(inputSelector, uploadedFiles);
+      await triggerEvent(inputSelector, 'change', uploadedFiles);
 
       // Test with `accept` being set
       expectedAcceptedFiles = uploadedFiles.slice(0, 2);

--- a/tests/integration/components/polaris-footer-help-test.js
+++ b/tests/integration/components/polaris-footer-help-test.js
@@ -1,126 +1,112 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { findAll } from 'ember-native-dom-helpers';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 import MockSvgJarComponent from '../../mocks/components/svg-jar';
 
-moduleForComponent(
-  'polaris-footer-help',
-  'Integration | Component | polaris footer help',
-  {
-    integration: true,
+module('Integration | Component | polaris footer help', function(hooks) {
+  setupRenderingTest(hooks);
 
-    beforeEach() {
-      this.register('component:svg-jar', MockSvgJarComponent);
-    },
-  }
-);
+  hooks.beforeEach(function() {
+    this.owner.register('component:svg-jar', MockSvgJarComponent);
+  });
 
-const footerHelpContentSelector = buildNestedSelector(
-  'div.Polaris-FooterHelp',
-  'div.Polaris-FooterHelp__Content'
-);
-const footerHelpIconSelector = buildNestedSelector(
-  footerHelpContentSelector,
-  'div.Polaris-FooterHelp__Icon',
-  'span.Polaris-Icon',
-  'svg'
-);
-const footerHelpTextSelector = buildNestedSelector(
-  footerHelpContentSelector,
-  'div.Polaris-FooterHelp__Text'
-);
-
-test('it renders the correct HTML in inline usage', function(assert) {
-  this.render(hbs`{{polaris-footer-help text="Looking for help?"}}`);
-
-  const footerHelpContents = findAll(footerHelpContentSelector);
-  assert.equal(
-    footerHelpContents.length,
-    1,
-    'renders one footer help component with contents'
+  const footerHelpContentSelector = buildNestedSelector(
+    'div.Polaris-FooterHelp',
+    'div.Polaris-FooterHelp__Content'
+  );
+  const footerHelpIconSelector = buildNestedSelector(
+    footerHelpContentSelector,
+    'div.Polaris-FooterHelp__Icon',
+    'span.Polaris-Icon',
+    'svg'
+  );
+  const footerHelpTextSelector = buildNestedSelector(
+    footerHelpContentSelector,
+    'div.Polaris-FooterHelp__Text'
   );
 
-  // Check the icon.
-  const footerHelpIcons = findAll(footerHelpIconSelector);
-  assert.equal(footerHelpIcons.length, 1, 'renders one footer help icon');
+  test('it renders the correct HTML in inline usage', async function(assert) {
+    await render(hbs`{{polaris-footer-help text="Looking for help?"}}`);
 
-  const icon = footerHelpIcons[0];
-  assert.equal(
-    icon.dataset.iconSource,
-    'polaris/help',
-    'renders the correct icon'
-  );
+    assert
+      .dom(footerHelpContentSelector)
+      .exists({ count: 1 }, 'renders one footer help component with contents');
 
-  const iconWrapper = icon.parentNode;
-  assert.ok(
-    iconWrapper.classList.contains('Polaris-Icon--colorTeal'),
-    'renders the icon with the correct color'
-  );
-  assert.ok(
-    iconWrapper.classList.contains('Polaris-Icon--hasBackdrop'),
-    'renders the icon with backdrop'
-  );
+    // Check the icon.
+    let footerHelpIcon = assert.dom(footerHelpIconSelector);
+    footerHelpIcon.exists({ count: 1 }, 'renders one footer help icon');
 
-  // Check the text.
-  const footerHelpTexts = findAll(footerHelpTextSelector);
-  assert.equal(
-    footerHelpTexts.length,
-    1,
-    'renders one footer help text wrapper'
-  );
-  assert.equal(
-    footerHelpTexts[0].textContent.trim(),
-    'Looking for help?',
-    'renders the correct text'
-  );
-});
+    footerHelpIcon.hasAttribute(
+      'data-icon-source',
+      'polaris/help',
+      'renders the correct icon'
+    );
 
-test('it renders the correct HTML in block usage', function(assert) {
-  this.render(hbs`
-    {{#polaris-footer-help}}
-      Looking for help?
-    {{/polaris-footer-help}}
-  `);
+    const iconWrapper = this.element.querySelector(footerHelpIconSelector)
+      .parentNode;
 
-  const footerHelpContents = findAll(footerHelpContentSelector);
-  assert.equal(
-    footerHelpContents.length,
-    1,
-    'renders one footer help component with contents'
-  );
+    assert
+      .dom(iconWrapper)
+      .hasClass(
+        'Polaris-Icon--colorTeal',
+        'renders the icon with the correct color'
+      );
+    assert
+      .dom(iconWrapper)
+      .hasClass('Polaris-Icon--hasBackdrop', 'renders the icon with backdrop');
 
-  // Check the icon.
-  const footerHelpIcons = findAll(footerHelpIconSelector);
-  assert.equal(footerHelpIcons.length, 1, 'renders one footer help icon');
+    // Check the text.
+    const footerHelpTexts = assert.dom(footerHelpTextSelector);
 
-  const icon = footerHelpIcons[0];
-  assert.equal(
-    icon.dataset.iconSource,
-    'polaris/help',
-    'renders the correct icon'
-  );
+    footerHelpTexts.exists(
+      { count: 1 },
+      'renders one footer help text wrapper'
+    );
+    footerHelpTexts.hasText('Looking for help?', 'renders the correct text');
+  });
 
-  const iconWrapper = icon.parentNode;
-  assert.ok(
-    iconWrapper.classList.contains('Polaris-Icon--colorTeal'),
-    'renders the icon with the correct color'
-  );
-  assert.ok(
-    iconWrapper.classList.contains('Polaris-Icon--hasBackdrop'),
-    'renders the icon with backdrop'
-  );
+  test('it renders the correct HTML in block usage', async function(assert) {
+    await render(hbs`
+      {{#polaris-footer-help}}
+        Looking for help?
+      {{/polaris-footer-help}}
+    `);
 
-  // Check the text.
-  const footerHelpTexts = findAll(footerHelpTextSelector);
-  assert.equal(
-    footerHelpTexts.length,
-    1,
-    'renders one footer help text wrapper'
-  );
-  assert.equal(
-    footerHelpTexts[0].textContent.trim(),
-    'Looking for help?',
-    'renders the correct text'
-  );
+    assert
+      .dom(footerHelpContentSelector)
+      .exists({ count: 1 }, 'renders one footer help component with contents');
+
+    // Check the icon.
+    const footerHelpIcons = assert.dom(footerHelpIconSelector);
+    footerHelpIcons.exists({ count: 1 }, 'renders one footer help icon');
+
+    footerHelpIcons.hasAttribute(
+      'data-icon-source',
+      'polaris/help',
+      'renders the correct icon'
+    );
+
+    const iconWrapper = this.element.querySelector(footerHelpIconSelector)
+      .parentNode;
+    assert
+      .dom(iconWrapper)
+      .hasClass(
+        'Polaris-Icon--colorTeal',
+        'renders the icon with the correct color'
+      );
+    assert
+      .dom(iconWrapper)
+      .hasClass('Polaris-Icon--hasBackdrop', 'renders the icon with backdrop');
+
+    // Check the text.
+    const footerHelpTexts = assert.dom(footerHelpTextSelector);
+
+    footerHelpTexts.exists(
+      { count: 1 },
+      'renders one footer help text wrapper'
+    );
+    footerHelpTexts.hasText('Looking for help?', 'renders the correct text');
+  });
 });

--- a/tests/integration/components/polaris-heading-test.js
+++ b/tests/integration/components/polaris-heading-test.js
@@ -1,44 +1,41 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { find, findAll } from 'ember-native-dom-helpers';
 
-moduleForComponent(
-  'polaris-heading',
-  'Integration | Component | polaris heading',
-  {
-    integration: true,
-  }
-);
+module('Integration | Component | polaris heading', function(hooks) {
+  setupRenderingTest(hooks);
 
-test('it renders the correct HTML', function(assert) {
-  // Inline form with defaults.
-  this.render(hbs`{{polaris-heading text="This is a heading"}}`);
+  test('it renders the correct HTML', async function(assert) {
+    // Inline form with defaults.
+    await render(hbs`{{polaris-heading text="This is a heading"}}`);
 
-  let headingSelector = 'h2.Polaris-Heading';
-  assert.equal(
-    findAll(headingSelector).length,
-    1,
-    'inline with defaults - renders one h2 heading'
-  );
-  assert.equal(
-    find(headingSelector).innerText,
-    'This is a heading',
-    'inline with defaults - renders correct text'
-  );
+    let headingSelector = 'h2.Polaris-Heading';
+    let heading = assert.dom('h2.Polaris-Heading');
+    heading.exists(
+      { count: 1 },
+      'inline with defaults - renders one h2 heading'
+    );
 
-  // Block form with element specified.
-  this.render(hbs`
-    {{#polaris-heading tagName="em"}}
-      This is an emphasised heading
-    {{/polaris-heading}}
-  `);
+    heading.hasText(
+      'This is a heading',
+      'inline with defaults - renders correct text'
+    );
 
-  headingSelector = 'em.Polaris-Heading';
-  assert.dom(headingSelector).exists({ count: 1 });
-  assert
-    .dom(headingSelector)
-    .hasText(
+    // Block form with element specified.
+    await render(hbs`
+      {{#polaris-heading tagName="em"}}
+        This is an emphasised heading
+      {{/polaris-heading}}
+    `);
+
+    headingSelector = 'em.Polaris-Heading';
+    heading = assert.dom(headingSelector);
+
+    heading.exists({ count: 1 });
+    heading.hasText(
       'This is an emphasised heading',
       'block with customisation - renders correct text'
     );
+  });
 });

--- a/tests/integration/components/polaris-icon-test.js
+++ b/tests/integration/components/polaris-icon-test.js
@@ -1,195 +1,197 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
 import { classify } from '@ember/string';
 import hbs from 'htmlbars-inline-precompile';
-import { findAll, find } from 'ember-native-dom-helpers';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 import MockSvgJarComponent from '../../mocks/components/svg-jar';
 
-moduleForComponent('polaris-icon', 'Integration | Component | polaris icon', {
-  integration: true,
+// Colors lifted from shopify source.
+const colors = [
+  'white',
+  'black',
+  'skyLighter',
+  'skyLight',
+  'sky',
+  'skyDark',
+  'inkLightest',
+  'inkLighter',
+  'inkLight',
+  'ink',
+  'blueLighter',
+  'blueLight',
+  'blue',
+  'blueDark',
+  'blueDarker',
+  'indigoLighter',
+  'indigoLight',
+  'indigo',
+  'indigoDark',
+  'indigoDarker',
+  'tealLighter',
+  'tealLight',
+  'teal',
+  'tealDark',
+  'tealDarker',
+  'greenLighter',
+  'green',
+  'greenDark',
+  'yellowLighter',
+  'yellow',
+  'yellowDark',
+  'orange',
+  'redLighter',
+  'red',
+  'redDark',
+  'purple',
+];
 
-  beforeEach() {
-    this.register('component:svg-jar', MockSvgJarComponent);
-  },
-});
+module('Integration | Component | polaris icon', function(hooks) {
+  setupRenderingTest(hooks);
 
-const iconSelector = 'span.Polaris-Icon';
+  hooks.beforeEach(function() {
+    this.owner.register('component:svg-jar', MockSvgJarComponent);
+  });
 
-test('it renders the specified icon correctly', function(assert) {
-  this.render(hbs`{{polaris-icon source="notes"}}`);
-
-  const icons = findAll(iconSelector);
-  assert.equal(icons.length, 1, 'renders one icon component');
+  const iconSelector = 'span.Polaris-Icon';
 
   const svgSelector = buildNestedSelector(
     iconSelector,
     'svg.Polaris-Icon__Svg'
   );
-  const svgs = findAll(svgSelector);
-  assert.equal(svgs.length, 1, 'renders one SVG element');
 
-  const svg = svgs[0];
-  assert.equal(
-    svg.dataset.iconSource,
-    'polaris/notes',
-    'uses the correct SVG source'
-  );
-  assert.equal(
-    svg.getAttribute('focusable'),
-    'false',
-    'applies focusable:false to the SVG element'
-  );
-  assert.equal(
-    svg.getAttribute('aria-hidden'),
-    'true',
-    'applies aria-hidden to the SVG element'
-  );
-});
+  test('it renders the specified icon correctly', async function(assert) {
+    await render(hbs`{{polaris-icon source="notes"}}`);
 
-test('it applies colors correctly', function(assert) {
-  // Colors lifted from shopify source.
-  const colors = [
-    'white',
-    'black',
-    'skyLighter',
-    'skyLight',
-    'sky',
-    'skyDark',
-    'inkLightest',
-    'inkLighter',
-    'inkLight',
-    'ink',
-    'blueLighter',
-    'blueLight',
-    'blue',
-    'blueDark',
-    'blueDarker',
-    'indigoLighter',
-    'indigoLight',
-    'indigo',
-    'indigoDark',
-    'indigoDarker',
-    'tealLighter',
-    'tealLight',
-    'teal',
-    'tealDark',
-    'tealDarker',
-    'greenLighter',
-    'green',
-    'greenDark',
-    'yellowLighter',
-    'yellow',
-    'yellowDark',
-    'orange',
-    'redLighter',
-    'red',
-    'redDark',
-    'purple',
-  ];
+    assert.dom(iconSelector).exists({ count: 1 }, 'renders one icon component');
 
-  assert.expect(2 + colors.length * 3);
+    const svg = assert.dom(svgSelector);
+    svg.exists({ count: 1 }, 'renders one SVG element');
 
-  this.render(hbs`{{polaris-icon source="add" color=color}}`);
+    svg.hasAttribute(
+      'data-icon-source',
+      'polaris/notes',
+      'uses the correct SVG source'
+    );
+    svg.hasAttribute(
+      'focusable',
+      'false',
+      'applies focusable:false to the SVG element'
+    );
+    svg.hasAttribute(
+      'aria-hidden',
+      'true',
+      'applies aria-hidden to the SVG element'
+    );
+  });
 
-  // Check without any color set first.
-  const icon = find(iconSelector);
-  assert.ok(
-    icon.className.indexOf('Polaris-Icon--color') === -1,
-    'icon without color does not add color class'
-  );
-  assert.notOk(
-    icon.classList.contains('Polaris-Icon--isColored'),
-    'icon without color does not add isColored class'
-  );
+  test('it applies colors correctly', async function(assert) {
+    assert.expect(2 + colors.length * 3);
 
-  // Check all the available colors are handled correctly.
-  for (const color of colors) {
-    this.set('color', color);
+    await render(hbs`{{polaris-icon source="add" color=color}}`);
 
-    const colorClass = `Polaris-Icon--color${classify(color)}`;
-    assert.ok(
-      icon.classList.contains(colorClass),
-      `icon with ${color} color applies ${colorClass} class`
+    // Check without any color set first.
+    const icon = assert.dom(iconSelector);
+    const iconClassList = this.element.querySelector(iconSelector).classList;
+
+    icon.doesNotHaveClass(
+      'Polaris-Icon--color',
+      'icon without color does not add color class'
+    );
+    icon.hasNoClass(
+      'Polaris-Icon--isColored',
+      'icon without color does not add isColored class'
     );
 
-    const colorClassNames = [...icon.classList].filter((className) => {
-      return className.indexOf('Polaris-Icon--color') === 0;
-    });
-    assert.equal(
-      colorClassNames.length,
-      1,
-      `icon with ${color} color does not add other color classes`
-    );
+    // Check all the available colors are handled correctly.
+    for (const color of colors) {
+      this.set('color', color);
 
-    if (color === 'white') {
-      assert.notOk(
-        icon.classList.contains('Polaris-Icon--isColored'),
-        `icon with ${color} color does not add isColored class`
+      const colorClass = `Polaris-Icon--color${classify(color)}`;
+      icon.hasClass(
+        colorClass,
+        `icon with ${color} color applies ${colorClass} class`
       );
-    } else {
-      assert.ok(
-        icon.classList.contains('Polaris-Icon--isColored'),
-        `icon with ${color} color adds isColored class`
+
+      const colorClassNames = [...iconClassList].filter((className) =>
+        className.includes('Polaris-Icon--color')
       );
+
+      assert.equal(
+        colorClassNames.length,
+        1,
+        `icon with ${color} color does not add other color classes`
+      );
+
+      if (color === 'white') {
+        icon.hasNoClass(
+          'Polaris-Icon--isColored',
+          `icon with ${color} color does not add isColored class`
+        );
+      } else {
+        icon.hasClass(
+          'Polaris-Icon--isColored',
+          `icon with ${color} color adds isColored class`
+        );
+      }
     }
-  }
-});
+  });
 
-test('it handles backdrop correctly', function(assert) {
-  this.render(hbs`{{polaris-icon source="add" backdrop=backdrop}}`);
+  test('it handles backdrop correctly', async function(assert) {
+    await render(hbs`{{polaris-icon source="add" backdrop=backdrop}}`);
 
-  // Check default setting.
-  const icon = find(iconSelector);
-  const backdropClass = 'Polaris-Icon--hasBackdrop';
-  assert.notOk(
-    icon.classList.contains(backdropClass),
-    'icon without backdrop set does not apply backdrop class'
-  );
+    // Check default setting.
+    const backdropClass = 'Polaris-Icon--hasBackdrop';
 
-  this.set('backdrop', true);
-  assert.ok(
-    icon.classList.contains(backdropClass),
-    `icon with backdrop=true applies backdrop class`
-  );
+    const icon = assert.dom(iconSelector);
+    icon.hasNoClass(
+      backdropClass,
+      'icon without backdrop set does not apply backdrop class'
+    );
 
-  this.set('backdrop', false);
-  assert.notOk(
-    icon.classList.contains(backdropClass),
-    `icon with backdrop=false does not apply backdrop class`
-  );
-});
+    this.set('backdrop', true);
+    icon.hasClass(
+      backdropClass,
+      `icon with backdrop=true applies backdrop class`
+    );
 
-test('it handles accessibilityLabel correctly', function(assert) {
-  this.render(
-    hbs`{{polaris-icon source="add" accessibilityLabel=accessibilityLabel}}`
-  );
+    this.set('backdrop', false);
+    icon.hasNoClass(
+      backdropClass,
+      `icon with backdrop=false does not apply backdrop class`
+    );
+  });
 
-  // Check default setting.
-  const icon = find(iconSelector);
-  assert.notOk(
-    icon.attributes['aria-label'],
-    'no accessibilityLabel set - does not add aria-label attribute'
-  );
+  test('it handles accessibilityLabel correctly', async function(assert) {
+    await render(
+      hbs`{{polaris-icon source="add" accessibilityLabel=accessibilityLabel}}`
+    );
 
-  this.set('accessibilityLabel', 'This is the accessibility label');
-  assert.ok(
-    icon.attributes['aria-label'],
-    'accessibilityLabel set - adds aria-label attribute'
-  );
-  assert.equal(
-    icon.attributes['aria-label'].value,
-    'This is the accessibility label',
-    'accessibilityLabel set - adds correct aria-label value'
-  );
-});
+    // Check default setting.
+    const icon = assert.dom(iconSelector);
 
-test('it handles placeholder icons correctly', function(assert) {
-  this.render(hbs`{{polaris-icon source="placeholder"}}`);
+    icon.doesNotHaveAttribute(
+      'aria-label',
+      'no accessibilityLabel set - does not add aria-label attribute'
+    );
 
-  const iconPlaceholderSelector = buildNestedSelector(
-    iconSelector,
-    'div.Polaris-Icon__Placeholder'
-  );
-  const iconPlaceholders = findAll(iconPlaceholderSelector);
-  assert.equal(iconPlaceholders.length, 1, 'renders one icon placeholder');
+    this.set('accessibilityLabel', 'This is the accessibility label');
+    icon.hasAttribute(
+      'aria-label',
+      'This is the accessibility label',
+      'accessibilityLabel set - adds aria-label attribute'
+    );
+  });
+
+  test('it handles placeholder icons correctly', async function(assert) {
+    await render(hbs`{{polaris-icon source="placeholder"}}`);
+
+    const iconPlaceholderSelector = buildNestedSelector(
+      iconSelector,
+      'div.Polaris-Icon__Placeholder'
+    );
+    assert
+      .dom(iconPlaceholderSelector)
+      .exists({ count: 1 }, 'renders one icon placeholder');
+  });
 });

--- a/tests/integration/components/polaris-layout-test.js
+++ b/tests/integration/components/polaris-layout-test.js
@@ -1,15 +1,8 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { findAll } from 'ember-native-dom-helpers';
 import buildNestedSelector from '../../helpers/build-nested-selector';
-
-moduleForComponent(
-  'polaris-layout',
-  'Integration | Component | polaris layout',
-  {
-    integration: true,
-  }
-);
 
 const layoutSelector = 'div.Polaris-Layout';
 const layoutSectionSelector = buildNestedSelector(
@@ -22,550 +15,483 @@ const layoutAnnotationWrapperSelector = buildNestedSelector(
   'div.Polaris-Layout__AnnotationWrapper'
 );
 
-test('it renders the correct HTML in basic usage', function(assert) {
-  // Test inline form.
-  this.render(hbs`{{polaris-layout text="This is an inline layout"}}`);
-
-  let layouts = findAll(layoutSelector);
-  assert.equal(
-    layouts.length,
-    1,
-    'inline without sectioned flag - renders one layout'
-  );
-
-  let layout = layouts[0];
-  assert.equal(
-    layout.children.length,
-    0,
-    'inline without sectioned flag - layout has no children'
-  );
-  assert.equal(
-    layout.textContent.trim(),
-    'This is an inline layout',
-    'inline without sectioned flag - renders text content'
-  );
-
-  // Test block form.
-  this.render(
-    hbs`{{#polaris-layout}}This is a block layout{{/polaris-layout}}`
-  );
-
-  layouts = findAll(layoutSelector);
-  assert.equal(
-    layouts.length,
-    1,
-    'block without sectioned flag - renders one layout'
-  );
-
-  layout = layouts[0];
-  assert.equal(
-    layout.children.length,
-    0,
-    'block without sectioned flag - layout has no children'
-  );
-  assert.equal(
-    layout.textContent.trim(),
-    'This is a block layout',
-    'block without sectioned flag - renders text content'
-  );
-
-  // Test inline form with sectioned flag.
-  this.render(
-    hbs`{{polaris-layout text="This is a sectioned inline layout" sectioned=true}}`
-  );
-
-  layouts = findAll(layoutSelector);
-  assert.equal(
-    layouts.length,
-    1,
-    'inline with sectioned flag - renders one layout'
-  );
-  assert.equal(
-    layouts[0].children.length,
-    1,
-    'inline with sectioned flag - layout has one child'
-  );
-
-  let layoutSections = findAll(layoutSectionSelector);
-  assert.equal(
-    layoutSections.length,
-    1,
-    'inline with sectioned flag - renders layout section'
-  );
-  assert.equal(
-    layoutSections[0].textContent.trim(),
-    'This is a sectioned inline layout',
-    'inline with sectioned flag - renders text content'
-  );
-
-  // Test block form with sectioned flag.
-  this.render(
-    hbs`{{#polaris-layout sectioned=true}}This is a sectioned block layout{{/polaris-layout}}`
-  );
-
-  layouts = findAll(layoutSelector);
-  assert.equal(
-    layouts.length,
-    1,
-    'block with sectioned flag - renders one layout'
-  );
-  assert.equal(
-    layouts[0].children.length,
-    1,
-    'block with sectioned flag - layout has one child'
-  );
-
-  layoutSections = findAll(layoutSectionSelector);
-  assert.equal(
-    layoutSections.length,
-    1,
-    'inline with sectioned flag - renders layout section'
-  );
-  assert.equal(
-    layoutSections[0].textContent.trim(),
-    'This is a sectioned block layout',
-    'block with sectioned flag - renders text content'
-  );
-});
-
-test('it renders the correct HTML when using sections', function(assert) {
-  this.render(hbs`
-    {{#polaris-layout as |layout|}}
-      {{layout.section text="This is an inline section"}}
-
-      {{#layout.section}}
-        This is a block section
-      {{/layout.section}}
-
-      {{layout.section text="This is a secondary section" secondary=true}}
-
-      {{layout.section text="This is a full-width section" fullWidth=true}}
-
-      {{layout.section text="This is a half-width section" oneHalf=true}}
-
-      {{layout.section text="This is a third-width section" oneThird=true}}
-    {{/polaris-layout}}
-  `);
-
-  const layoutSections = findAll(layoutSectionSelector);
-  assert.equal(layoutSections.length, 6, 'renders six layout sections');
-
-  // Check the first section.
-  let layoutSection = layoutSections[0];
-  assert.notOk(
-    layoutSection.classList.contains('Polaris-Layout__Section--secondary'),
-    'first section - does not have secondary class'
-  );
-  assert.notOk(
-    layoutSection.classList.contains('Polaris-Layout__Section--fullWidth'),
-    'first section - does not have full width class'
-  );
-  assert.notOk(
-    layoutSection.classList.contains('Polaris-Layout__Section--oneHalf'),
-    'first section - does not have half width class'
-  );
-  assert.notOk(
-    layoutSection.classList.contains('Polaris-Layout__Section--oneThird'),
-    'first section - does not have third width class'
-  );
-  assert.equal(
-    layoutSection.textContent.trim(),
-    'This is an inline section',
-    'first section - renders text content'
-  );
-
-  // Check the second section.
-  layoutSection = layoutSections[1];
-  assert.notOk(
-    layoutSection.classList.contains('Polaris-Layout__Section--secondary'),
-    'second section - does not have secondary class'
-  );
-  assert.notOk(
-    layoutSection.classList.contains('Polaris-Layout__Section--fullWidth'),
-    'second section - does not have full width class'
-  );
-  assert.notOk(
-    layoutSection.classList.contains('Polaris-Layout__Section--oneHalf'),
-    'second section - does not have half width class'
-  );
-  assert.notOk(
-    layoutSection.classList.contains('Polaris-Layout__Section--oneThird'),
-    'second section - does not have third width class'
-  );
-  assert.equal(
-    layoutSection.textContent.trim(),
-    'This is a block section',
-    'second section - renders text content'
-  );
-
-  // Check the third section.
-  layoutSection = layoutSections[2];
-  assert.ok(
-    layoutSection.classList.contains('Polaris-Layout__Section--secondary'),
-    'third section - has secondary class'
-  );
-  assert.notOk(
-    layoutSection.classList.contains('Polaris-Layout__Section--fullWidth'),
-    'third section - does not have full width class'
-  );
-  assert.notOk(
-    layoutSection.classList.contains('Polaris-Layout__Section--oneHalf'),
-    'third section - does not have half width class'
-  );
-  assert.notOk(
-    layoutSection.classList.contains('Polaris-Layout__Section--oneThird'),
-    'third section - does not have third width class'
-  );
-  assert.equal(
-    layoutSection.textContent.trim(),
-    'This is a secondary section',
-    'third section - renders text content'
-  );
-
-  // Check the fourth section.
-  layoutSection = layoutSections[3];
-  assert.notOk(
-    layoutSection.classList.contains('Polaris-Layout__Section--secondary'),
-    'fourth section - does not have secondary class'
-  );
-  assert.ok(
-    layoutSection.classList.contains('Polaris-Layout__Section--fullWidth'),
-    'fourth section - has full width class'
-  );
-  assert.notOk(
-    layoutSection.classList.contains('Polaris-Layout__Section--oneHalf'),
-    'fourth section - does not have half width class'
-  );
-  assert.notOk(
-    layoutSection.classList.contains('Polaris-Layout__Section--oneThird'),
-    'fourth section - does not have third width class'
-  );
-  assert.equal(
-    layoutSection.textContent.trim(),
-    'This is a full-width section',
-    'fourth section - renders text content'
-  );
-
-  // Check the fifth section.
-  layoutSection = layoutSections[4];
-  assert.notOk(
-    layoutSection.classList.contains('Polaris-Layout__Section--secondary'),
-    'fifth section - does not have secondary class'
-  );
-  assert.notOk(
-    layoutSection.classList.contains('Polaris-Layout__Section--fullWidth'),
-    'fifth section - does not have full width class'
-  );
-  assert.ok(
-    layoutSection.classList.contains('Polaris-Layout__Section--oneHalf'),
-    'fifth section - has half width class'
-  );
-  assert.notOk(
-    layoutSection.classList.contains('Polaris-Layout__Section--oneThird'),
-    'fifth section - does not have third width class'
-  );
-  assert.equal(
-    layoutSection.textContent.trim(),
-    'This is a half-width section',
-    'fifth section - renders text content'
-  );
-
-  // Check the sixth section.
-  layoutSection = layoutSections[5];
-  assert.notOk(
-    layoutSection.classList.contains('Polaris-Layout__Section--secondary'),
-    'sixth section - does not have secondary class'
-  );
-  assert.notOk(
-    layoutSection.classList.contains('Polaris-Layout__Section--fullWidth'),
-    'sixth section - does not have full width class'
-  );
-  assert.notOk(
-    layoutSection.classList.contains('Polaris-Layout__Section--oneHalf'),
-    'sixth section - does not have half width class'
-  );
-  assert.ok(
-    layoutSection.classList.contains('Polaris-Layout__Section--oneThird'),
-    'sixth section - has third width class'
-  );
-  assert.equal(
-    layoutSection.textContent.trim(),
-    'This is a third-width section',
-    'sixth section - renders text content'
-  );
-});
-
-test('it renders the correct HTML when no title, text or description are passed to annotated section', function(assert) {
-  this.render(hbs`
-    {{#polaris-layout as |layout|}}
-      {{layout.annotatedSection}}
-    {{/polaris-layout}}
-  `);
-
-  const annotationWrappers = findAll(layoutAnnotationWrapperSelector);
-  assert.equal(annotationWrappers.length, 1, 'renders one annotation wrapper');
-
-  const textContainerSelector = buildNestedSelector(
-    'div.Polaris-Layout__Annotation',
-    'div.Polaris-TextContainer'
-  );
-  const headerSelector = buildNestedSelector(
-    textContainerSelector,
-    'h2.Polaris-Heading'
-  );
-
-  const contentSelector = 'div.Polaris-Layout__AnnotationContent';
-
-  const annotationWrapper = annotationWrappers[0];
-  let headers = findAll(headerSelector, annotationWrapper);
-  assert.equal(headers.length, 1, 'renders header');
-  assert.equal(headers[0].textContent.trim(), '', 'renders header correctly');
-
-  let descriptionSelector = '[data-test-annotation-description]';
-
-  let descriptions = findAll(descriptionSelector, annotationWrapper);
-  assert.equal(
-    descriptions.length,
-    0,
-    'renders description paragraph correctly'
-  );
-
-  let contents = findAll(contentSelector, annotationWrapper);
-  assert.equal(contents.length, 1, 'renders content');
-  assert.equal(contents[0].textContent.trim(), '', 'renders correct content');
-});
-
-test('it renders the correct HTML when a title and no text or description are passed to annotated section', function(assert) {
-  this.render(hbs`
-    {{#polaris-layout as |layout|}}
-      {{layout.annotatedSection
-        text="This is an inline annotated section without title or description"
-      }}
-    {{/polaris-layout}}
-  `);
-
-  const annotationWrappers = findAll(layoutAnnotationWrapperSelector);
-  assert.equal(annotationWrappers.length, 1, 'renders one annotation wrapper');
-
-  const textContainerSelector = buildNestedSelector(
-    'div.Polaris-Layout__Annotation',
-    'div.Polaris-TextContainer'
-  );
-  const headerSelector = buildNestedSelector(
-    textContainerSelector,
-    'h2.Polaris-Heading'
-  );
-
-  const contentSelector = 'div.Polaris-Layout__AnnotationContent';
-
-  const annotationWrapper = annotationWrappers[0];
-  let headers = findAll(headerSelector, annotationWrapper);
-  assert.equal(headers.length, 1, 'renders header');
-  assert.equal(headers[0].textContent.trim(), '', 'renders header correctly');
-
-  let descriptionSelector = '[data-test-annotation-description]';
-
-  let descriptions = findAll(descriptionSelector, annotationWrapper);
-  assert.equal(
-    descriptions.length,
-    0,
-    'renders description paragraph correctly'
-  );
-
-  let contents = findAll(contentSelector, annotationWrapper);
-  assert.equal(contents.length, 1, 'renders content');
-  assert.equal(
-    contents[0].textContent.trim(),
-    'This is an inline annotated section without title or description',
-    'renders correct content'
-  );
-});
-
-test('it renders the correct HTML when a title and text and no description are passed to annotated section', function(assert) {
-  this.render(hbs`
-    {{#polaris-layout as |layout|}}
-      {{layout.annotatedSection
-        title="Inline title"
-        text="This is an inline annotated section with a title but no description"
-      }}
-    {{/polaris-layout}}
-  `);
-
-  const annotationWrappers = findAll(layoutAnnotationWrapperSelector);
-  assert.equal(annotationWrappers.length, 1, 'renders one annotation wrapper');
-
-  const textContainerSelector = buildNestedSelector(
-    'div.Polaris-Layout__Annotation',
-    'div.Polaris-TextContainer'
-  );
-  const headerSelector = buildNestedSelector(
-    textContainerSelector,
-    'h2.Polaris-Heading'
-  );
-
-  const contentSelector = 'div.Polaris-Layout__AnnotationContent';
-
-  const annotationWrapper = annotationWrappers[0];
-  let headers = findAll(headerSelector, annotationWrapper);
-  assert.equal(headers.length, 1, 'renders header');
-  assert.equal(
-    headers[0].textContent.trim(),
-    'Inline title',
-    'renders header correctly'
-  );
-
-  let descriptionSelector = '[data-test-annotation-description]';
-
-  let descriptions = findAll(descriptionSelector, annotationWrapper);
-  assert.equal(
-    descriptions.length,
-    0,
-    'renders description paragraph correctly'
-  );
-
-  let contents = findAll(contentSelector, annotationWrapper);
-  assert.equal(contents.length, 1, 'renders content');
-  assert.equal(
-    contents[0].textContent.trim(),
-    'This is an inline annotated section with a title but no description',
-    'renders correct content'
-  );
-});
-
-test('it renders the correct HTML when text and description string and no title are passed to annotated section', function(assert) {
-  this.render(hbs`
-    {{#polaris-layout as |layout|}}
-      {{layout.annotatedSection
-        description="Inline description"
-        text="This is an inline annotated section with a description but no title"
-      }}
-    {{/polaris-layout}}
-  `);
-
-  const annotationWrappers = findAll(layoutAnnotationWrapperSelector);
-  assert.equal(annotationWrappers.length, 1, 'renders one annotation wrapper');
-
-  const textContainerSelector = buildNestedSelector(
-    'div.Polaris-Layout__Annotation',
-    'div.Polaris-TextContainer'
-  );
-  const headerSelector = buildNestedSelector(
-    textContainerSelector,
-    'h2.Polaris-Heading'
-  );
-
-  const contentSelector = 'div.Polaris-Layout__AnnotationContent';
-
-  const annotationWrapper = annotationWrappers[0];
-  let headers = findAll(headerSelector, annotationWrapper);
-  assert.equal(headers.length, 1, 'renders header');
-  assert.equal(headers[0].textContent.trim(), '', 'renders header correctly');
-
-  let descriptionSelector = '[data-test-annotation-description]';
-
-  let descriptions = findAll(descriptionSelector, annotationWrapper);
-  assert.equal(descriptions.length, 1, 'renders description paragraph');
-  assert.equal(
-    descriptions[0].textContent.trim(),
-    'Inline description',
-    'renders header correctly'
-  );
-
-  let contents = findAll(contentSelector, annotationWrapper);
-  assert.equal(contents.length, 1, 'renders content');
-  assert.equal(
-    contents[0].textContent.trim(),
-    'This is an inline annotated section with a description but no title',
-    'renders correct content'
-  );
-});
-
-test('it renders the correct HTML when text and description string and title are passed to annotated section', function(assert) {
-  this.render(hbs`
-    {{#polaris-layout as |layout|}}
-      {{layout.annotatedSection
-        title="Inline title"
-        description="Inline description"
-        text="This is an inline annotated section with both a title and description"
-      }}
-    {{/polaris-layout}}
-  `);
-
-  const annotationWrappers = findAll(layoutAnnotationWrapperSelector);
-  assert.equal(annotationWrappers.length, 1, 'renders one annotation wrapper');
-
-  const textContainerSelector = buildNestedSelector(
-    'div.Polaris-Layout__Annotation',
-    'div.Polaris-TextContainer'
-  );
-  const headerSelector = buildNestedSelector(
-    textContainerSelector,
-    'h2.Polaris-Heading'
-  );
-
-  const contentSelector = 'div.Polaris-Layout__AnnotationContent';
-
-  const annotationWrapper = annotationWrappers[0];
-  let headers = findAll(headerSelector, annotationWrapper);
-  assert.equal(headers.length, 1, 'renders header');
-  assert.equal(
-    headers[0].textContent.trim(),
-    'Inline title',
-    'renders header correctly'
-  );
-
-  let descriptionSelector = '[data-test-annotation-description]';
-
-  let descriptions = findAll(descriptionSelector, annotationWrapper);
-  assert.equal(descriptions.length, 1, 'renders description paragraph');
-  assert.equal(
-    descriptions[0].textContent.trim(),
-    'Inline description',
-    'renders header correctly'
-  );
-
-  let contents = findAll(contentSelector, annotationWrapper);
-  assert.equal(contents.length, 1, 'renders content');
-  assert.equal(
-    contents[0].textContent.trim(),
-    'This is an inline annotated section with both a title and description',
-    'renders correct content'
-  );
-});
-
-test('it renders the correct HTML when description component is passed to annotated section', function(assert) {
-  this.render(hbs`
-    {{#polaris-layout as |layout|}}
-      {{layout.annotatedSection
-        description=(component "wrapper-element" data-test-annotation-description-content=true)
-      }}
-    {{/polaris-layout}}
-  `);
-
-  const descriptionSelector = buildNestedSelector(
-    '[data-test-annotation-description]',
-    '[data-test-annotation-description-content]'
-  );
-  assert.dom(descriptionSelector).exists({ count: 1 });
-});
-
-test('it renders the correct HTML when description hash is passed to annotated section', function(assert) {
-  this.render(hbs`
-    {{#polaris-layout as |layout|}}
-      {{layout.annotatedSection
-        description=(hash
-          componentName="wrapper-element"
-          props=(hash
-            data-test-annotation-description-content=true
+const textContainerSelector = buildNestedSelector(
+  'div.Polaris-Layout__Annotation',
+  'div.Polaris-TextContainer'
+);
+const headerSelector = `${layoutAnnotationWrapperSelector} ${buildNestedSelector(
+  textContainerSelector,
+  'h2.Polaris-Heading'
+)}`;
+
+const contentSelector = `${layoutAnnotationWrapperSelector} div.Polaris-Layout__AnnotationContent`;
+const descriptionSelector = `${layoutAnnotationWrapperSelector} [data-test-annotation-description]`;
+
+module('Integration | Component | polaris layout', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the correct HTML in basic usage', async function(assert) {
+    // Test inline form.
+    await render(hbs`{{polaris-layout text="This is an inline layout"}}`);
+
+    let layouts = findAll(layoutSelector);
+    assert.equal(
+      layouts.length,
+      1,
+      'inline without sectioned flag - renders one layout'
+    );
+
+    let layout = layouts[0];
+    assert.equal(
+      layout.children.length,
+      0,
+      'inline without sectioned flag - layout has no children'
+    );
+    assert
+      .dom(layout)
+      .hasText(
+        'This is an inline layout',
+        'inline without sectioned flag - renders text content'
+      );
+
+    // Test block form.
+    await render(
+      hbs`{{#polaris-layout}}This is a block layout{{/polaris-layout}}`
+    );
+
+    layouts = findAll(layoutSelector);
+    assert.equal(
+      layouts.length,
+      1,
+      'block without sectioned flag - renders one layout'
+    );
+
+    layout = layouts[0];
+    assert.equal(
+      layout.children.length,
+      0,
+      'block without sectioned flag - layout has no children'
+    );
+    assert
+      .dom(layout)
+      .hasText(
+        'This is a block layout',
+        'block without sectioned flag - renders text content'
+      );
+
+    // Test inline form with sectioned flag.
+    await render(
+      hbs`{{polaris-layout text="This is a sectioned inline layout" sectioned=true}}`
+    );
+
+    layouts = findAll(layoutSelector);
+    assert.equal(
+      layouts.length,
+      1,
+      'inline with sectioned flag - renders one layout'
+    );
+    assert.equal(
+      layouts[0].children.length,
+      1,
+      'inline with sectioned flag - layout has one child'
+    );
+
+    let layoutSections = findAll(layoutSectionSelector);
+    assert.equal(
+      layoutSections.length,
+      1,
+      'inline with sectioned flag - renders layout section'
+    );
+    assert
+      .dom(layoutSections[0])
+      .hasText(
+        'This is a sectioned inline layout',
+        'inline with sectioned flag - renders text content'
+      );
+
+    // Test block form with sectioned flag.
+    await render(
+      hbs`{{#polaris-layout sectioned=true}}This is a sectioned block layout{{/polaris-layout}}`
+    );
+
+    layouts = findAll(layoutSelector);
+    assert.equal(
+      layouts.length,
+      1,
+      'block with sectioned flag - renders one layout'
+    );
+    assert.equal(
+      layouts[0].children.length,
+      1,
+      'block with sectioned flag - layout has one child'
+    );
+
+    layoutSections = findAll(layoutSectionSelector);
+    assert.equal(
+      layoutSections.length,
+      1,
+      'inline with sectioned flag - renders layout section'
+    );
+    assert
+      .dom(layoutSections[0])
+      .hasText(
+        'This is a sectioned block layout',
+        'block with sectioned flag - renders text content'
+      );
+  });
+
+  test('it renders the correct HTML when using sections', async function(assert) {
+    await render(hbs`
+      {{#polaris-layout as |layout|}}
+        {{layout.section text="This is an inline section"}}
+
+        {{#layout.section}}
+          This is a block section
+        {{/layout.section}}
+
+        {{layout.section text="This is a secondary section" secondary=true}}
+
+        {{layout.section text="This is a full-width section" fullWidth=true}}
+
+        {{layout.section text="This is a half-width section" oneHalf=true}}
+
+        {{layout.section text="This is a third-width section" oneThird=true}}
+      {{/polaris-layout}}
+    `);
+
+    const layoutSections = findAll(layoutSectionSelector);
+    assert.equal(layoutSections.length, 6, 'renders six layout sections');
+
+    // Check the first section.
+    let layoutSection = layoutSections[0];
+    assert
+      .dom(layoutSection)
+      .hasNoClass(
+        'Polaris-Layout__Section--secondary',
+        'first section - does not have secondary class'
+      );
+    assert
+      .dom(layoutSection)
+      .hasNoClass(
+        'Polaris-Layout__Section--fullWidth',
+        'first section - does not have full width class'
+      );
+    assert
+      .dom(layoutSection)
+      .hasNoClass(
+        'Polaris-Layout__Section--oneHalf',
+        'first section - does not have half width class'
+      );
+    assert
+      .dom(layoutSection)
+      .hasNoClass(
+        'Polaris-Layout__Section--oneThird',
+        'first section - does not have third width class'
+      );
+    assert
+      .dom(layoutSection)
+      .hasText(
+        'This is an inline section',
+        'first section - renders text content'
+      );
+
+    // Check the second section.
+    layoutSection = assert.dom(layoutSections[1]);
+
+    layoutSection.hasNoClass(
+      'Polaris-Layout__Section--secondary',
+      'second section - does not have secondary class'
+    );
+    layoutSection.hasNoClass(
+      'Polaris-Layout__Section--fullWidth',
+      'second section - does not have full width class'
+    );
+    layoutSection.hasNoClass(
+      'Polaris-Layout__Section--oneHalf',
+      'second section - does not have half width class'
+    );
+    layoutSection.hasNoClass(
+      'Polaris-Layout__Section--oneThird',
+      'second section - does not have third width class'
+    );
+    layoutSection.hasText(
+      'This is a block section',
+      'second section - renders text content'
+    );
+
+    // Check the third section.
+    layoutSection = assert.dom(layoutSections[2]);
+    layoutSection.hasClass(
+      'Polaris-Layout__Section--secondary',
+      'third section - has secondary class'
+    );
+    layoutSection.hasNoClass(
+      'Polaris-Layout__Section--fullWidth',
+      'third section - does not have full width class'
+    );
+    layoutSection.hasNoClass(
+      'Polaris-Layout__Section--oneHalf',
+      'third section - does not have half width class'
+    );
+    layoutSection.hasNoClass(
+      'Polaris-Layout__Section--oneThird',
+      'third section - does not have third width class'
+    );
+    layoutSection.hasText(
+      'This is a secondary section',
+      'third section - renders text content'
+    );
+
+    // Check the fourth section.
+    layoutSection = assert.dom(layoutSections[3]);
+    layoutSection.hasNoClass(
+      'Polaris-Layout__Section--secondary',
+      'fourth section - does not have secondary class'
+    );
+    layoutSection.hasClass(
+      'Polaris-Layout__Section--fullWidth',
+      'fourth section - has full width class'
+    );
+    layoutSection.hasNoClass(
+      'Polaris-Layout__Section--oneHalf',
+      'fourth section - does not have half width class'
+    );
+    layoutSection.hasNoClass(
+      'Polaris-Layout__Section--oneThird',
+      'fourth section - does not have third width class'
+    );
+    layoutSection.hasText(
+      'This is a full-width section',
+      'fourth section - renders text content'
+    );
+
+    // Check the fifth section.
+    layoutSection = assert.dom(layoutSections[4]);
+
+    layoutSection.hasNoClass(
+      'Polaris-Layout__Section--secondary',
+      'fifth section - does not have secondary class'
+    );
+    layoutSection.hasNoClass(
+      'Polaris-Layout__Section--fullWidth',
+      'fifth section - does not have full width class'
+    );
+    layoutSection.hasClass(
+      'Polaris-Layout__Section--oneHalf',
+      'fifth section - has half width class'
+    );
+    layoutSection.hasNoClass(
+      'Polaris-Layout__Section--oneThird',
+      'fifth section - does not have third width class'
+    );
+    layoutSection.hasText(
+      'This is a half-width section',
+      'fifth section - renders text content'
+    );
+
+    // Check the sixth section.
+    layoutSection = assert.dom(layoutSections[5]);
+
+    layoutSection.hasNoClass(
+      'Polaris-Layout__Section--secondary',
+      'sixth section - does not have secondary class'
+    );
+    layoutSection.hasNoClass(
+      'Polaris-Layout__Section--fullWidth',
+      'sixth section - does not have full width class'
+    );
+    layoutSection.hasNoClass(
+      'Polaris-Layout__Section--oneHalf',
+      'sixth section - does not have half width class'
+    );
+    layoutSection.hasClass(
+      'Polaris-Layout__Section--oneThird',
+      'sixth section - has third width class'
+    );
+    layoutSection.hasText(
+      'This is a third-width section',
+      'sixth section - renders text content'
+    );
+  });
+
+  test('it renders the correct HTML when no title, text or description are passed to annotated section', async function(assert) {
+    await render(hbs`
+      {{#polaris-layout as |layout|}}
+        {{layout.annotatedSection}}
+      {{/polaris-layout}}
+    `);
+
+    assert
+      .dom(layoutAnnotationWrapperSelector)
+      .exists({ count: 1 }, 'renders one annotation wrapper');
+
+    let headers = assert.dom(headerSelector);
+    headers.exists({ count: 1 }, 'renders header');
+    headers.hasText('', 'renders header correctly');
+
+    let descriptions = assert.dom(descriptionSelector);
+    descriptions.doesNotExist('renders description paragraph correctly');
+
+    let contents = assert.dom(contentSelector);
+    contents.exists({ count: 1 }, 'renders content');
+    contents.hasText('', 'renders correct content');
+  });
+
+  test('it renders the correct HTML when a title and no text or description are passed to annotated section', async function(assert) {
+    await render(hbs`
+      {{#polaris-layout as |layout|}}
+        {{layout.annotatedSection
+          text="This is an inline annotated section without title or description"
+        }}
+      {{/polaris-layout}}
+    `);
+
+    assert
+      .dom(layoutAnnotationWrapperSelector)
+      .exists({ count: 1 }, 'renders one annotation wrapper');
+
+    let headers = assert.dom(headerSelector);
+    headers.exists({ count: 1 }, 'renders header');
+    headers.hasText('', 'renders header correctly');
+
+    assert
+      .dom(descriptionSelector)
+      .doesNotExist('renders description paragraph correctly');
+
+    let contents = assert.dom(contentSelector);
+    contents.exists({ count: 1 }, 'renders content');
+    contents.hasText(
+      'This is an inline annotated section without title or description',
+      'renders correct content'
+    );
+  });
+
+  test('it renders the correct HTML when a title and text and no description are passed to annotated section', async function(assert) {
+    await render(hbs`
+      {{#polaris-layout as |layout|}}
+        {{layout.annotatedSection
+          title="Inline title"
+          text="This is an inline annotated section with a title but no description"
+        }}
+      {{/polaris-layout}}
+    `);
+
+    const annotationWrappers = assert.dom(layoutAnnotationWrapperSelector);
+
+    annotationWrappers.exists({ count: 1 }, 'renders one annotation wrapper');
+
+    let headers = assert.dom(headerSelector);
+    headers.exists({ count: 1 }, 'renders header');
+    headers.hasText('Inline title', 'renders header correctly');
+
+    assert
+      .dom(descriptionSelector)
+      .doesNotExist('renders description paragraph correctly');
+
+    let contents = assert.dom(contentSelector);
+    contents.exists({ count: 1 }, 'renders content');
+    contents.hasText(
+      'This is an inline annotated section with a title but no description',
+      'renders correct content'
+    );
+  });
+
+  test('it renders the correct HTML when text and description string and no title are passed to annotated section', async function(assert) {
+    await render(hbs`
+      {{#polaris-layout as |layout|}}
+        {{layout.annotatedSection
+          description="Inline description"
+          text="This is an inline annotated section with a description but no title"
+        }}
+      {{/polaris-layout}}
+    `);
+
+    const annotationWrappers = assert.dom(layoutAnnotationWrapperSelector);
+
+    annotationWrappers.exists({ count: 1 }, 'renders one annotation wrapper');
+
+    let headers = assert.dom(headerSelector);
+    headers.exists({ count: 1 }, 'renders header');
+    headers.hasText('', 'renders header correctly');
+
+    let descriptions = assert.dom(descriptionSelector);
+    descriptions.exists({ count: 1 }, 'renders description paragraph');
+    descriptions.hasText('Inline description', 'renders header correctly');
+
+    let contents = assert.dom(contentSelector);
+    contents.exists({ count: 1 }, 'renders content');
+    contents.hasText(
+      'This is an inline annotated section with a description but no title',
+      'renders correct content'
+    );
+  });
+
+  test('it renders the correct HTML when text and description string and title are passed to annotated section', async function(assert) {
+    await render(hbs`
+      {{#polaris-layout as |layout|}}
+        {{layout.annotatedSection
+          title="Inline title"
+          description="Inline description"
+          text="This is an inline annotated section with both a title and description"
+        }}
+      {{/polaris-layout}}
+    `);
+
+    const annotationWrappers = assert.dom(layoutAnnotationWrapperSelector);
+
+    annotationWrappers.exists({ count: 1 }, 'renders one annotation wrapper');
+
+    let headers = assert.dom(headerSelector);
+    headers.exists({ count: 1 }, 'renders header');
+    headers.hasText('Inline title', 'renders header correctly');
+
+    let descriptions = assert.dom(descriptionSelector);
+    descriptions.exists({ count: 1 }, 'renders description paragraph');
+    descriptions.hasText('Inline description', 'renders header correctly');
+
+    let contents = assert.dom(contentSelector);
+    contents.exists({ count: 1 }, 'renders content');
+    contents.hasText(
+      'This is an inline annotated section with both a title and description',
+      'renders correct content'
+    );
+  });
+
+  test('it renders the correct HTML when description component is passed to annotated section', async function(assert) {
+    await render(hbs`
+      {{#polaris-layout as |layout|}}
+        {{layout.annotatedSection
+          description=(component "wrapper-element" data-test-annotation-description-content=true)
+        }}
+      {{/polaris-layout}}
+    `);
+
+    const descriptionSelector = buildNestedSelector(
+      '[data-test-annotation-description]',
+      '[data-test-annotation-description-content]'
+    );
+    assert.dom(descriptionSelector).exists({ count: 1 });
+  });
+
+  test('it renders the correct HTML when description hash is passed to annotated section', async function(assert) {
+    await render(hbs`
+      {{#polaris-layout as |layout|}}
+        {{layout.annotatedSection
+          description=(hash
+            componentName="wrapper-element"
+            props=(hash
+              data-test-annotation-description-content=true
+            )
           )
-        )
-      }}
-    {{/polaris-layout}}
-  `);
+        }}
+      {{/polaris-layout}}
+    `);
 
-  const descriptionSelector = buildNestedSelector(
-    '[data-test-annotation-description]',
-    '[data-test-annotation-description-content]'
-  );
-  assert.dom(descriptionSelector).exists({ count: 1 });
+    const descriptionSelector = buildNestedSelector(
+      '[data-test-annotation-description]',
+      '[data-test-annotation-description-content]'
+    );
+
+    assert.dom(descriptionSelector).exists({ count: 1 });
+  });
 });

--- a/tests/integration/components/polaris-link-test.js
+++ b/tests/integration/components/polaris-link-test.js
@@ -1,267 +1,275 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { findAll, find, click } from 'ember-native-dom-helpers';
 
-moduleForComponent('polaris-link', 'Integration | Component | polaris link', {
-  integration: true,
-});
+module('Integration | Component | polaris link', function(hooks) {
+  setupRenderingTest(hooks);
 
-const linkSelector = 'a.Polaris-Link';
-const linkButtonSelector = 'button.Polaris-Link';
-
-test('it renders the correct HTML in basic inline usage with a URL', function(assert) {
-  this.render(
-    hbs`{{polaris-link url="http://www.somewhere.com/" text="This is an inline link"}}`
-  );
-
-  const links = findAll(linkSelector);
-  assert.equal(links.length, 1, 'renders one link');
-
-  const link = links[0];
-  assert.equal(
-    link.href,
-    'http://www.somewhere.com/',
-    'renders the correct href'
-  );
-  assert.equal(
-    link.textContent.trim(),
-    'This is an inline link',
-    'renders the correct link text'
-  );
-  assert.equal(
-    link.dataset.polarisUnstyled,
-    'true',
-    'applies data-polaris-unstyled to the link'
-  );
-  assert.notOk(link.target, 'does not set a target attribute on the link');
-  assert.notOk(link.rel, 'does not set a rel attribute on the link');
-});
-
-test('it renders the correct HTML in basic block usage with a URL', function(assert) {
-  this.render(hbs`
-    {{#polaris-link url="http://www.somewhere.com/"}}
-      This is a block link
-    {{/polaris-link}}
-  `);
-
-  const links = findAll(linkSelector);
-  assert.equal(links.length, 1, 'renders one link');
-
-  const link = links[0];
-  assert.equal(
-    link.href,
-    'http://www.somewhere.com/',
-    'renders the correct href'
-  );
-  assert.equal(
-    link.textContent.trim(),
-    'This is a block link',
-    'renders the correct link text'
-  );
-  assert.equal(
-    link.dataset.polarisUnstyled,
-    'true',
-    'applies data-polaris-unstyled to the link'
-  );
-  assert.notOk(link.target, 'does not set a target attribute on the link');
-  assert.notOk(link.rel, 'does not set a rel attribute on the link');
-});
-
-test('it renders the correct HTML with external attribute', function(assert) {
-  this.render(hbs`
-    {{polaris-link
-      url="http://www.somewhere.com/"
-      external=true
-      text="Testing external attribute"
-    }}
-  `);
-
-  const links = findAll(linkSelector);
-  assert.equal(links.length, 1, 'renders one link');
-
-  const link = links[0];
-  assert.equal(
-    link.target,
-    '_blank',
-    'sets the correct target attribute on the link'
-  );
-  assert.equal(
-    link.rel,
-    'noopener noreferrer',
-    'sets the correct rel attribute on the link'
-  );
-});
-
-test('it renders the correct HTML with monochrome attribute', function(assert) {
-  this.render(hbs`
-    {{polaris-link
-      url="http://www.somewhere.com/"
-      monochrome=true
-      text="Testing monochrome attribute"
-    }}
-  `);
-
-  const links = findAll(linkSelector);
-  assert.equal(links.length, 1, 'renders one link');
-
-  const link = links[0];
-  assert.ok(
-    link.classList.contains('Polaris-Link--monochrome'),
-    'sets the monochrome class on the link'
-  );
-});
-
-test('it renders the correct HTML in basic inline usage without a URL', function(assert) {
-  this.render(hbs`{{polaris-link text="This is an inline link button"}}`);
-
-  const linkButtons = findAll(linkButtonSelector);
-  assert.equal(linkButtons.length, 1, 'renders one link button');
-
-  const linkButton = linkButtons[0];
-  assert.equal(
-    linkButton.textContent.trim(),
-    'This is an inline link button',
-    'renders the correct link text'
-  );
-  assert.equal(linkButton.type, 'button', 'renders the correct button type');
-});
-
-test('it renders the correct HTML in basic block usage without a URL', function(assert) {
-  this.render(hbs`
-    {{#polaris-link}}
-      This is a block link button
-    {{/polaris-link}}
-  `);
-
-  const linkButtons = findAll(linkButtonSelector);
-  assert.equal(linkButtons.length, 1, 'renders one link button');
-
-  const linkButton = linkButtons[0];
-  assert.equal(
-    linkButton.textContent.trim(),
-    'This is a block link button',
-    'renders the correct link text'
-  );
-});
-
-test('it handles click events correctly', function(assert) {
-  let clickHandlerCalled = false;
-  this.on('click', () => {
-    clickHandlerCalled = true;
+  hooks.beforeEach(function() {
+    this.actions = {};
+    this.send = (actionName, ...args) =>
+      this.actions[actionName].apply(this, args);
   });
 
-  this.render(hbs`{{polaris-link onClick=(action "click")}}`);
+  const linkSelector = 'a.Polaris-Link';
+  const linkButtonSelector = 'button.Polaris-Link';
 
-  const linkButtons = findAll(linkButtonSelector);
-  assert.equal(linkButtons.length, 1, 'renders one link button');
+  test('it renders the correct HTML in basic inline usage with a URL', async function(assert) {
+    await render(
+      hbs`{{polaris-link url="http://www.somewhere.com/" text="This is an inline link"}}`
+    );
 
-  click(linkButtonSelector);
-  assert.ok(clickHandlerCalled, 'click handler fired');
-});
+    const links = assert.dom(linkSelector);
+    links.exists({ count: 1 }, 'renders one link');
 
-test('clicking a link navigates but does not bubble to the parent', function(assert) {
-  // Reset the hash part of the browser URL to keep this test valid on reruns.
-  window.location.hash = 'linkNotClicked';
+    links.hasAttribute(
+      'href',
+      'http://www.somewhere.com/',
+      'renders the correct href'
+    );
+    links.hasText('This is an inline link', 'renders the correct link text');
 
-  let parentHandlerCalled = false;
-  this.on('parentClicked', () => {
-    parentHandlerCalled = true;
+    links.hasAttribute(
+      'data-polaris-unstyled',
+      'true',
+      'applies data-polaris-unstyled to the link'
+    );
+    links.doesNotHaveAttribute(
+      'target',
+      'does not set a target attribute on the link'
+    );
+    links.doesNotHaveAttribute(
+      'rel',
+      'does not set a rel attribute on the link'
+    );
   });
 
-  this.render(hbs`
-    <div {{action (action "parentClicked")}}>
-      {{polaris-link url="#linkClicked"}}
-    </div>
-  `);
+  test('it renders the correct HTML in basic block usage with a URL', async function(assert) {
+    await render(hbs`
+      {{#polaris-link url="http://www.somewhere.com/"}}
+        This is a block link
+      {{/polaris-link}}
+    `);
 
-  const links = findAll(linkSelector);
-  assert.equal(links.length, 1, 'renders one link');
+    const links = assert.dom(linkSelector);
+    links.exists({ count: 1 }, 'renders one link');
 
-  click(linkSelector);
-  assert.equal(location.hash, '#linkClicked', 'app navigates to specified URL');
-  assert.notOk(parentHandlerCalled, 'parent click handler is not fired');
-});
-
-test('clicking a link fires the onClick handler if present', function(assert) {
-  // Reset the hash part of the browser URL to keep this test valid on reruns.
-  window.location.hash = 'linkNotClicked';
-
-  this.set('clickHandlerCalled', false);
-  let parentHandlerCalled = false;
-  this.on('parentClicked', () => {
-    parentHandlerCalled = true;
+    links.hasAttribute(
+      'href',
+      'http://www.somewhere.com/',
+      'renders the correct href'
+    );
+    links.hasText('This is a block link', 'renders the correct link text');
+    links.hasAttribute(
+      'data-polaris-unstyled',
+      'true',
+      'applies data-polaris-unstyled to the link'
+    );
+    links.doesNotHaveAttribute(
+      'target',
+      'does not set a target attribute on the link'
+    );
+    links.doesNotHaveAttribute(
+      'rel',
+      'does not set a rel attribute on the link'
+    );
   });
 
-  this.render(hbs`
-    <div {{action (action "parentClicked")}}>
+  test('it renders the correct HTML with external attribute', async function(assert) {
+    await render(hbs`
       {{polaris-link
-        url="#linkClicked"
-        onClick=(action (mut clickHandlerCalled) true)
+        url="http://www.somewhere.com/"
+        external=true
+        text="Testing external attribute"
       }}
-    </div>
-  `);
+    `);
 
-  const links = findAll(linkSelector);
-  assert.equal(links.length, 1, 'renders one link');
+    const links = assert.dom(linkSelector);
+    links.exists({ count: 1 }, 'renders one link');
 
-  click(linkSelector);
-  assert.equal(location.hash, '#linkClicked', 'app navigates to specified URL');
-  assert.ok(this.get('clickHandlerCalled'), 'link click handler is fired');
-  assert.notOk(parentHandlerCalled, 'parent click handler is not fired');
-});
+    links.hasAttribute(
+      'target',
+      '_blank',
+      'sets the correct target attribute on the link'
+    );
 
-test('clicking a link button performs the button action but does not bubble to the parent', function(assert) {
-  let parentHandlerCalled = false;
-  this.on('parentClicked', () => {
-    parentHandlerCalled = true;
-  });
-  let buttonHandlerCalled = false;
-  this.on('buttonClicked', () => {
-    buttonHandlerCalled = true;
+    links.hasAttribute(
+      'rel',
+      'noopener noreferrer',
+      'sets the correct rel attribute on the link'
+    );
   });
 
-  this.render(hbs`
-    <div {{action (action "parentClicked")}}>
-      {{polaris-link onClick=(action "buttonClicked")}}
-    </div>
-  `);
+  test('it renders the correct HTML with monochrome attribute', async function(assert) {
+    await render(hbs`
+      {{polaris-link
+        url="http://www.somewhere.com/"
+        monochrome=true
+        text="Testing monochrome attribute"
+      }}
+    `);
 
-  const linkButtons = findAll(linkButtonSelector);
-  assert.equal(linkButtons.length, 1, 'renders one link button');
+    const links = assert.dom(linkSelector);
+    links.exists({ count: 1 }, 'renders one link');
 
-  click(linkButtonSelector);
-  assert.ok(buttonHandlerCalled, 'button click handler is fired');
-  assert.notOk(parentHandlerCalled, 'parent click handler is not fired');
-});
+    links.hasClass(
+      'Polaris-Link--monochrome',
+      'sets the monochrome class on the link'
+    );
+  });
 
-test('it applies passed-in classes to the rendered element when rendering a link', function(assert) {
-  this.set('class', 'my-link click-me');
-  this.render(
-    hbs`{{polaris-link class=class url="http://www.somewhere.com/"}}`
-  );
+  test('it renders the correct HTML in basic inline usage without a URL', async function(assert) {
+    await render(hbs`{{polaris-link text="This is an inline link button"}}`);
 
-  let link = find(`${linkSelector}.my-link.click-me`);
-  assert.ok(link, 'renders link with input classes');
+    const linkButtons = assert.dom(linkButtonSelector);
+    linkButtons.exists({ count: 1 }, 'renders one link button');
 
-  // Try updating the classes.
-  this.set('class', 'click-me-to-go-somewhere');
+    linkButtons.hasText(
+      'This is an inline link button',
+      'renders the correct link text'
+    );
+  });
 
-  link = find(`${linkSelector}.click-me-to-go-somewhere`);
-  assert.ok(link, 'renders link with updated classes');
-  assert.notOk(link.classList.contains('my-link'));
-});
+  test('it renders the correct HTML in basic block usage without a URL', async function(assert) {
+    await render(hbs`
+      {{#polaris-link}}
+        This is a block link button
+      {{/polaris-link}}
+    `);
 
-test('it applies passed-in classes to the rendered element when rendering a button', function(assert) {
-  this.set('class', 'my-button press-me');
-  this.render(hbs`{{polaris-link class=class}}`);
+    const linkButton = assert.dom(linkButtonSelector);
 
-  let linkButton = find(`${linkButtonSelector}.my-button.press-me`);
-  assert.ok(linkButton, 'renders button with input classes');
+    linkButton.exists({ count: 1 }, 'renders one link button');
 
-  // Try updating the classes.
-  this.set('class', 'press-me-to-make-something-happen');
+    linkButton.hasText(
+      'This is a block link button',
+      'renders the correct link text'
+    );
+  });
 
-  linkButton = find(`${linkButtonSelector}.press-me-to-make-something-happen`);
-  assert.ok(linkButton, 'renders button with updated classes');
-  assert.notOk(linkButton.classList.contains('my-button'));
+  test('it handles click events correctly', async function(assert) {
+    let clickHandlerCalled = false;
+    this.actions.click = () => (clickHandlerCalled = true);
+
+    await render(hbs`{{polaris-link onClick=(action "click")}}`);
+
+    assert
+      .dom(linkButtonSelector)
+      .exists({ count: 1 }, 'renders one link button');
+
+    await click(linkButtonSelector);
+    assert.ok(clickHandlerCalled, 'click handler fired');
+  });
+
+  test('clicking a link navigates but does not bubble to the parent', async function(assert) {
+    // Reset the hash part of the browser URL to keep this test valid on reruns.
+    window.location.hash = 'linkNotClicked';
+
+    let parentHandlerCalled = false;
+    this.actions.parentClicked = () => (parentHandlerCalled = true);
+
+    await render(hbs`
+      <div {{action (action "parentClicked")}}>
+        {{polaris-link url="#linkClicked"}}
+      </div>
+    `);
+
+    assert.dom(linkSelector).exists({ count: 1 }, 'renders one link');
+
+    await click(linkSelector);
+    assert.equal(
+      location.hash,
+      '#linkClicked',
+      'app navigates to specified URL'
+    );
+    assert.notOk(parentHandlerCalled, 'parent click handler is not fired');
+  });
+
+  test('clicking a link fires the onClick handler if present', async function(assert) {
+    // Reset the hash part of the browser URL to keep this test valid on reruns.
+    window.location.hash = 'linkNotClicked';
+
+    this.set('clickHandlerCalled', false);
+    let parentHandlerCalled = false;
+    this.actions.parentClicked = () => (parentHandlerCalled = true);
+
+    await render(hbs`
+      <div {{action (action "parentClicked")}}>
+        {{polaris-link
+          url="#linkClicked"
+          onClick=(action (mut clickHandlerCalled) true)
+        }}
+      </div>
+    `);
+
+    assert.dom(linkSelector).exists({ count: 1 }, 'renders one link');
+
+    await click(linkSelector);
+    assert.equal(
+      location.hash,
+      '#linkClicked',
+      'app navigates to specified URL'
+    );
+    assert.ok(this.get('clickHandlerCalled'), 'link click handler is fired');
+    assert.notOk(parentHandlerCalled, 'parent click handler is not fired');
+  });
+
+  test('clicking a link button performs the button action but does not bubble to the parent', async function(assert) {
+    let parentHandlerCalled = false;
+    let buttonHandlerCalled = false;
+
+    this.actions.parentClicked = () => (parentHandlerCalled = true);
+    this.actions.buttonClicked = () => (buttonHandlerCalled = true);
+
+    await render(hbs`
+      <div {{action (action "parentClicked")}}>
+        {{polaris-link onClick=(action "buttonClicked")}}
+      </div>
+    `);
+
+    assert
+      .dom(linkButtonSelector)
+      .exists({ count: 1 }, 'renders one link button');
+
+    await click(linkButtonSelector);
+    assert.ok(buttonHandlerCalled, 'button click handler is fired');
+    assert.notOk(parentHandlerCalled, 'parent click handler is not fired');
+  });
+
+  test('it applies passed-in classes to the rendered element when rendering a link', async function(assert) {
+    this.set('class', 'my-link click-me');
+    await render(
+      hbs`{{polaris-link class=class url="http://www.somewhere.com/"}}`
+    );
+
+    assert
+      .dom(`${linkSelector}.my-link.click-me`)
+      .exists('renders link with input classes');
+
+    // Try updating the classes.
+    this.set('class', 'click-me-to-go-somewhere');
+
+    let link = assert.dom(`${linkSelector}.click-me-to-go-somewhere`);
+    link.exists('renders link with updated classes');
+    link.hasNoClass('my-link');
+  });
+
+  test('it applies passed-in classes to the rendered element when rendering a button', async function(assert) {
+    this.set('class', 'my-button press-me');
+    await render(hbs`{{polaris-link class=class}}`);
+
+    assert
+      .dom(`${linkButtonSelector}.my-button.press-me`)
+      .exists('renders button with input classes');
+
+    // Try updating the classes.
+    this.set('class', 'press-me-to-make-something-happen');
+
+    let linkButton = assert.dom(
+      `${linkButtonSelector}.press-me-to-make-something-happen`
+    );
+    linkButton.exists('renders button with updated classes');
+    linkButton.hasNoClass('my-button');
+  });
 });

--- a/tests/integration/components/polaris-list-test.js
+++ b/tests/integration/components/polaris-list-test.js
@@ -1,120 +1,133 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { findAll, find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { findAll, find } from 'ember-native-dom-helpers';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
-moduleForComponent('polaris-list', 'Integration | Component | polaris list', {
-  integration: true,
-});
+module('Integration | Component | polaris list', function(hooks) {
+  setupRenderingTest(hooks);
 
-const listSelector = '.Polaris-List';
-const listItemSelector = buildNestedSelector(
-  listSelector,
-  'li.Polaris-List__Item'
-);
-
-test('it renders the correct HTML', function(assert) {
-  this.render(hbs`
-    {{#polaris-list type=type as |list|}}
-      {{#each items as |item|}}
-        {{#if item.inline}}
-          {{list.item text=item.text}}
-        {{else}}
-          {{#list.item}}
-            {{item.text}}
-          {{/list.item}}
-        {{/if}}
-      {{/each}}
-    {{/polaris-list}}
-  `);
-
-  let lists = findAll(listSelector);
-  assert.equal(lists.length, 1, 'renders one bulleted list');
-
-  let listItems = findAll(listItemSelector);
-  assert.equal(
-    listItems.length,
-    0,
-    'no items - does not render any list items'
+  const listSelector = '.Polaris-List';
+  const listItemSelector = buildNestedSelector(
+    listSelector,
+    'li.Polaris-List__Item'
   );
 
-  this.set('items', [
-    {
-      text: 'Item one (block)',
-      inline: false,
-    },
-    {
-      text: 'Second one (inline)',
-      inline: true,
-    },
-  ]);
+  test('it renders the correct HTML', async function(assert) {
+    await render(hbs`
+      {{#polaris-list type=type as |list|}}
+        {{#each items as |item|}}
+          {{#if item.inline}}
+            {{list.item text=item.text}}
+          {{else}}
+            {{#list.item}}
+              {{item.text}}
+            {{/list.item}}
+          {{/if}}
+        {{/each}}
+      {{/polaris-list}}
+    `);
 
-  listItems = findAll(listItemSelector);
-  assert.equal(listItems.length, 2, 'with items - renders two list items');
+    let lists = findAll(listSelector);
+    assert.equal(lists.length, 1, 'renders one bulleted list');
 
-  assert.equal(
-    listItems[0].textContent.trim(),
-    'Item one (block)',
-    'first item has correct text'
-  );
-  assert.equal(
-    listItems[1].textContent.trim(),
-    'Second one (inline)',
-    'second item has correct text'
-  );
+    let listItems = findAll(listItemSelector);
+    assert.equal(
+      listItems.length,
+      0,
+      'no items - does not render any list items'
+    );
 
-  let list = lists[0];
-  assert.equal(
-    list.nodeName,
-    'UL',
-    'unspecified type - renders unordered list'
-  );
-  assert.ok(
-    list.classList.contains('Polaris-List--typeBullet'),
-    'unspecified type - applies bullet class'
-  );
-  assert.notOk(
-    list.classList.contains('Polaris-List--typeNumber'),
-    'unspecified type - does not apply number class'
-  );
+    this.set('items', [
+      {
+        text: 'Item one (block)',
+        inline: false,
+      },
+      {
+        text: 'Second one (inline)',
+        inline: true,
+      },
+    ]);
 
-  this.set('type', 'number');
-  list = find(listSelector);
-  assert.equal(list.nodeName, 'OL', 'number type - renders ordered list');
-  assert.notOk(
-    list.classList.contains('Polaris-List--typeBullet'),
-    'number type - does not apply bullet class'
-  );
-  assert.ok(
-    list.classList.contains('Polaris-List--typeNumber'),
-    'number type - applies number class'
-  );
+    listItems = findAll(listItemSelector);
+    assert.equal(listItems.length, 2, 'with items - renders two list items');
 
-  this.set('type', 'bullet');
-  list = find(listSelector);
-  assert.equal(list.nodeName, 'UL', 'bullet type - renders unordered list');
-  assert.ok(
-    list.classList.contains('Polaris-List--typeBullet'),
-    'bullet type - applies bullet class'
-  );
-  assert.notOk(
-    list.classList.contains('Polaris-List--typeNumber'),
-    'bullet type - does not apply number class'
-  );
+    assert
+      .dom(listItems[0])
+      .hasText('Item one (block)', 'first item has correct text');
+    assert
+      .dom(listItems[1])
+      .hasText('Second one (inline)', 'second item has correct text');
 
-  this.set('type', 'unsupported');
-  list = find(listSelector);
-  assert.equal(
-    list.nodeName,
-    'UL',
-    'unsupported type - renders unordered list'
-  );
-  assert.ok(
-    list.classList.contains('Polaris-List--typeBullet'),
-    'unsupported type - applies bullet class'
-  );
-  assert.notOk(
-    list.classList.contains('Polaris-List--typeNumber'),
-    'unsupported type - does not apply number class'
-  );
+    let list = lists[0];
+    assert.equal(
+      list.nodeName,
+      'UL',
+      'unspecified type - renders unordered list'
+    );
+    assert
+      .dom(list)
+      .hasClass(
+        'Polaris-List--typeBullet',
+        'unspecified type - applies bullet class'
+      );
+    assert
+      .dom(list)
+      .hasNoClass(
+        'Polaris-List--typeNumber',
+        'unspecified type - does not apply number class'
+      );
+
+    this.set('type', 'number');
+    list = find(listSelector);
+    assert.equal(list.nodeName, 'OL', 'number type - renders ordered list');
+    assert
+      .dom(list)
+      .hasNoClass(
+        'Polaris-List--typeBullet',
+        'number type - does not apply bullet class'
+      );
+    assert
+      .dom(list)
+      .hasClass(
+        'Polaris-List--typeNumber',
+        'number type - applies number class'
+      );
+
+    this.set('type', 'bullet');
+    list = find(listSelector);
+    assert.equal(list.nodeName, 'UL', 'bullet type - renders unordered list');
+    assert
+      .dom(list)
+      .hasClass(
+        'Polaris-List--typeBullet',
+        'bullet type - applies bullet class'
+      );
+    assert
+      .dom(list)
+      .hasNoClass(
+        'Polaris-List--typeNumber',
+        'bullet type - does not apply number class'
+      );
+
+    this.set('type', 'unsupported');
+    list = find(listSelector);
+    assert.equal(
+      list.nodeName,
+      'UL',
+      'unsupported type - renders unordered list'
+    );
+    assert
+      .dom(list)
+      .hasClass(
+        'Polaris-List--typeBullet',
+        'unsupported type - applies bullet class'
+      );
+    assert
+      .dom(list)
+      .hasNoClass(
+        'Polaris-List--typeNumber',
+        'unsupported type - does not apply number class'
+      );
+  });
 });

--- a/tests/integration/components/polaris-page-actions-test.js
+++ b/tests/integration/components/polaris-page-actions-test.js
@@ -1,487 +1,510 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { click, find, findAll, render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { findAll, find, click } from 'ember-native-dom-helpers';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 import MockSvgJarComponent from '../../mocks/components/svg-jar';
 
-moduleForComponent(
-  'polaris-page-actions',
-  'Integration | Component | polaris page actions',
-  {
-    integration: true,
+module('Integration | Component | polaris page actions', function(hooks) {
+  setupRenderingTest(hooks);
 
-    beforeEach() {
-      this.register('component:svg-jar', MockSvgJarComponent);
-    },
-  }
-);
+  hooks.beforeEach(function() {
+    this.actions = {};
+    this.send = (actionName, ...args) =>
+      this.actions[actionName].apply(this, args);
+  });
 
-const pageActionsSelector = 'div.Polaris-PageActions';
-const pageActionsStackSelector = buildNestedSelector(
-  pageActionsSelector,
-  'div.Polaris-Stack'
-);
-const pageActionsStackItemSelector = buildNestedSelector(
-  pageActionsStackSelector,
-  'div.Polaris-Stack__Item'
-);
-const secondaryButtonSelector = buildNestedSelector(
-  pageActionsStackItemSelector,
-  'div.Polaris-ButtonGroup',
-  'div.Polaris-ButtonGroup__Item',
-  'button.Polaris-Button'
-);
-const iconSelector = buildNestedSelector('span.Polaris-Icon', 'svg');
+  hooks.beforeEach(function() {
+    this.owner.register('component:svg-jar', MockSvgJarComponent);
+  });
 
-test('it renders the correct HTML when primary and secondary actions are supplied', function(assert) {
-  this.render(hbs`
-    {{polaris-page-actions
-      primaryAction=(hash
-        text="Primary button here"
-      )
-      secondaryActions=(array
-        (hash
-          text="This is a secondary button"
-        )
-        (hash
-          text="This is another secondary button"
-        )
-      )
-    }}
-  `);
-
-  const pageActions = findAll(pageActionsSelector);
-  assert.equal(pageActions.length, 1, 'renders one page actions component');
-
-  const pageActionsStacks = findAll(pageActionsStackSelector);
-  assert.equal(pageActionsStacks.length, 1, 'renders one stack component');
-  const pageActionsStack = pageActionsStacks[0];
-  assert.ok(
-    pageActionsStack.classList.contains('Polaris-Stack--spacingTight'),
-    'stack has tight spacing'
+  const pageActionsSelector = 'div.Polaris-PageActions';
+  const pageActionsStackSelector = buildNestedSelector(
+    pageActionsSelector,
+    'div.Polaris-Stack'
   );
-  assert.ok(
-    pageActionsStack.classList.contains(
-      'Polaris-Stack--distributionEqualSpacing'
-    ),
-    'stack has equal distribution'
+  const pageActionsStackItemSelector = buildNestedSelector(
+    pageActionsStackSelector,
+    'div.Polaris-Stack__Item'
   );
-
-  const pageActionsStackItems = findAll(pageActionsStackItemSelector);
-  assert.equal(pageActionsStackItems.length, 2, 'renders two stack items');
-
-  const primaryButtonSelector = buildNestedSelector(
-    pageActionsStackItemSelector,
-    'button.Polaris-Button.Polaris-Button--primary'
-  );
-  const primaryButtons = findAll(primaryButtonSelector);
-  assert.equal(primaryButtons.length, 1, 'renders one primary button');
-  assert.equal(
-    primaryButtons[0].textContent.trim(),
-    'Primary button here',
-    'primary button - renders the correct content'
-  );
-
-  const secondaryButtons = findAll(secondaryButtonSelector);
-  assert.equal(secondaryButtons.length, 2, 'renders two secondary button');
-  assert.equal(
-    secondaryButtons[0].textContent.trim(),
-    'This is a secondary button',
-    'first secondary button - renders the correct content'
-  );
-  assert.equal(
-    secondaryButtons[1].textContent.trim(),
-    'This is another secondary button',
-    'second secondary button - renders the correct content'
-  );
-});
-
-test('it renders the correct HTML when primary action is supplied with empty secondary actions list', function(assert) {
-  this.render(hbs`
-    {{polaris-page-actions
-      primaryAction=(hash
-        text="Primary button here"
-      )
-      secondaryActions=(array)
-    }}
-  `);
-
-  const pageActions = findAll(pageActionsSelector);
-  assert.equal(pageActions.length, 1, 'renders one page actions component');
-
-  const pageActionsStacks = findAll(pageActionsStackSelector);
-  assert.equal(pageActionsStacks.length, 1, 'renders one stack component');
-  const pageActionsStack = pageActionsStacks[0];
-  assert.ok(
-    pageActionsStack.classList.contains('Polaris-Stack--spacingTight'),
-    'stack has tight spacing'
-  );
-  assert.ok(
-    pageActionsStack.classList.contains(
-      'Polaris-Stack--distributionEqualSpacing'
-    ),
-    'stack has equal distribution'
-  );
-
-  const pageActionsStackItems = findAll(pageActionsStackItemSelector);
-  assert.equal(pageActionsStackItems.length, 2, 'renders two stack items');
-
-  const primaryButtonSelector = buildNestedSelector(
-    pageActionsStackItemSelector,
-    'button.Polaris-Button.Polaris-Button--primary'
-  );
-  const primaryButtons = findAll(primaryButtonSelector);
-  assert.equal(primaryButtons.length, 1, 'renders one primary button');
-  assert.equal(
-    primaryButtons[0].textContent.trim(),
-    'Primary button here',
-    'primary button - renders the correct content'
-  );
-
   const secondaryButtonSelector = buildNestedSelector(
     pageActionsStackItemSelector,
     'div.Polaris-ButtonGroup',
     'div.Polaris-ButtonGroup__Item',
     'button.Polaris-Button'
   );
-  const secondaryButtons = findAll(secondaryButtonSelector);
-  assert.equal(
-    secondaryButtons.length,
-    0,
-    'does not render any secondary buttons'
-  );
-});
+  const iconSelector = buildNestedSelector('span.Polaris-Icon', 'svg');
 
-test('it renders the correct HTML when only a primary action is supplied', function(assert) {
-  this.render(hbs`
-    {{polaris-page-actions
-      primaryAction=(hash
-        text="I'm the only button here"
-      )
-    }}
-  `);
+  test('it renders the correct HTML when primary and secondary actions are supplied', async function(assert) {
+    await render(hbs`
+      {{polaris-page-actions
+        primaryAction=(hash
+          text="Primary button here"
+        )
+        secondaryActions=(array
+          (hash
+            text="This is a secondary button"
+          )
+          (hash
+            text="This is another secondary button"
+          )
+        )
+      }}
+    `);
 
-  const pageActions = findAll(pageActionsSelector);
-  assert.equal(pageActions.length, 1, 'renders one page actions component');
+    const pageActions = findAll(pageActionsSelector);
+    assert.equal(pageActions.length, 1, 'renders one page actions component');
 
-  const pageActionsStacks = findAll(pageActionsStackSelector);
-  assert.equal(pageActionsStacks.length, 1, 'renders one stack component');
-  const pageActionsStack = pageActionsStacks[0];
-  assert.ok(
-    pageActionsStack.classList.contains('Polaris-Stack--spacingTight'),
-    'stack has tight spacing'
-  );
-  assert.ok(
-    pageActionsStack.classList.contains('Polaris-Stack--distributionTrailing'),
-    'stack has trailing distribution'
-  );
+    const pageActionsStacks = findAll(pageActionsStackSelector);
+    assert.equal(pageActionsStacks.length, 1, 'renders one stack component');
+    const pageActionsStack = pageActionsStacks[0];
+    assert
+      .dom(pageActionsStack)
+      .hasClass('Polaris-Stack--spacingTight', 'stack has tight spacing');
+    assert
+      .dom(pageActionsStack)
+      .hasClass(
+        'Polaris-Stack--distributionEqualSpacing',
+        'stack has equal distribution'
+      );
 
-  const pageActionsStackItems = findAll(pageActionsStackItemSelector);
-  assert.equal(pageActionsStackItems.length, 1, 'renders one stack item');
+    const pageActionsStackItems = findAll(pageActionsStackItemSelector);
+    assert.equal(pageActionsStackItems.length, 2, 'renders two stack items');
 
-  const primaryButtonSelector = buildNestedSelector(
-    pageActionsStackItemSelector,
-    'button.Polaris-Button.Polaris-Button--primary'
-  );
-  const primaryButtons = findAll(primaryButtonSelector);
-  assert.equal(primaryButtons.length, 1, 'renders one primary button');
-  assert.equal(
-    primaryButtons[0].textContent.trim(),
-    "I'm the only button here",
-    'primary button - renders the correct content'
-  );
+    const primaryButtonSelector = buildNestedSelector(
+      pageActionsStackItemSelector,
+      'button.Polaris-Button.Polaris-Button--primary'
+    );
+    const primaryButtons = findAll(primaryButtonSelector);
+    assert.equal(primaryButtons.length, 1, 'renders one primary button');
+    assert
+      .dom(primaryButtons[0])
+      .hasText(
+        'Primary button here',
+        'primary button - renders the correct content'
+      );
 
-  const secondaryButtonGroupSelector = buildNestedSelector(
-    pageActionsStackItemSelector,
-    'div.Polaris-ButtonGroup'
-  );
-  const secondaryButtons = findAll(secondaryButtonGroupSelector);
-  assert.equal(
-    secondaryButtons.length,
-    0,
-    'does not render a secondary button group'
-  );
-});
+    const secondaryButtons = findAll(secondaryButtonSelector);
+    assert.equal(secondaryButtons.length, 2, 'renders two secondary button');
+    assert
+      .dom(secondaryButtons[0])
+      .hasText(
+        'This is a secondary button',
+        'first secondary button - renders the correct content'
+      );
+    assert
+      .dom(secondaryButtons[1])
+      .hasText(
+        'This is another secondary button',
+        'second secondary button - renders the correct content'
+      );
+  });
 
-test('it renders the correct HTML when only a secondary action is supplied', function(assert) {
-  this.render(hbs`
-    {{polaris-page-actions
-      secondaryActions=(array (hash
-        text="I'm the only button here"
-      ))
-    }}
-  `);
+  test('it renders the correct HTML when primary action is supplied with empty secondary actions list', async function(assert) {
+    await render(hbs`
+      {{polaris-page-actions
+        primaryAction=(hash
+          text="Primary button here"
+        )
+        secondaryActions=(array)
+      }}
+    `);
 
-  const pageActions = findAll(pageActionsSelector);
-  assert.equal(pageActions.length, 1, 'renders one page actions component');
+    const pageActions = findAll(pageActionsSelector);
+    assert.equal(pageActions.length, 1, 'renders one page actions component');
 
-  const pageActionsStacks = findAll(pageActionsStackSelector);
-  assert.equal(pageActionsStacks.length, 1, 'renders one stack component');
-  const pageActionsStack = pageActionsStacks[0];
-  assert.ok(
-    pageActionsStack.classList.contains('Polaris-Stack--spacingTight'),
-    'stack has tight spacing'
-  );
-  assert.ok(
-    pageActionsStack.classList.contains(
-      'Polaris-Stack--distributionEqualSpacing'
-    ),
-    'stack has equal spacing distribution'
-  );
+    const pageActionsStacks = findAll(pageActionsStackSelector);
+    assert.equal(pageActionsStacks.length, 1, 'renders one stack component');
+    const pageActionsStack = pageActionsStacks[0];
+    assert
+      .dom(pageActionsStack)
+      .hasClass('Polaris-Stack--spacingTight', 'stack has tight spacing');
+    assert
+      .dom(pageActionsStack)
+      .hasClass(
+        'Polaris-Stack--distributionEqualSpacing',
+        'stack has equal distribution'
+      );
 
-  const pageActionsStackItems = findAll(pageActionsStackItemSelector);
-  assert.equal(pageActionsStackItems.length, 1, 'renders one stack item');
+    const pageActionsStackItems = findAll(pageActionsStackItemSelector);
+    assert.equal(pageActionsStackItems.length, 2, 'renders two stack items');
 
-  const primaryButtonSelector = buildNestedSelector(
-    pageActionsStackItemSelector,
-    'button.Polaris-Button.Polaris-Button--primary'
-  );
-  const primaryButtons = findAll(primaryButtonSelector);
-  assert.equal(primaryButtons.length, 0, 'does not render a primary button');
+    const primaryButtonSelector = buildNestedSelector(
+      pageActionsStackItemSelector,
+      'button.Polaris-Button.Polaris-Button--primary'
+    );
+    const primaryButtons = findAll(primaryButtonSelector);
+    assert.equal(primaryButtons.length, 1, 'renders one primary button');
+    assert
+      .dom(primaryButtons[0])
+      .hasText(
+        'Primary button here',
+        'primary button - renders the correct content'
+      );
 
-  const secondaryButtonGroupSelector = buildNestedSelector(
-    pageActionsStackItemSelector,
-    'div.Polaris-ButtonGroup',
-    'div.Polaris-ButtonGroup__Item',
-    'button.Polaris-Button'
-  );
-  const secondaryButtons = findAll(secondaryButtonGroupSelector);
-  assert.equal(
-    secondaryButtons.length,
-    1,
-    'renders one secondary button group'
-  );
-  assert.equal(
-    secondaryButtons[0].textContent.trim(),
-    "I'm the only button here",
-    'primary button - renders the correct content'
-  );
-});
+    const secondaryButtonSelector = buildNestedSelector(
+      pageActionsStackItemSelector,
+      'div.Polaris-ButtonGroup',
+      'div.Polaris-ButtonGroup__Item',
+      'button.Polaris-Button'
+    );
+    const secondaryButtons = findAll(secondaryButtonSelector);
+    assert.equal(
+      secondaryButtons.length,
+      0,
+      'does not render any secondary buttons'
+    );
+  });
 
-test('it renders the correct HTML when the primary action is disabled', function(assert) {
-  this.render(hbs`
-    {{polaris-page-actions
-      primaryAction=(hash
-        text="I'm the only button here"
-        disabled=true
-      )
-    }}
-  `);
+  test('it renders the correct HTML when only a primary action is supplied', async function(assert) {
+    await render(hbs`
+      {{polaris-page-actions
+        primaryAction=(hash
+          text="I'm the only button here"
+        )
+      }}
+    `);
 
-  const primaryButtonSelector = buildNestedSelector(
-    pageActionsStackItemSelector,
-    'button.Polaris-Button.Polaris-Button--primary'
-  );
-  const primaryButton = find(primaryButtonSelector);
-  assert.ok(primaryButton, 'renders primary button');
-  assert.ok(primaryButton.disabled, 'primary button is disabled');
-});
+    const pageActions = findAll(pageActionsSelector);
+    assert.equal(pageActions.length, 1, 'renders one page actions component');
 
-test('it renders the correct HTML when the primary action is loading', function(assert) {
-  this.render(hbs`
-    {{polaris-page-actions
-      primaryAction=(hash
-        text="I'm the only button here"
-        loading=true
-      )
-    }}
-  `);
+    const pageActionsStacks = findAll(pageActionsStackSelector);
+    assert.equal(pageActionsStacks.length, 1, 'renders one stack component');
+    const pageActionsStack = pageActionsStacks[0];
+    assert
+      .dom(pageActionsStack)
+      .hasClass('Polaris-Stack--spacingTight', 'stack has tight spacing');
+    assert
+      .dom(pageActionsStack)
+      .hasClass(
+        'Polaris-Stack--distributionTrailing',
+        'stack has trailing distribution'
+      );
 
-  const primaryButtonSelector = buildNestedSelector(
-    pageActionsStackItemSelector,
-    'button.Polaris-Button.Polaris-Button--primary'
-  );
-  const primaryButton = find(primaryButtonSelector);
-  assert.ok(primaryButton, 'renders primary button');
-  assert.ok(primaryButton.disabled, 'primary button is disabled');
-  assert.ok(
-    primaryButton.classList.contains('Polaris-Button--loading'),
-    'primary button is in loading state'
-  );
-});
+    const pageActionsStackItems = findAll(pageActionsStackItemSelector);
+    assert.equal(pageActionsStackItems.length, 1, 'renders one stack item');
 
-test('it renders the correct HTML when secondary actions have complex properties', function(assert) {
-  this.render(hbs`
-    {{polaris-page-actions
-      secondaryActions=(array
-        (hash
-          text="Disabled secondary action"
+    const primaryButtonSelector = buildNestedSelector(
+      pageActionsStackItemSelector,
+      'button.Polaris-Button.Polaris-Button--primary'
+    );
+    const primaryButtons = findAll(primaryButtonSelector);
+    assert.equal(primaryButtons.length, 1, 'renders one primary button');
+    assert
+      .dom(primaryButtons[0])
+      .hasText(
+        "I'm the only button here",
+        'primary button - renders the correct content'
+      );
+
+    const secondaryButtonGroupSelector = buildNestedSelector(
+      pageActionsStackItemSelector,
+      'div.Polaris-ButtonGroup'
+    );
+    const secondaryButtons = findAll(secondaryButtonGroupSelector);
+    assert.equal(
+      secondaryButtons.length,
+      0,
+      'does not render a secondary button group'
+    );
+  });
+
+  test('it renders the correct HTML when only a secondary action is supplied', async function(assert) {
+    await render(hbs`
+      {{polaris-page-actions
+        secondaryActions=(array (hash
+          text="I'm the only button here"
+        ))
+      }}
+    `);
+
+    const pageActions = findAll(pageActionsSelector);
+    assert.equal(pageActions.length, 1, 'renders one page actions component');
+
+    const pageActionsStacks = findAll(pageActionsStackSelector);
+    assert.equal(pageActionsStacks.length, 1, 'renders one stack component');
+    const pageActionsStack = pageActionsStacks[0];
+    assert
+      .dom(pageActionsStack)
+      .hasClass('Polaris-Stack--spacingTight', 'stack has tight spacing');
+    assert
+      .dom(pageActionsStack)
+      .hasClass(
+        'Polaris-Stack--distributionEqualSpacing',
+        'stack has equal spacing distribution'
+      );
+
+    const pageActionsStackItems = findAll(pageActionsStackItemSelector);
+    assert.equal(pageActionsStackItems.length, 1, 'renders one stack item');
+
+    const primaryButtonSelector = buildNestedSelector(
+      pageActionsStackItemSelector,
+      'button.Polaris-Button.Polaris-Button--primary'
+    );
+    const primaryButtons = findAll(primaryButtonSelector);
+    assert.equal(primaryButtons.length, 0, 'does not render a primary button');
+
+    const secondaryButtonGroupSelector = buildNestedSelector(
+      pageActionsStackItemSelector,
+      'div.Polaris-ButtonGroup',
+      'div.Polaris-ButtonGroup__Item',
+      'button.Polaris-Button'
+    );
+    const secondaryButtons = findAll(secondaryButtonGroupSelector);
+    assert.equal(
+      secondaryButtons.length,
+      1,
+      'renders one secondary button group'
+    );
+    assert
+      .dom(secondaryButtons[0])
+      .hasText(
+        "I'm the only button here",
+        'primary button - renders the correct content'
+      );
+  });
+
+  test('it renders the correct HTML when the primary action is disabled', async function(assert) {
+    await render(hbs`
+      {{polaris-page-actions
+        primaryAction=(hash
+          text="I'm the only button here"
           disabled=true
         )
-        (hash
-          text="Loading secondary action"
+      }}
+    `);
+
+    const primaryButtonSelector = buildNestedSelector(
+      pageActionsStackItemSelector,
+      'button.Polaris-Button.Polaris-Button--primary'
+    );
+    const primaryButton = find(primaryButtonSelector);
+    assert.ok(primaryButton, 'renders primary button');
+    assert.ok(primaryButton.disabled, 'primary button is disabled');
+  });
+
+  test('it renders the correct HTML when the primary action is loading', async function(assert) {
+    await render(hbs`
+      {{polaris-page-actions
+        primaryAction=(hash
+          text="I'm the only button here"
           loading=true
         )
-        (hash
-          text="Destructive secondary action"
-          destructive=true
-        )
-        (hash
-          text="Secondary action with icon"
-          icon="notes"
-        )
-      )
-    }}
-  `);
+      }}
+    `);
 
-  const secondaryButtons = findAll(secondaryButtonSelector);
-  assert.equal(secondaryButtons.length, 4, 'renders four secondary buttons');
-
-  // Check the first (disabled) button.
-  let secondaryButton = secondaryButtons[0];
-  assert.ok(secondaryButton.disabled, 'disabled secondary button is disabled');
-  assert.ok(
-    secondaryButton.classList.contains('Polaris-Button--disabled'),
-    'disabled secondary button has disabled class'
-  );
-  assert.notOk(
-    secondaryButton.classList.contains('Polaris-Button--loading'),
-    'disabled secondary button does not have loading class'
-  );
-  assert.notOk(
-    secondaryButton.classList.contains('Polaris-Button--destructive'),
-    'disabled secondary button does not have destructive class'
-  );
-  assert.notOk(
-    find(iconSelector, secondaryButton),
-    'disabled secondary button does not have an icon'
-  );
-
-  // Check the second (loading) button.
-  secondaryButton = secondaryButtons[1];
-  assert.ok(secondaryButton.disabled, 'loading secondary button is disabled');
-  assert.ok(
-    secondaryButton.classList.contains('Polaris-Button--disabled'),
-    'loading secondary button has disabled class'
-  );
-  assert.ok(
-    secondaryButton.classList.contains('Polaris-Button--loading'),
-    'loading secondary button has loading class'
-  );
-  assert.notOk(
-    secondaryButton.classList.contains('Polaris-Button--destructive'),
-    'disabled secondary button does not have destructive class'
-  );
-  assert.notOk(
-    find(iconSelector, secondaryButton),
-    'disabled secondary button does not have an icon'
-  );
-
-  // Check the third (destructive) button.
-  secondaryButton = secondaryButtons[2];
-  assert.notOk(
-    secondaryButton.disabled,
-    'destructive secondary button is not disabled'
-  );
-  assert.notOk(
-    secondaryButton.classList.contains('Polaris-Button--disabled'),
-    'destructive secondary button does not have disabled class'
-  );
-  assert.notOk(
-    secondaryButton.classList.contains('Polaris-Button--loading'),
-    'destructive secondary button does not have loading class'
-  );
-  assert.ok(
-    secondaryButton.classList.contains('Polaris-Button--destructive'),
-    'destructive secondary button has destructive class'
-  );
-  assert.notOk(
-    find(iconSelector, secondaryButton),
-    'destructive secondary button does not have an icon'
-  );
-
-  // Check the fourth (iconed) button.
-  secondaryButton = secondaryButtons[3];
-  assert.notOk(
-    secondaryButton.disabled,
-    'iconed secondary button is not disabled'
-  );
-  assert.notOk(
-    secondaryButton.classList.contains('Polaris-Button--disabled'),
-    'iconed secondary button does not have disabled class'
-  );
-  assert.notOk(
-    secondaryButton.classList.contains('Polaris-Button--loading'),
-    'iconed secondary button does not have loading class'
-  );
-  assert.notOk(
-    secondaryButton.classList.contains('Polaris-Button--destructive'),
-    'iconed secondary button does not have destructive class'
-  );
-
-  const icon = find(iconSelector, secondaryButton);
-  assert.ok(icon, 'iconed secondary button has an icon');
-  assert.equal(
-    icon.dataset.iconSource,
-    'polaris/notes',
-    'iconed secondary button has the correct icon'
-  );
-});
-
-test('it handles item actions correctly', function(assert) {
-  let primaryActionFired = false;
-  this.on('primaryAction', () => {
-    primaryActionFired = true;
+    const primaryButtonSelector = buildNestedSelector(
+      pageActionsStackItemSelector,
+      'button.Polaris-Button.Polaris-Button--primary'
+    );
+    const primaryButton = find(primaryButtonSelector);
+    assert.ok(primaryButton, 'renders primary button');
+    assert.ok(primaryButton.disabled, 'primary button is disabled');
+    assert
+      .dom(primaryButton)
+      .hasClass(
+        'Polaris-Button--loading',
+        'primary button is in loading state'
+      );
   });
-  this.set('secondaryAction1Fired', false);
-  this.set('secondaryAction2Fired', false);
 
-  this.render(hbs`
-    {{polaris-page-actions
-      primaryAction=(hash
-        text="Primary"
-        onAction=(action "primaryAction")
-      )
-      secondaryActions=(array
-        (hash
-          text="Secondary 1"
-          onAction=(action (mut secondaryAction1Fired) true)
+  test('it renders the correct HTML when secondary actions have complex properties', async function(assert) {
+    await render(hbs`
+      {{polaris-page-actions
+        secondaryActions=(array
+          (hash
+            text="Disabled secondary action"
+            disabled=true
+          )
+          (hash
+            text="Loading secondary action"
+            loading=true
+          )
+          (hash
+            text="Destructive secondary action"
+            destructive=true
+          )
+          (hash
+            text="Secondary action with icon"
+            icon="notes"
+          )
         )
-        (hash
-          text="Secondary 2"
-          onAction=(action (mut secondaryAction2Fired) true)
+      }}
+    `);
+
+    let secondaryButtons = assert.dom(secondaryButtonSelector);
+    secondaryButtons.exists({ count: 4 }, 'renders four secondary buttons');
+
+    secondaryButtons = findAll(secondaryButtonSelector);
+
+    // Check the first (disabled) button.
+    let secondaryButton = assert.dom(secondaryButtons[0]);
+
+    secondaryButton.isDisabled('disabled secondary button is disabled');
+    secondaryButton.hasClass(
+      'Polaris-Button--disabled',
+      'disabled secondary button has disabled class'
+    );
+    secondaryButton.hasNoClass(
+      'Polaris-Button--loading',
+      'disabled secondary button does not have loading class'
+    );
+    secondaryButton.hasNoClass(
+      'Polaris-Button--destructive',
+      'disabled secondary button does not have destructive class'
+    );
+
+    assert
+      .dom(iconSelector, secondaryButton.target)
+      .doesNotExist('disabled secondary button does not have an icon');
+
+    // Check the second (loading) button.
+    secondaryButton = assert.dom(secondaryButtons[1]);
+    secondaryButton.isDisabled('loading secondary button is disabled');
+    secondaryButton.hasClass(
+      'Polaris-Button--disabled',
+      'loading secondary button has disabled class'
+    );
+    secondaryButton.hasClass(
+      'Polaris-Button--loading',
+      'loading secondary button has loading class'
+    );
+    secondaryButton.hasNoClass(
+      'Polaris-Button--destructive',
+      'disabled secondary button does not have destructive class'
+    );
+    assert
+      .dom(iconSelector, secondaryButton.target)
+      .doesNotExist('disabled secondary button does not have an icon');
+
+    // Check the third (destructive) button.
+    secondaryButton = assert.dom(secondaryButtons[2]);
+
+    secondaryButton.isNotDisabled(
+      'destructive secondary button is not disabled'
+    );
+    secondaryButton.hasNoClass(
+      'Polaris-Button--disabled',
+      'destructive secondary button does not have disabled class'
+    );
+    secondaryButton.hasNoClass(
+      'Polaris-Button--loading',
+      'destructive secondary button does not have loading class'
+    );
+    secondaryButton.hasClass(
+      'Polaris-Button--destructive',
+      'destructive secondary button has destructive class'
+    );
+    assert
+      .dom(iconSelector, secondaryButton.target)
+      .doesNotExist('destructive secondary button does not have an icon');
+
+    // Check the fourth (iconed) button.
+    secondaryButton = assert.dom(secondaryButtons[3]);
+    secondaryButton.isNotDisabled('iconed secondary button is not disabled');
+    secondaryButton.hasNoClass(
+      'Polaris-Button--disabled',
+      'iconed secondary button does not have disabled class'
+    );
+    secondaryButton.hasNoClass(
+      'Polaris-Button--loading',
+      'iconed secondary button does not have loading class'
+    );
+    secondaryButton.hasNoClass(
+      'Polaris-Button--destructive',
+      'iconed secondary button does not have destructive class'
+    );
+
+    const icon = assert.dom(iconSelector, secondaryButton.target);
+    icon.exists('iconed secondary button has an icon');
+    icon.hasAttribute(
+      'data-icon-source',
+      'polaris/notes',
+      'iconed secondary button has the correct icon'
+    );
+  });
+
+  test('it handles item actions correctly', async function(assert) {
+    const initState = () =>
+      this.setProperties({
+        primaryActionFired: false,
+        secondaryAction1Fired: false,
+        secondaryAction2Fired: false,
+      });
+
+    initState();
+    await render(hbs`
+      {{polaris-page-actions
+        primaryAction=(hash
+          text="Primary"
+          onAction=(action (mut primaryActionFired) true)
         )
-      )
-    }}
-  `);
+        secondaryActions=(array
+          (hash
+            text="Secondary 1"
+            onAction=(action (mut secondaryAction1Fired) true)
+          )
+          (hash
+            text="Secondary 2"
+            onAction=(action (mut secondaryAction2Fired) true)
+          )
+        )
+      }}
+    `);
 
-  const secondaryButtonGroupItems = findAll('div.Polaris-ButtonGroup__Item');
-  assert.equal(
-    secondaryButtonGroupItems.length,
-    2,
-    'renders both secondary buttons'
-  );
+    const secondaryButtonGroupItems = findAll('div.Polaris-ButtonGroup__Item');
+    assert.equal(
+      secondaryButtonGroupItems.length,
+      2,
+      'renders both secondary buttons'
+    );
 
-  // Click the first secondary button.
-  click('button', secondaryButtonGroupItems[0]);
-  assert.notOk(
-    primaryActionFired,
-    'after clicking first secondary button - primary action not fired'
-  );
-  assert.ok(
-    this.get('secondaryAction1Fired'),
-    'after clicking first secondary button - first secondary action fired'
-  );
-  assert.notOk(
-    this.get('secondaryAction2Fired'),
-    'after clicking first secondary button - second secondary action not fired'
-  );
+    // Click the primary button.
+    await click('button.Polaris-Button--primary');
+    assert.ok(
+      this.get('primaryActionFired'),
+      'after clicking primary button - primary action fired'
+    );
+    assert.notOk(
+      this.get('secondaryAction1Fired'),
+      'after clicking primary button - second secondary action not fired'
+    );
+    assert.notOk(
+      this.get('secondaryAction2Fired'),
+      'after clicking primary button - second secondary action not fired'
+    );
 
-  // Click the primary button.
-  click('button.Polaris-Button--primary');
-  assert.ok(
-    primaryActionFired,
-    'after clicking primary button - primary action fired'
-  );
-  assert.notOk(
-    this.get('secondaryAction2Fired'),
-    'after clicking first secondary button - second secondary action not fired'
-  );
+    initState();
+    // Click the first secondary button.
+    await click(secondaryButtonGroupItems[0].querySelector('button'));
+    assert.notOk(
+      this.get('primaryActionFired'),
+      'after clicking first secondary button - primary action not fired'
+    );
+    assert.ok(
+      this.get('secondaryAction1Fired'),
+      'after clicking first secondary button - first secondary action fired'
+    );
+    assert.notOk(
+      this.get('secondaryAction2Fired'),
+      'after clicking first secondary button - second secondary action not fired'
+    );
 
-  // Click the remaining secondary button.
-  click('button', secondaryButtonGroupItems[1]);
-  assert.ok(
-    this.get('secondaryAction2Fired'),
-    'after clicking second secondary button - second secondary action fired'
-  );
+    initState();
+
+    // Click the remaining secondary button.
+    await click(secondaryButtonGroupItems[1].querySelector('button'));
+    assert.notOk(
+      this.get('primaryActionFired'),
+      'after clicking second secondary button - primary action not fired'
+    );
+    assert.notOk(
+      this.get('secondaryAction1Fired'),
+      'after clicking second secondary button - first secondary action not fired'
+    );
+    assert.ok(
+      this.get('secondaryAction2Fired'),
+      'after clicking second secondary button - second secondary action fired'
+    );
+  });
 });

--- a/tests/integration/components/polaris-page-test.js
+++ b/tests/integration/components/polaris-page-test.js
@@ -1,8 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, render } from '@ember/test-helpers';
+import { click, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { findAll, find } from 'ember-native-dom-helpers';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 import stubRouting from '../../helpers/stub-routing';
 import MockSvgJarComponent from '../../mocks/components/svg-jar';
@@ -58,28 +57,25 @@ module('Integration | Component | polaris page', function(hooks) {
         <div class="test-page-content">This is some test content</div>
       {{/polaris-page}}`);
 
-    const pages = findAll(pageSelector);
-    assert.equal(pages.length, 1, 'renders one page div');
+    const pages = assert.dom(pageSelector);
+    pages.exists({ count: 1 }, 'renders one page div');
 
-    const page = pages[0];
-    assert
-      .dom(page)
-      .hasNoClass('Polaris-Page--fullWidth', 'does not apply full width class');
-    assert
-      .dom(page)
-      .hasNoClass(
-        'Polaris-Page--singleColumn',
-        'does not apply single column class'
-      );
+    pages.hasNoClass(
+      'Polaris-Page--fullWidth',
+      'does not apply full width class'
+    );
+    pages.hasNoClass(
+      'Polaris-Page--singleColumn',
+      'does not apply single column class'
+    );
 
-    const headers = findAll(headerSelector);
-    assert.equal(headers.length, 1, 'renders one page header div');
-    assert
-      .dom(headers[0])
-      .hasNoClass(
-        'Polaris-Page-Header__Header--hasSecondaryActions',
-        'does not apply secondary actions class to header'
-      );
+    const headers = assert.dom(headerSelector);
+    headers.exists({ count: 1 }, 'renders one page header div');
+
+    headers.hasNoClass(
+      'Polaris-Page-Header__Header--hasSecondaryActions',
+      'does not apply secondary actions class to header'
+    );
 
     const displayTextSelector = buildNestedSelector(
       headerSelector,
@@ -88,15 +84,15 @@ module('Integration | Component | polaris page', function(hooks) {
       'div',
       'h1.Polaris-DisplayText.Polaris-DisplayText--sizeLarge'
     );
-    const displayTexts = findAll(displayTextSelector);
-    assert.equal(
-      displayTexts.length,
-      1,
+    const displayTexts = assert.dom(displayTextSelector);
+
+    displayTexts.exists(
+      { count: 1 },
+
       'renders one page header display text'
     );
-    const titleText = displayTexts[0].textContent.trim();
-    assert.equal(
-      titleText,
+
+    displayTexts.hasText(
       'This is the title',
       'renders correct page header display text content'
     );
@@ -105,69 +101,48 @@ module('Integration | Component | polaris page', function(hooks) {
       pageSelector,
       'div.Polaris-Page__Content'
     );
-    const contentWrappers = findAll(contentWrapperSelector);
-    assert.equal(
-      contentWrappers.length,
-      1,
-      'renders one page content wrapper div'
-    );
+    assert
+      .dom(contentWrapperSelector)
+      .exists({ count: 1 }, 'renders one page content wrapper div');
 
     const contentSelector = buildNestedSelector(
       contentWrapperSelector,
       'div.test-page-content'
     );
-    const contents = findAll(contentSelector);
-    assert.equal(contents.length, 1, 'renders one content div');
+    const contents = assert.dom(contentSelector);
+    contents.exists({ count: 1 }, 'renders one content div');
 
-    const contentText = contents[0].textContent.trim();
-    assert.equal(
-      contentText,
-      'This is some test content',
-      'renders correct content'
+    contents.hasText('This is some test content', 'renders correct content');
+
+    pages.hasNoClass(
+      'Polaris-Page--fullWidth',
+      'fullWidth unset - does not apply fullWidth class'
+    );
+    this.set('fullWidth', true);
+    pages.hasClass(
+      'Polaris-Page--fullWidth',
+      'fullWidth set - applies fullWidth class'
     );
 
-    assert
-      .dom(page)
-      .hasNoClass(
-        'Polaris-Page--fullWidth',
-        'fullWidth unset - does not apply fullWidth class'
-      );
-    this.set('fullWidth', true);
-    assert
-      .dom(page)
-      .hasClass(
-        'Polaris-Page--fullWidth',
-        'fullWidth set - applies fullWidth class'
-      );
-
-    assert
-      .dom(page)
-      .hasNoClass(
-        'Polaris-Page--singleColumn',
-        'singleColumn unset - does not apply singleColumn class'
-      );
+    pages.hasNoClass(
+      'Polaris-Page--singleColumn',
+      'singleColumn unset - does not apply singleColumn class'
+    );
     this.set('singleColumn', true);
-    assert
-      .dom(page)
-      .hasClass(
-        'Polaris-Page--singleColumn',
-        'singleColumn set - applies singleColumn class'
-      );
+    pages.hasClass(
+      'Polaris-Page--singleColumn',
+      'singleColumn set - applies singleColumn class'
+    );
 
-    let header = headers[0];
-    assert
-      .dom(header)
-      .hasNoClass(
-        'Polaris-Page-Header__Title--hidden',
-        'titleHidden unset - does not apply titleHidden class'
-      );
+    headers.hasNoClass(
+      'Polaris-Page-Header__Title--hidden',
+      'titleHidden unset - does not apply titleHidden class'
+    );
     this.set('titleHidden', true);
-    assert
-      .dom(header)
-      .hasClass(
-        'Polaris-Page-Header__Title--hidden',
-        'titleHidden set - applies titleHidden class'
-      );
+    headers.hasClass(
+      'Polaris-Page-Header__Title--hidden',
+      'titleHidden set - applies titleHidden class'
+    );
   });
 
   test('it handles primary action correctly when supplied', async function(assert) {
@@ -192,43 +167,33 @@ module('Integration | Component | polaris page', function(hooks) {
       }}
     `);
 
-    const primaryButtons = findAll(primaryButtonSelector);
-    assert.equal(primaryButtons.length, 1, 'renders one primary button');
-    const primaryButton = primaryButtons[0];
-    const primaryButtonText = primaryButton.textContent.trim();
-    assert.equal(
-      primaryButtonText,
+    const primaryButtons = assert.dom(primaryButtonSelector);
+    primaryButtons.exists({ count: 1 }, 'renders one primary button');
+
+    primaryButtons.hasText(
       'Take action!',
       'uses correct text on primary button'
     );
 
-    assert.ok(
-      primaryButton.disabled,
-      'primary action button is initially disabled'
+    primaryButtons.isDisabled('primary action button is initially disabled');
+    primaryButtons.hasNoClass(
+      'Polaris-Button--loading',
+      'primary action button is not initially in loading state'
     );
-    assert
-      .dom(primaryButton)
-      .hasNoClass(
-        'Polaris-Button--loading',
-        'primary action button is not initially in loading state'
-      );
 
     this.setProperties({
       primaryActionDisabled: false,
       primaryActionLoading: true,
     });
-    assert
-      .dom(primaryButton)
-      .hasClass(
-        'Polaris-Button--loading',
-        'primary action button goes into loading state'
-      );
+
+    primaryButtons.hasClass(
+      'Polaris-Button--loading',
+      'primary action button goes into loading state'
+    );
 
     this.set('primaryActionLoading', false);
-    assert.notOk(
-      primaryButton.disabled,
-      'primary action button becomes enabled'
-    );
+
+    primaryButtons.isNotDisabled('primary action button becomes enabled');
     assert.notOk(
       primaryActionFired,
       "hasn't fired primary action before clicking button"
@@ -264,9 +229,8 @@ module('Integration | Component | polaris page', function(hooks) {
       }}
     `);
 
-    const header = find(headerSelector);
     assert
-      .dom(header)
+      .dom(headerSelector)
       .hasClass(
         'Polaris-Page-Header__Header--hasSecondaryActions',
         'applies secondary actions class'
@@ -398,28 +362,25 @@ module('Integration | Component | polaris page', function(hooks) {
       hbs`{{polaris-page title="This is a page" breadcrumbs=breadcrumbs}}`
     );
 
-    // Test before setting breadcrumbs.
-    const header = find(headerSelector);
     const headerWithBreadcrumbsClass =
       'Polaris-Page-Header__Header--hasBreadcrumbs';
-    assert.ok(header, 'without breadcrumbs - renders header');
-    assert
-      .dom(header)
-      .hasNoClass(
-        headerWithBreadcrumbsClass,
-        'without breadcrumbs - does not apply hasBreadcrumbs class'
-      );
+
+    // Test before setting breadcrumbs.
+    const header = assert.dom(headerSelector);
+
+    header.exists('without breadcrumbs - renders header');
+    header.hasNoClass(
+      headerWithBreadcrumbsClass,
+      'without breadcrumbs - does not apply hasBreadcrumbs class'
+    );
 
     const navigationSelector = buildNestedSelector(
       headerSelector,
       'div.Polaris-Page-Header__Navigation'
     );
-    const navigations = findAll(navigationSelector);
-    assert.equal(
-      navigations.length,
-      0,
-      'without breadcrumbs - does not render navigation div'
-    );
+    assert
+      .dom(navigationSelector)
+      .doesNotExist('without breadcrumbs - does not render navigation div');
 
     // Add the breadcrumbs.
     this.set('breadcrumbs', [
@@ -433,12 +394,10 @@ module('Integration | Component | polaris page', function(hooks) {
       },
     ]);
 
-    assert
-      .dom(header)
-      .hasClass(
-        headerWithBreadcrumbsClass,
-        'with breadcrumbs - applies hasBreadcrumbs class'
-      );
+    header.hasClass(
+      headerWithBreadcrumbsClass,
+      'with breadcrumbs - applies hasBreadcrumbs class'
+    );
 
     // Check the breadcrumbs rendered.
     const breadcrumbLinkSelector = buildNestedSelector(
@@ -446,10 +405,10 @@ module('Integration | Component | polaris page', function(hooks) {
       'nav[role="navigation"]',
       'a.Polaris-Breadcrumbs__Breadcrumb'
     );
-    const breadcrumbLinks = findAll(breadcrumbLinkSelector);
-    assert.equal(
-      breadcrumbLinks.length,
-      1,
+    const breadcrumbLinks = assert.dom(breadcrumbLinkSelector);
+
+    breadcrumbLinks.exists(
+      { count: 1 },
       'with breadcrumbs - renders 1 breadcrumb'
     );
 
@@ -460,28 +419,27 @@ module('Integration | Component | polaris page', function(hooks) {
     );
     const contentSelector = 'span.Polaris-Breadcrumbs__Content';
 
-    let breadcrumbLink = breadcrumbLinks[0];
-    assert.ok(
-      breadcrumbLink.href.indexOf('/home/the-beginning') > -1,
+    breadcrumbLinks.hasAttribute(
+      'href',
+      '/home/the-beginning',
       'breadcrumb has href of last breadcrumb in list'
     );
-    assert.equal(
-      breadcrumbLink.dataset.polarisUnstyled,
+    breadcrumbLinks.hasAttribute(
+      'data-polaris-unstyled',
       'true',
       'breadcrumb has data-polaris-unstyled attribute'
     );
 
-    let contents = findAll(contentSelector, breadcrumbLink);
-    assert.equal(contents.length, 1, 'breadcrumb renders content');
-    assert
-      .dom(contents[0])
-      .hasText(
-        'No, really!',
-        'breadcrumb renders text from last breadcrumb in list'
-      );
+    let contents = assert.dom(`${breadcrumbLinkSelector} ${contentSelector}`);
+    contents.exists({ count: 1 }, 'breadcrumb renders content');
+    contents.hasText(
+      'No, really!',
+      'breadcrumb renders text from last breadcrumb in list'
+    );
 
-    let icons = findAll(iconSelector, breadcrumbLink);
-    assert.equal(icons.length, 1, 'breadcrumb renders icon');
+    assert
+      .dom(`${breadcrumbLinkSelector} ${iconSelector}`)
+      .exists({ count: 1 }, 'breadcrumb renders icon');
   });
 
   test('it renders title metadata', async function(assert) {
@@ -492,9 +450,7 @@ module('Integration | Component | polaris page', function(hooks) {
       }}
     `);
 
-    const metadataBadgeSelector = '.Polaris-Badge';
-    let metadataBadge = find(metadataBadgeSelector);
-    assert.ok(metadataBadge, 'renders title metadata');
+    assert.dom('.Polaris-Badge').exists('renders title metadata');
   });
 
   test('it allows the primary action to be rendered as not primary', async function(assert) {
@@ -511,37 +467,29 @@ module('Integration | Component | polaris page', function(hooks) {
       }}
     `);
 
-    let primaryButton = find(primaryButtonSelector);
-    assert.ok(primaryButton, 'primary false - renders primary action');
-    assert
-      .dom(primaryButton)
-      .hasNoClass(
-        'Polaris-Button--primary',
-        'primary false - button is not rendered as primary'
-      );
+    let primaryButton = assert.dom(primaryButtonSelector);
+    primaryButton.exists('primary false - renders primary action');
+    primaryButton.hasNoClass(
+      'Polaris-Button--primary',
+      'primary false - button is not rendered as primary'
+    );
 
     this.set('shouldRenderPrimaryActionAsPrimary', null);
-    assert
-      .dom(primaryButton)
-      .hasNoClass(
-        'Polaris-Button--primary',
-        'primary null - button is not rendered as primary'
-      );
+    primaryButton.hasNoClass(
+      'Polaris-Button--primary',
+      'primary null - button is not rendered as primary'
+    );
 
     this.set('shouldRenderPrimaryActionAsPrimary', true);
-    assert
-      .dom(primaryButton)
-      .hasClass(
-        'Polaris-Button--primary',
-        'primary true - button is rendered as primary'
-      );
+    primaryButton.hasClass(
+      'Polaris-Button--primary',
+      'primary true - button is rendered as primary'
+    );
 
     this.set('shouldRenderPrimaryActionAsPrimary', undefined);
-    assert
-      .dom(primaryButton)
-      .hasClass(
-        'Polaris-Button--primary',
-        'primary undefined - button is rendered as primary'
-      );
+    primaryButton.hasClass(
+      'Polaris-Button--primary',
+      'primary undefined - button is rendered as primary'
+    );
   });
 });

--- a/tests/integration/components/polaris-popover-test.js
+++ b/tests/integration/components/polaris-popover-test.js
@@ -1,239 +1,246 @@
-import { moduleForComponent, test, skip } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { findAll, click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { find, findAll, click } from 'ember-native-dom-helpers';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
-moduleForComponent(
-  'polaris-popover',
-  'Integration | Component | polaris popover',
-  {
-    integration: true,
-  }
-);
+module('Integration | Component | polaris popover', function(hooks) {
+  setupRenderingTest(hooks);
 
-const activatorSelector = 'button.Polaris-Button';
-const overlaySelector = 'div.Polaris-PositionedOverlay';
-const popoverSelector = buildNestedSelector(
-  overlaySelector,
-  'div.Polaris-Popover'
-);
-const popoverChildSelector = buildNestedSelector(popoverSelector, 'div');
-const popoverContentSelector = buildNestedSelector(
-  popoverChildSelector,
-  'div.Polaris-Popover__Content'
-);
-const popoverContentAboveSelector = '.ember-basic-dropdown-content--above';
-const popoverContentBelowSelector = '.ember-basic-dropdown-content--below';
-const popoverPaneSelector = buildNestedSelector(
-  popoverContentSelector,
-  'div.Polaris-Popover__Pane.Polaris-Scrollable.Polaris-Scrollable--vertical'
-);
-
-skip('it renders the correct HTML with default attributes', function(assert) {
-  this.render(hbs`
-    {{#polaris-popover as |popover|}}
-      {{#popover.activator}}
-        {{polaris-button text="Toggle popover"}}
-      {{/popover.activator}}
-
-      {{#popover.content}}
-        This is the popover content
-      {{/popover.content}}
-    {{/polaris-popover}}
-  `);
-
-  const activator = find(activatorSelector);
-  assert.ok(activator, 'renders activator');
-
-  // Check that the popover content isn't rendered.
-  let overlays = findAll(overlaySelector);
-  assert.equal(
-    overlays.length,
-    0,
-    'before clicking activator - does not render any content'
-  );
-
-  // Click the activator button.
-  click(activatorSelector);
-
-  // Check that the content is now rendered.
-  const popovers = findAll(popoverSelector);
-  assert.equal(
-    popovers.length,
-    1,
-    'renders one popover after clicking activator'
-  );
-  assert.equal(
-    popovers[0].dataset.polarisOverlay,
-    'true',
-    'popover has data-polaris-overlay attribute'
-  );
-
-  // Check the popover renders the correct HTML.
-  const popoverChildren = findAll(popoverChildSelector);
-  assert.equal(
-    popoverChildren.length,
-    4,
-    'popover has the correct number of children'
-  );
-
-  // Check the popover has the correct child elements.
-  let child = popoverChildren[0];
-  assert.ok(
-    child.classList.contains('Polaris-Popover__Tip'),
-    'first popover child is tip'
-  );
-
-  child = popoverChildren[1];
-  assert.ok(
-    child.classList.contains('Polaris-Popover__FocusTracker'),
-    'second popover child is focus tracker'
-  );
-
-  child = popoverChildren[2];
-  assert.ok(
-    child.classList.contains('Polaris-Popover__Wrapper'),
-    'third popover child is content wrapper'
-  );
-
-  child = popoverChildren[3];
-  assert.ok(
-    child.classList.contains('Polaris-Popover__FocusTracker'),
-    'fourth popover child is focus tracker'
-  );
-
-  // Check the content was rendered correctly.
-  const popoverContents = findAll(popoverContentSelector);
-  assert.equal(popoverContents.length, 1, 'renders one popover content div');
-
-  const popoverPanes = findAll(popoverPaneSelector);
-  assert.equal(popoverPanes.length, 1, 'renders one popover pane');
-
-  const popoverPane = popoverPanes[0];
-  assert.equal(
-    popoverPane.dataset.polarisScrollable,
-    'true',
-    'popover pane has data-polaris-scrollable attribute'
-  );
-  assert.equal(
-    popoverPane.textContent.trim(),
-    'This is the popover content',
-    'popover pane contains the correct content'
-  );
-
-  // Click the activator button again.
-  click(activatorSelector);
-
-  // Check that the popover content is removed.
-  overlays = findAll(overlaySelector);
-  assert.equal(
-    overlays.length,
-    0,
-    'after clicking activator twice - does not render any content'
-  );
-});
-
-test('it renders the correct HTML with sectioned attribute', function(assert) {
-  this.render(hbs`
-    {{#polaris-popover sectioned=true as |popover|}}
-      {{#popover.activator}}
-        {{polaris-button text="Toggle popover"}}
-      {{/popover.activator}}
-
-      {{#popover.content}}
-        This is some sectioned popover content
-      {{/popover.content}}
-    {{/polaris-popover}}
-  `);
-
-  click(activatorSelector);
-
-  const popoverSectionSelector = buildNestedSelector(
-    popoverPaneSelector,
-    'div.Polaris-Popover__Section'
-  );
-  const popoverSections = findAll(popoverSectionSelector);
-  assert.equal(popoverSections.length, 1, 'renders one popover section');
-  assert.equal(
-    popoverSections[0].textContent.trim(),
-    'This is some sectioned popover content',
-    'popover section contains the correct content'
-  );
-});
-
-test('it renders the correct HTML with preferredPosition attribute', function(assert) {
-  assert.expect(2);
-
-  this.set('preferredPosition', 'above');
-
-  this.render(hbs`
-    {{#polaris-popover
-      preferredPosition=preferredPosition
-      sectioned=true
-      as |popover|
-    }}
-      {{#popover.activator}}
-        {{polaris-button text="Toggle popover"}}
-      {{/popover.activator}}
-
-      {{#popover.content}}
-        This is some sectioned popover content
-      {{/popover.content}}
-    {{/polaris-popover}}
-  `);
-
-  click(activatorSelector);
-
-  const contentAbove = document.querySelector(popoverContentAboveSelector);
-  assert.ok(contentAbove, 'renders popover content above the trigger');
-
-  // close the popover before resetting position
-  click(activatorSelector);
-
-  this.set('preferredPosition', 'below');
-
-  click(activatorSelector);
-
-  const contentBelow = document.querySelector(popoverContentBelowSelector);
-  assert.ok(contentBelow, 'renders popover content below the trigger');
-});
-
-test('it calls a passed-in onClose action when closed', function(assert) {
-  this.set('onCloseCalled', false);
-
-  this.on('close', () => {
-    this.set('onCloseCalled', true);
+  hooks.beforeEach(function() {
+    this.actions = {};
+    this.send = (actionName, ...args) =>
+      this.actions[actionName].apply(this, args);
   });
 
-  this.render(hbs`
-    {{#polaris-popover
-      sectioned=true
-      onClose=(action "close")
-      as |popover|
-    }}
-      {{#popover.activator}}
-        {{polaris-button text="Toggle popover"}}
-      {{/popover.activator}}
-
-      {{#popover.content}}
-        This is some sectioned popover content
-      {{/popover.content}}
-    {{/polaris-popover}}
-  `);
-
-  // open the popover
-  click(activatorSelector);
-
-  assert.notOk(
-    this.get('onCloseCalled'),
-    'the passed-in onClose action has not been called'
+  const activatorSelector = 'button.Polaris-Button';
+  const overlaySelector = 'div.Polaris-PositionedOverlay';
+  const popoverSelector = buildNestedSelector(
+    overlaySelector,
+    'div.Polaris-Popover'
+  );
+  const popoverChildSelector = buildNestedSelector(popoverSelector, 'div');
+  const popoverContentSelector = buildNestedSelector(
+    popoverChildSelector,
+    'div.Polaris-Popover__Content'
+  );
+  const popoverContentAboveSelector = '.ember-basic-dropdown-content--above';
+  const popoverContentBelowSelector = '.ember-basic-dropdown-content--below';
+  const popoverPaneSelector = buildNestedSelector(
+    popoverContentSelector,
+    'div.Polaris-Popover__Pane.Polaris-Scrollable.Polaris-Scrollable--vertical'
   );
 
-  // close the popover
-  click(activatorSelector);
+  test('it renders the correct HTML with default attributes', async function(assert) {
+    await render(hbs`
+      {{#polaris-popover as |popover|}}
+        {{#popover.activator}}
+          {{polaris-button text="Toggle popover"}}
+        {{/popover.activator}}
 
-  assert.ok(
-    this.get('onCloseCalled'),
-    'the passed-in onClose action is called when popover is closed'
-  );
+        {{#popover.content}}
+          This is the popover content
+        {{/popover.content}}
+      {{/polaris-popover}}
+    `);
+
+    assert.dom(activatorSelector).exists('renders activator');
+
+    // Check that the popover content isn't rendered.
+    assert
+      .dom(overlaySelector)
+      .doesNotExist('before clicking activator - does not render any content');
+
+    // Click the activator button.
+    await click(activatorSelector);
+
+    // Check that the content is now rendered.
+    const popovers = assert.dom(popoverSelector);
+
+    popovers.exists(
+      { count: 1 },
+      'renders one popover after clicking activator'
+    );
+
+    popovers.hasAttribute(
+      'data-polaris-overlay',
+      'true',
+      'popover has data-polaris-overlay attribute'
+    );
+
+    // Check the popover renders the correct HTML.
+    const popoverChildren = findAll(popoverChildSelector);
+    assert.equal(
+      popoverChildren.length,
+      4,
+      'popover has the correct number of children'
+    );
+
+    // Check the popover has the correct child elements.
+    let child = popoverChildren[0];
+    assert
+      .dom(child)
+      .hasClass('Polaris-Popover__Tip', 'first popover child is tip');
+
+    child = popoverChildren[1];
+    assert
+      .dom(child)
+      .hasClass(
+        'Polaris-Popover__FocusTracker',
+        'second popover child is focus tracker'
+      );
+
+    child = popoverChildren[2];
+    assert
+      .dom(child)
+      .hasClass(
+        'Polaris-Popover__Wrapper',
+        'third popover child is content wrapper'
+      );
+
+    child = popoverChildren[3];
+    assert
+      .dom(child)
+      .hasClass(
+        'Polaris-Popover__FocusTracker',
+        'fourth popover child is focus tracker'
+      );
+
+    // Check the content was rendered correctly.
+    assert
+      .dom(popoverContentSelector)
+      .exists({ count: 1 }, 'renders one popover content div');
+
+    const popoverPanes = findAll(popoverPaneSelector);
+    assert.equal(popoverPanes.length, 1, 'renders one popover pane');
+
+    const popoverPane = popoverPanes[0];
+    assert.equal(
+      popoverPane.dataset.polarisScrollable,
+      'true',
+      'popover pane has data-polaris-scrollable attribute'
+    );
+    assert
+      .dom(popoverPane)
+      .hasText(
+        'This is the popover content',
+        'popover pane contains the correct content'
+      );
+
+    // Click the activator button again.
+    await click(activatorSelector);
+
+    // Check that the popover content is removed.
+    assert
+      .dom(overlaySelector)
+      .doesNotExist(
+        'after clicking activator twice - does not render any content'
+      );
+  });
+
+  test('it renders the correct HTML with sectioned attribute', async function(assert) {
+    await render(hbs`
+      {{#polaris-popover sectioned=true as |popover|}}
+        {{#popover.activator}}
+          {{polaris-button text="Toggle popover"}}
+        {{/popover.activator}}
+
+        {{#popover.content}}
+          This is some sectioned popover content
+        {{/popover.content}}
+      {{/polaris-popover}}
+    `);
+
+    await click(activatorSelector);
+
+    const popoverSectionSelector = buildNestedSelector(
+      popoverPaneSelector,
+      'div.Polaris-Popover__Section'
+    );
+
+    const popoverSections = assert.dom(popoverSectionSelector);
+    popoverSections.exists({ count: 1 }, 'renders one popover section');
+
+    popoverSections.hasText(
+      'This is some sectioned popover content',
+      'popover section contains the correct content'
+    );
+  });
+
+  test('it renders the correct HTML with preferredPosition attribute', async function(assert) {
+    assert.expect(2);
+
+    this.set('preferredPosition', 'above');
+
+    await render(hbs`
+      {{#polaris-popover
+        preferredPosition=preferredPosition
+        sectioned=true
+        as |popover|
+      }}
+        {{#popover.activator}}
+          {{polaris-button text="Toggle popover"}}
+        {{/popover.activator}}
+
+        {{#popover.content}}
+          This is some sectioned popover content
+        {{/popover.content}}
+      {{/polaris-popover}}
+    `);
+
+    await click(activatorSelector);
+
+    const contentAbove = document.querySelector(popoverContentAboveSelector);
+    assert.ok(contentAbove, 'renders popover content above the trigger');
+
+    // close the popover before resetting position
+    await click(activatorSelector);
+
+    this.set('preferredPosition', 'below');
+
+    await click(activatorSelector);
+
+    const contentBelow = document.querySelector(popoverContentBelowSelector);
+    assert.ok(contentBelow, 'renders popover content below the trigger');
+  });
+
+  test('it calls a passed-in onClose action when closed', async function(assert) {
+    this.set('onCloseCalled', false);
+
+    this.actions.close = () => {
+      this.set('onCloseCalled', true);
+    };
+
+    await render(hbs`
+      {{#polaris-popover
+        sectioned=true
+        onClose=(action "close")
+        as |popover|
+      }}
+        {{#popover.activator}}
+          {{polaris-button text="Toggle popover"}}
+        {{/popover.activator}}
+
+        {{#popover.content}}
+          This is some sectioned popover content
+        {{/popover.content}}
+      {{/polaris-popover}}
+    `);
+
+    // open the popover
+    await click(activatorSelector);
+
+    assert.notOk(
+      this.get('onCloseCalled'),
+      'the passed-in onClose action has not been called'
+    );
+
+    // close the popover
+    await click(activatorSelector);
+
+    assert.ok(
+      this.get('onCloseCalled'),
+      'the passed-in onClose action is called when popover is closed'
+    );
+  });
 });

--- a/tests/integration/components/polaris-radio-button-test.js
+++ b/tests/integration/components/polaris-radio-button-test.js
@@ -1,7 +1,8 @@
 import Component from '@ember/component';
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { focus, click, blur, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { findAll, find, focus, click, blur } from 'ember-native-dom-helpers';
 import MockSvgJarComponent from '../../mocks/components/svg-jar';
 
 // Mock the polaris-choice component to simplify testing what gets rendered.
@@ -21,153 +22,151 @@ const MockPolarisChoiceComponent = Component.extend({
   layout: hbs`{{yield}}`,
 });
 
-moduleForComponent(
-  'polaris-radio-button',
-  'Integration | Component | polaris radio button',
-  {
-    integration: true,
+module('Integration | Component | polaris radio button', function(hooks) {
+  setupRenderingTest(hooks);
 
-    beforeEach() {
-      this.register('component:polaris-choice', MockPolarisChoiceComponent);
-      this.register('component:svg-jar', MockSvgJarComponent);
-    },
-  }
-);
-
-const choiceSelector = 'label.Polaris-Choice';
-const radioButtonSelector = '[data-test-radio-button]';
-const radioButtonInputSelector = '[data-test-radio-button-input][type="radio"]';
-const radioButtonBackdropSelector = '[data-test-radio-button-backdrop]';
-const radioButtonIconSelector = '[data-test-radio-button-icon]';
-
-test('it renders the correct HTML', function(assert) {
-  this.render(hbs`
-    {{polaris-radio-button
-      inputId="some-radio-button-id"
-      name="Radio"
-      value="gaga"
-      label="Radio label"
-      labelHidden="Label is hidden, yes"
-      helpText="Help!"
-    }}
-  `);
-
-  const choices = findAll(choiceSelector);
-  assert.equal(choices.length, 1, 'renders one `polaris-choice` component');
-
-  const choiceData = choices[0].dataset;
-  assert.equal(
-    choiceData.inputId,
-    'some-radio-button-id',
-    'passes inputId through to `polaris-choice` component'
-  );
-  assert.equal(
-    choiceData.label,
-    'Radio label',
-    'passes label through to `polaris-choice` component'
-  );
-  assert.equal(
-    choiceData.labelHidden,
-    'Label is hidden, yes',
-    'passes labelHidden through to `polaris-choice` component'
-  );
-  assert.equal(
-    choiceData.helpText,
-    'Help!',
-    'passes helpText through to `polaris-choice` component'
-  );
-
-  // Check the wrapper element.
-  const radioButtons = findAll(radioButtonSelector);
-  assert.equal(radioButtons.length, 1, 'renders one radio button wrapper');
-
-  // Check the input.
-  const inputs = findAll(radioButtonInputSelector);
-  assert.equal(inputs.length, 1, 'renders one radio input');
-
-  const input = inputs[0];
-  assert.equal(
-    input.id,
-    'some-radio-button-id',
-    'radio input has the right id'
-  );
-  assert.equal(input.name, 'Radio', 'radio input has the right name');
-  assert.equal(input.value, 'gaga', 'radio input has the right value');
-
-  const backdrops = findAll(radioButtonBackdropSelector);
-  assert.equal(backdrops.length, 1, 'renders one radio button backdrop');
-
-  const icons = findAll(radioButtonIconSelector);
-  assert.equal(icons.length, 1, 'renders one radio button icon wrapper');
-});
-
-test('it handles the disabled attribute correctly', function(assert) {
-  this.set('disabled', true);
-  this.render(hbs`{{polaris-radio-button disabled=disabled}}`);
-
-  const input = find(radioButtonInputSelector);
-  assert.ok(input, 'renders the input');
-  assert.ok(input.disabled, 'radio input is disabled when disabled is true');
-
-  this.set('disabled', false);
-  assert.notOk(
-    input.disabled,
-    'radio input is not disabled when disabled is false'
-  );
-});
-
-test("it sets the input's aria-describedby attribute correctly", function(assert) {
-  this.set('helpText', 'some help text');
-  this.render(hbs`
-    {{polaris-radio-button
-      inputId="described-radio-button"
-      helpText=helpText
-    }}
-  `);
-
-  const input = find(radioButtonInputSelector);
-  assert.ok(input, 'renders the input');
-
-  assert.equal(
-    input.getAttribute('aria-describedby'),
-    'described-radio-buttonHelpText',
-    'described by help text element when help text is present'
-  );
-
-  this.set('helpText', null);
-  assert.notOk(
-    input.getAttribute('aria-describedby'),
-    'has no description when help text is present'
-  );
-});
-
-test('it handles events correctly', function(assert) {
-  this.setProperties({
-    selectedValue: 'none',
-    focusFired: false,
-    blurFired: false,
+  hooks.beforeEach(function() {
+    this.owner.register('component:polaris-choice', MockPolarisChoiceComponent);
+    this.owner.register('component:svg-jar', MockSvgJarComponent);
   });
-  this.render(hbs`
-    {{polaris-radio-button
-      value="clicked"
-      onChange=(action (mut selectedValue))
-      onFocus=(action (mut focusFired) true)
-      onBlur=(action (mut blurFired) true)
-    }}
-  `);
 
-  focus(radioButtonInputSelector);
-  assert.ok(this.get('focusFired'), 'after focus - onFocus fired');
-  assert.notOk(this.get('blurFired'), 'after focus - onBlur not fired');
+  const choiceSelector = 'label.Polaris-Choice';
+  const radioButtonSelector = '[data-test-radio-button]';
+  const radioButtonInputSelector =
+    '[data-test-radio-button-input][type="radio"]';
+  const radioButtonBackdropSelector = '[data-test-radio-button-backdrop]';
+  const radioButtonIconSelector = '[data-test-radio-button-icon]';
 
-  click(radioButtonInputSelector);
-  assert.notOk(this.get('blurFired'), 'after click - onBlur not fired');
-  assert.equal(
-    this.get('selectedValue'),
-    'clicked',
-    'after click - selected value has updated'
-  );
+  test('it renders the correct HTML', async function(assert) {
+    await render(hbs`
+      {{polaris-radio-button
+        inputId="some-radio-button-id"
+        name="Radio"
+        value="gaga"
+        label="Radio label"
+        labelHidden="Label is hidden, yes"
+        helpText="Help!"
+      }}
+    `);
 
-  blur(radioButtonInputSelector);
-  assert.ok(this.get('blurFired'), 'after blur - onBlur fired');
+    const choices = assert.dom(choiceSelector);
+    choices.exists({ count: 1 }, 'renders one `polaris-choice` component');
+
+    choices.hasAttribute(
+      'data-input-id',
+      'some-radio-button-id',
+      'passes inputId through to `polaris-choice` component'
+    );
+    choices.hasAttribute(
+      'data-label',
+      'Radio label',
+      'passes label through to `polaris-choice` component'
+    );
+    choices.hasAttribute(
+      'data-label-hidden',
+      'Label is hidden, yes',
+      'passes labelHidden through to `polaris-choice` component'
+    );
+    choices.hasAttribute(
+      'data-help-text',
+      'Help!',
+      'passes helpText through to `polaris-choice` component'
+    );
+
+    // Check the wrapper element.
+    assert
+      .dom(radioButtonSelector)
+      .exists({ count: 1 }, 'renders one radio button wrapper');
+
+    // Check the input.
+    const inputs = assert.dom(radioButtonInputSelector);
+
+    inputs.exists({ count: 1 }, 'renders one radio input');
+
+    inputs.hasAttribute(
+      'id',
+      'some-radio-button-id',
+      'radio input has the right id'
+    );
+    inputs.hasAttribute('name', 'Radio', 'radio input has the right name');
+    inputs.hasValue('gaga', 'radio input has the right value');
+
+    assert
+      .dom(radioButtonBackdropSelector)
+      .exists({ count: 1 }, 'renders one radio button backdrop');
+
+    assert
+      .dom(radioButtonIconSelector)
+      .exists({ count: 1 }, 'renders one radio button icon wrapper');
+  });
+
+  test('it handles the disabled attribute correctly', async function(assert) {
+    this.set('disabled', true);
+    await render(hbs`{{polaris-radio-button disabled=disabled}}`);
+
+    const input = assert.dom(radioButtonInputSelector);
+    input.exists('renders the input');
+    input.isDisabled('radio input is disabled when disabled is true');
+
+    this.set('disabled', false);
+    input.isNotDisabled('radio input is not disabled when disabled is false');
+  });
+
+  test("it sets the input's aria-describedby attribute correctly", async function(assert) {
+    this.set('helpText', 'some help text');
+    await render(hbs`
+      {{polaris-radio-button
+        inputId="described-radio-button"
+        helpText=helpText
+      }}
+    `);
+
+    const input = assert.dom(radioButtonInputSelector);
+    input.exists('renders the input');
+
+    input.hasAttribute(
+      'aria-describedby',
+      'described-radio-buttonHelpText',
+      'described by help text element when help text is present'
+    );
+
+    this.set('helpText', null);
+
+    input.doesNotHaveAttribute(
+      'aria-describedby',
+      'has no description when help text is present'
+    );
+  });
+
+  test('it handles events correctly', async function(assert) {
+    this.setProperties({
+      selectedValue: 'none',
+      focusFired: false,
+      blurFired: false,
+    });
+
+    await render(hbs`
+      {{polaris-radio-button
+        value="clicked"
+        onChange=(action (mut selectedValue))
+        onFocus=(action (mut focusFired) true)
+        onBlur=(action (mut blurFired) true)
+      }}
+    `);
+
+    await focus(radioButtonInputSelector);
+    assert.ok(this.get('focusFired'), 'after focus - onFocus fired');
+    assert.notOk(this.get('blurFired'), 'after focus - onBlur not fired');
+
+    await click(radioButtonInputSelector);
+    assert.notOk(this.get('blurFired'), 'after click - onBlur not fired');
+    assert.equal(
+      this.get('selectedValue'),
+      'clicked',
+      'after click - selected value has updated'
+    );
+
+    await blur(radioButtonInputSelector);
+    assert.ok(this.get('blurFired'), 'after blur - onBlur fired');
+  });
 });

--- a/tests/integration/components/polaris-resource-list/bulk-actions-test.js
+++ b/tests/integration/components/polaris-resource-list/bulk-actions-test.js
@@ -52,9 +52,7 @@ module('Integration | Component | polaris-resource-list/bulk-actions', function(
 
   module('actions', function() {
     test('promotedActions render in the last position on intial load', async function(assert) {
-      this.setProperties({
-        promotedActions,
-      });
+      this.setProperties({ promotedActions });
 
       await render(hbs`
         {{polaris-resource-list/bulk-actions
@@ -65,16 +63,18 @@ module('Integration | Component | polaris-resource-list/bulk-actions', function(
 
       let allActionsButtons = findAll(actionsButtonGroupButtonsSelector);
 
-      assert.equal(
-        allActionsButtons[0].textContent.trim(),
-        'button 1',
-        'first promoted action is the first button rendered'
-      );
-      assert.equal(
-        allActionsButtons[1].textContent.trim(),
-        'button 2',
-        'second promoted action is the second button rendered'
-      );
+      assert
+        .dom(allActionsButtons[0])
+        .hasText(
+          'button 1',
+          'first promoted action is the first button rendered'
+        );
+      assert
+        .dom(allActionsButtons[1])
+        .hasText(
+          'button 2',
+          'second promoted action is the second button rendered'
+        );
     });
 
     test('actionsCollection actions render in the first position on initial load', async function(assert) {
@@ -91,24 +91,19 @@ module('Integration | Component | polaris-resource-list/bulk-actions', function(
         }}
       `);
 
-      assert
-        .dom(actionsButtonGroupSelector)
-        .doesNotIncludeText(
-          'button 3',
-          'non promoted actions are not rendered (button 3)'
-        );
-      assert
-        .dom(actionsButtonGroupSelector)
-        .doesNotIncludeText(
-          'button 4',
-          'non promoted actions are not rendered (button 4)'
-        );
-      assert
-        .dom(actionsButtonGroupSelector)
-        .doesNotIncludeText(
-          'button 5',
-          'non promoted actions are not rendered (button 5)'
-        );
+      const actionBtn = assert.dom(actionsButtonGroupSelector);
+      actionBtn.doesNotIncludeText(
+        'button 3',
+        'non promoted actions are not rendered (button 3)'
+      );
+      actionBtn.doesNotIncludeText(
+        'button 4',
+        'non promoted actions are not rendered (button 4)'
+      );
+      actionBtn.doesNotIncludeText(
+        'button 5',
+        'non promoted actions are not rendered (button 5)'
+      );
     });
 
     test('it renders a popover', async function(assert) {
@@ -163,11 +158,7 @@ module('Integration | Component | polaris-resource-list/bulk-actions', function(
         );
       assert
         .dom(checkableButtonCheckboxSelector)
-        .hasAttribute(
-          'disabled',
-          '',
-          'disabled is passed down into checkable-button'
-        );
+        .isDisabled('disabled is passed down into checkable-button');
     });
 
     test('renders a button for actions and one for each item in promotedActions', async function(assert) {

--- a/tests/integration/components/polaris-setting-toggle-test.js
+++ b/tests/integration/components/polaris-setting-toggle-test.js
@@ -1,200 +1,183 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { findAll, find, click } from 'ember-native-dom-helpers';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
-moduleForComponent(
-  'polaris-setting-toggle',
-  'Integration | Component | polaris setting toggle',
-  {
-    integration: true,
-  }
-);
+module('Integration | Component | polaris setting toggle', function(hooks) {
+  setupRenderingTest(hooks);
 
-const settingActionSelector = buildNestedSelector(
-  'div.Polaris-Card',
-  'div.Polaris-Card__Section',
-  'div.Polaris-SettingAction'
-);
-const settingActionSettingSelector = buildNestedSelector(
-  settingActionSelector,
-  'div.Polaris-SettingAction__Setting'
-);
-const settingActionWrapperSelector = buildNestedSelector(
-  settingActionSelector,
-  'div.Polaris-SettingAction__Action'
-);
-const settingActionButtonSelector = buildNestedSelector(
-  settingActionWrapperSelector,
-  'button.Polaris-Button'
-);
-
-test('it renders the correct HTML in inline usage with default attributes', function(assert) {
-  this.render(hbs`{{polaris-setting-toggle text="Inline setting toggle"}}`);
-
-  const settingActions = findAll(settingActionSelector);
-  assert.equal(settingActions.length, 1, 'renders one setting action');
-
-  const settingActionSettings = findAll(settingActionSettingSelector);
-  assert.equal(
-    settingActionSettings.length,
-    1,
-    'renders one setting action setting'
+  const settingActionSelector = buildNestedSelector(
+    'div.Polaris-Card',
+    'div.Polaris-Card__Section',
+    'div.Polaris-SettingAction'
   );
-  assert.equal(
-    settingActionSettings[0].textContent.trim(),
-    'Inline setting toggle',
-    'renders the correct setting action setting text'
+  const settingActionSettingSelector = buildNestedSelector(
+    settingActionSelector,
+    'div.Polaris-SettingAction__Setting'
+  );
+  const settingActionWrapperSelector = buildNestedSelector(
+    settingActionSelector,
+    'div.Polaris-SettingAction__Action'
+  );
+  const settingActionButtonSelector = buildNestedSelector(
+    settingActionWrapperSelector,
+    'button.Polaris-Button'
   );
 
-  const settingActionWrappers = findAll(settingActionWrapperSelector);
-  assert.equal(
-    settingActionWrappers.length,
-    1,
-    'renders one setting action wrapper'
-  );
+  test('it renders the correct HTML in inline usage with default attributes', async function(assert) {
+    await render(hbs`{{polaris-setting-toggle text="Inline setting toggle"}}`);
 
-  const settingActionButtons = findAll(settingActionButtonSelector);
-  assert.equal(
-    settingActionButtons.length,
-    0,
-    'does not render any setting action buttons'
-  );
-});
+    assert
+      .dom(settingActionSelector)
+      .exists({ count: 1 }, 'renders one setting action');
 
-test('it renders the correct HTML in block usage with action supplied', function(assert) {
-  this.render(hbs`
-    {{#polaris-setting-toggle
-      action=(hash
-        text="Take action!"
-      )
-    }}
-      Block setting toggle
-    {{/polaris-setting-toggle}}
-  `);
+    const settingActionSettings = assert.dom(settingActionSettingSelector);
+    settingActionSettings.exists(
+      { count: 1 },
+      'renders one setting action setting'
+    );
+    settingActionSettings.hasText(
+      'Inline setting toggle',
+      'renders the correct setting action setting text'
+    );
 
-  const settingActions = findAll(settingActionSelector);
-  assert.equal(settingActions.length, 1, 'renders one setting action');
+    assert
+      .dom(settingActionWrapperSelector)
+      .exists({ count: 1 }, 'renders one setting action wrapper');
 
-  const settingActionSettings = findAll(settingActionSettingSelector);
-  assert.equal(
-    settingActionSettings.length,
-    1,
-    'renders one setting action setting'
-  );
-  assert.equal(
-    settingActionSettings[0].textContent.trim(),
-    'Block setting toggle',
-    'renders the correct setting action setting content'
-  );
-
-  const settingActionWrappers = findAll(settingActionWrapperSelector);
-  assert.equal(
-    settingActionWrappers.length,
-    1,
-    'renders one setting action wrapper'
-  );
-
-  const settingActionButtons = findAll(settingActionButtonSelector);
-  assert.equal(
-    settingActionButtons.length,
-    1,
-    'renders one setting action button'
-  );
-
-  const settingActionButton = settingActionButtons[0];
-  assert.equal(
-    settingActionButton.textContent.trim(),
-    'Take action!',
-    'renders the correct setting action button content'
-  );
-  assert.notOk(
-    settingActionButton.classList.contains('Polaris-Button--primary'),
-    'renders plain setting action button'
-  );
-});
-
-test('it handles the enabled attribute correctly', function(assert) {
-  this.set('enabled', true);
-  this.render(hbs`
-    {{polaris-setting-toggle
-      enabled=enabled
-      action=(hash
-        text="Flip the switch"
-      )
-    }}
-  `);
-
-  const settingActionButton = find(settingActionButtonSelector);
-  assert.ok(settingActionButton, 'renders the setting action button');
-  assert.equal(
-    settingActionButton.textContent.trim(),
-    'Flip the switch',
-    'renders the correct setting action button content'
-  );
-
-  assert.ok(
-    settingActionButton.classList.contains('Polaris-Button--primary'),
-    'with enabled true - renders primary setting action button'
-  );
-
-  this.set('enabled', false);
-  assert.notOk(
-    settingActionButton.classList.contains('Polaris-Button--primary'),
-    'with enabled false - renders plain setting action button'
-  );
-});
-
-test('it handles the supplied action correctly', function(assert) {
-  this.set('actionFired', false);
-  this.render(hbs`
-    {{polaris-setting-toggle
-      enabled=enabled
-      action=(hash
-        text="Flip the switch"
-        onAction=(action (mut actionFired) true)
-      )
-    }}
-  `);
-
-  click(settingActionButtonSelector);
-  assert.ok(this.get('actionFired'), 'fires the action when button clicked');
-});
-
-test("it obeys the passed-in action hash's loading and disabled flags", function(assert) {
-  this.setProperties({
-    isLoading: true,
-    isDisabled: false,
+    assert
+      .dom(settingActionButtonSelector)
+      .doesNotExist('does not render any setting action buttons');
   });
 
-  this.render(hbs`
-    {{polaris-setting-toggle
-      action=(hash
-        text="Toggle"
-        loading=isLoading
-        disabled=isDisabled
-        onAction=(action (mut dummy))
-      )
-    }}
-  `);
+  test('it renders the correct HTML in block usage with action supplied', async function(assert) {
+    await render(hbs`
+      {{#polaris-setting-toggle
+        action=(hash
+          text="Take action!"
+        )
+      }}
+        Block setting toggle
+      {{/polaris-setting-toggle}}
+    `);
 
-  let button = find(settingActionButtonSelector);
-  assert.ok(
-    button.classList.contains('Polaris-Button--loading'),
-    'button is in loading state when loading is true'
-  );
+    assert
+      .dom(settingActionSelector)
+      .exists({ count: 1 }, 'renders one setting action');
 
-  this.setProperties({
-    isLoading: false,
-    isDisabled: true,
+    const settingActionSettings = assert.dom(settingActionSettingSelector);
+    settingActionSettings.exists(
+      { count: 1 },
+      'renders one setting action setting'
+    );
+    settingActionSettings.hasText(
+      'Block setting toggle',
+      'renders the correct setting action setting content'
+    );
+
+    assert
+      .dom(settingActionWrapperSelector)
+      .exists({ count: 1 }, 'renders one setting action wrapper');
+
+    const settingActionButtons = assert.dom(settingActionButtonSelector);
+
+    settingActionButtons.exists(
+      { count: 1 },
+      'renders one setting action button'
+    );
+
+    settingActionButtons.hasText(
+      'Take action!',
+      'renders the correct setting action button content'
+    );
+    settingActionButtons.hasNoClass(
+      'Polaris-Button--primary',
+      'renders plain setting action button'
+    );
   });
 
-  assert.ok(
-    button.classList.contains('Polaris-Button--disabled'),
-    'button is in disabled state when disabled is true'
-  );
-  assert.notOk(
-    button.classList.contains('Polaris-Button--loading'),
-    'button is not in loading state when loading is false'
-  );
+  test('it handles the enabled attribute correctly', async function(assert) {
+    this.set('enabled', true);
+    await render(hbs`
+      {{polaris-setting-toggle
+        enabled=enabled
+        action=(hash
+          text="Flip the switch"
+        )
+      }}
+    `);
+
+    const settingActionButton = assert.dom(settingActionButtonSelector);
+    settingActionButton.exists('renders the setting action button');
+    settingActionButton.hasText(
+      'Flip the switch',
+      'renders the correct setting action button content'
+    );
+
+    settingActionButton.hasClass(
+      'Polaris-Button--primary',
+      'with enabled true - renders primary setting action button'
+    );
+
+    this.set('enabled', false);
+    settingActionButton.hasNoClass(
+      'Polaris-Button--primary',
+      'with enabled false - renders plain setting action button'
+    );
+  });
+
+  test('it handles the supplied action correctly', async function(assert) {
+    this.set('actionFired', false);
+    await render(hbs`
+      {{polaris-setting-toggle
+        enabled=enabled
+        action=(hash
+          text="Flip the switch"
+          onAction=(action (mut actionFired) true)
+        )
+      }}
+    `);
+
+    await click(settingActionButtonSelector);
+    assert.ok(this.get('actionFired'), 'fires the action when button clicked');
+  });
+
+  test("it obeys the passed-in action hash's loading and disabled flags", async function(assert) {
+    this.setProperties({
+      isLoading: true,
+      isDisabled: false,
+    });
+
+    await render(hbs`
+      {{polaris-setting-toggle
+        action=(hash
+          text="Toggle"
+          loading=isLoading
+          disabled=isDisabled
+          onAction=(action (mut dummy))
+        )
+      }}
+    `);
+
+    let button = assert.dom(settingActionButtonSelector);
+    button.hasClass(
+      'Polaris-Button--loading',
+      'button is in loading state when loading is true'
+    );
+
+    this.setProperties({
+      isLoading: false,
+      isDisabled: true,
+    });
+
+    button.hasClass(
+      'Polaris-Button--disabled',
+      'button is in disabled state when disabled is true'
+    );
+    button.hasNoClass(
+      'Polaris-Button--loading',
+      'button is not in loading state when loading is false'
+    );
+  });
 });

--- a/tests/integration/components/polaris-skeleton-body-text-test.js
+++ b/tests/integration/components/polaris-skeleton-body-text-test.js
@@ -1,53 +1,49 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { findAll } from 'ember-native-dom-helpers';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
-moduleForComponent(
-  'polaris-skeleton-body-text',
-  'Integration | Component | polaris skeleton body text',
-  {
-    integration: true,
-  }
-);
+module('Integration | Component | polaris skeleton body text', function(hooks) {
+  setupRenderingTest(hooks);
 
-const containerSelector =
-  'div.Polaris-SkeletonBodyText__SkeletonBodyTextContainer';
-const lineSelector = buildNestedSelector(
-  containerSelector,
-  'div.Polaris-SkeletonBodyText'
-);
-
-test('it renders the specified number of lines', function(assert) {
-  this.render(hbs`{{polaris-skeleton-body-text lines=lines}}`);
-
-  let containers = findAll(containerSelector);
-  assert.equal(
-    containers.length,
-    1,
-    'renders one skeleton body text container'
+  const containerSelector =
+    'div.Polaris-SkeletonBodyText__SkeletonBodyTextContainer';
+  const lineSelector = buildNestedSelector(
+    containerSelector,
+    'div.Polaris-SkeletonBodyText'
   );
 
-  let lines = findAll(lineSelector);
-  assert.equal(
-    lines.length,
-    3,
-    'lines not specified - renders three skeleton body text lines'
-  );
+  test('it renders the specified number of lines', async function(assert) {
+    await render(hbs`{{polaris-skeleton-body-text lines=lines}}`);
 
-  this.set('lines', 1);
-  lines = findAll(lineSelector);
-  assert.equal(
-    lines.length,
-    1,
-    'lines set to 1 - renders one skeleton body text line'
-  );
+    assert
+      .dom(containerSelector)
+      .exists({ count: 1 }, 'renders one skeleton body text container');
 
-  this.set('lines', 5);
-  lines = findAll(lineSelector);
-  assert.equal(
-    lines.length,
-    5,
-    'lines set to 5 - renders five skeleton body text lines'
-  );
+    assert
+      .dom(lineSelector)
+      .exists(
+        { count: 3 },
+        'lines not specified - renders three skeleton body text lines'
+      );
+
+    this.set('lines', 1);
+
+    assert
+      .dom(lineSelector)
+      .exists(
+        { count: 1 },
+        'lines set to 1 - renders one skeleton body text line'
+      );
+
+    this.set('lines', 5);
+
+    assert
+      .dom(lineSelector)
+      .exists(
+        { count: 5 },
+        'lines set to 5 - renders five skeleton body text lines'
+      );
+  });
 });

--- a/tests/integration/components/polaris-skeleton-display-text-test.js
+++ b/tests/integration/components/polaris-skeleton-display-text-test.js
@@ -1,128 +1,126 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { findAll } from 'ember-native-dom-helpers';
 
-moduleForComponent(
-  'polaris-skeleton-display-text',
-  'Integration | Component | polaris skeleton display text',
-  {
-    integration: true,
-  }
-);
+module('Integration | Component | polaris skeleton display text', function(
+  hooks
+) {
+  setupRenderingTest(hooks);
 
-const textSelector = 'div.Polaris-SkeletonDisplayText__DisplayText';
+  const textSelector = 'div.Polaris-SkeletonDisplayText__DisplayText';
 
-test('it renders the correct size', function(assert) {
-  this.render(hbs`{{polaris-skeleton-display-text size=size}}`);
+  test('it renders the correct size', async function(assert) {
+    await render(hbs`{{polaris-skeleton-display-text size=size}}`);
 
-  let texts = findAll(textSelector);
-  assert.equal(texts.length, 1, 'renders one skeleton display text');
+    let text = assert.dom(textSelector);
+    text.exists({ count: 1 }, 'renders one skeleton display text');
 
-  let text = texts[0];
-  assert.notOk(
-    text.classList.contains('Polaris-SkeletonDisplayText--sizeSmall'),
-    'size unset - does not apply small size'
-  );
-  assert.ok(
-    text.classList.contains('Polaris-SkeletonDisplayText--sizeMedium'),
-    'size unset - applies medium size'
-  );
-  assert.notOk(
-    text.classList.contains('Polaris-SkeletonDisplayText--sizeLarge'),
-    'size unset - does not apply large size'
-  );
-  assert.notOk(
-    text.classList.contains('Polaris-SkeletonDisplayText--sizeExtraLarge'),
-    'size unset - does not apply extra-large size'
-  );
+    text.hasNoClass(
+      'Polaris-SkeletonDisplayText--sizeSmall',
+      'size unset - does not apply small size'
+    );
+    text.hasClass(
+      'Polaris-SkeletonDisplayText--sizeMedium',
+      'size unset - applies medium size'
+    );
+    text.hasNoClass(
+      'Polaris-SkeletonDisplayText--sizeLarge',
+      'size unset - does not apply large size'
+    );
+    text.hasNoClass(
+      'Polaris-SkeletonDisplayText--sizeExtraLarge',
+      'size unset - does not apply extra-large size'
+    );
 
-  this.set('size', 'small');
-  assert.ok(
-    text.classList.contains('Polaris-SkeletonDisplayText--sizeSmall'),
-    'size small - applies small class'
-  );
-  assert.notOk(
-    text.classList.contains('Polaris-SkeletonDisplayText--sizeMedium'),
-    'size small - does not apply medium class'
-  );
-  assert.notOk(
-    text.classList.contains('Polaris-SkeletonDisplayText--sizeLarge'),
-    'size small - does not apply large class'
-  );
-  assert.notOk(
-    text.classList.contains('Polaris-SkeletonDisplayText--sizeExtraLarge'),
-    'size small - does not apply extra-large class'
-  );
+    this.set('size', 'small');
+    text.hasClass(
+      'Polaris-SkeletonDisplayText--sizeSmall',
+      'size small - applies small class'
+    );
+    text.hasNoClass(
+      'Polaris-SkeletonDisplayText--sizeMedium',
+      'size small - does not apply medium class'
+    );
+    text.hasNoClass(
+      'Polaris-SkeletonDisplayText--sizeLarge',
+      'size small - does not apply large class'
+    );
+    text.hasNoClass(
+      'Polaris-SkeletonDisplayText--sizeExtraLarge',
+      'size small - does not apply extra-large class'
+    );
 
-  this.set('size', 'medium');
-  assert.notOk(
-    text.classList.contains('Polaris-SkeletonDisplayText--sizeSmall'),
-    'size medium - does not apply small class'
-  );
-  assert.ok(
-    text.classList.contains('Polaris-SkeletonDisplayText--sizeMedium'),
-    'size medium - applies medium class'
-  );
-  assert.notOk(
-    text.classList.contains('Polaris-SkeletonDisplayText--sizeLarge'),
-    'size medium - does not apply large class'
-  );
-  assert.notOk(
-    text.classList.contains('Polaris-SkeletonDisplayText--sizeExtraLarge'),
-    'size medium - does not apply extra-large class'
-  );
+    this.set('size', 'medium');
+    text.hasNoClass(
+      'Polaris-SkeletonDisplayText--sizeSmall',
+      'size medium - does not apply small class'
+    );
+    text.hasClass(
+      'Polaris-SkeletonDisplayText--sizeMedium',
+      'size medium - applies medium class'
+    );
+    text.hasNoClass(
+      'Polaris-SkeletonDisplayText--sizeLarge',
+      'size medium - does not apply large class'
+    );
+    text.hasNoClass(
+      'Polaris-SkeletonDisplayText--sizeExtraLarge',
+      'size medium - does not apply extra-large class'
+    );
 
-  this.set('size', 'large');
-  assert.notOk(
-    text.classList.contains('Polaris-SkeletonDisplayText--sizeSmall'),
-    'size large - does not apply small class'
-  );
-  assert.notOk(
-    text.classList.contains('Polaris-SkeletonDisplayText--sizeMedium'),
-    'size large - does not apply medium class'
-  );
-  assert.ok(
-    text.classList.contains('Polaris-SkeletonDisplayText--sizeLarge'),
-    'size large - applies large class'
-  );
-  assert.notOk(
-    text.classList.contains('Polaris-SkeletonDisplayText--sizeExtraLarge'),
-    'size large - does not apply extra-large class'
-  );
+    this.set('size', 'large');
+    text.hasNoClass(
+      'Polaris-SkeletonDisplayText--sizeSmall',
+      'size large - does not apply small class'
+    );
+    text.hasNoClass(
+      'Polaris-SkeletonDisplayText--sizeMedium',
+      'size large - does not apply medium class'
+    );
+    text.hasClass(
+      'Polaris-SkeletonDisplayText--sizeLarge',
+      'size large - applies large class'
+    );
+    text.hasNoClass(
+      'Polaris-SkeletonDisplayText--sizeExtraLarge',
+      'size large - does not apply extra-large class'
+    );
 
-  this.set('size', 'extraLarge');
-  assert.notOk(
-    text.classList.contains('Polaris-SkeletonDisplayText--sizeSmall'),
-    'size extra-large - does not apply small class'
-  );
-  assert.notOk(
-    text.classList.contains('Polaris-SkeletonDisplayText--sizeMedium'),
-    'size extra-large - does not apply medium class'
-  );
-  assert.notOk(
-    text.classList.contains('Polaris-SkeletonDisplayText--sizeLarge'),
-    'size extra-large - does not apply large class'
-  );
-  assert.ok(
-    text.classList.contains('Polaris-SkeletonDisplayText--sizeExtraLarge'),
-    'size extra-large - applies extra-large class'
-  );
+    this.set('size', 'extraLarge');
+    text.hasNoClass(
+      'Polaris-SkeletonDisplayText--sizeSmall',
+      'size extra-large - does not apply small class'
+    );
+    text.hasNoClass(
+      'Polaris-SkeletonDisplayText--sizeMedium',
+      'size extra-large - does not apply medium class'
+    );
+    text.hasNoClass(
+      'Polaris-SkeletonDisplayText--sizeLarge',
+      'size extra-large - does not apply large class'
+    );
+    text.hasClass(
+      'Polaris-SkeletonDisplayText--sizeExtraLarge',
+      'size extra-large - applies extra-large class'
+    );
 
-  this.set('size', 'unsupported');
-  assert.notOk(
-    text.classList.contains('Polaris-SkeletonDisplayText--sizeSmall'),
-    'size unsupported - does not apply small size'
-  );
-  assert.ok(
-    text.classList.contains('Polaris-SkeletonDisplayText--sizeMedium'),
-    'size unsupported - applies medium size'
-  );
-  assert.notOk(
-    text.classList.contains('Polaris-SkeletonDisplayText--sizeLarge'),
-    'size unsupported - does not apply large size'
-  );
-  assert.notOk(
-    text.classList.contains('Polaris-SkeletonDisplayText--sizeExtraLarge'),
-    'size unsupported - does not apply extra-large size'
-  );
+    this.set('size', 'unsupported');
+    text.hasNoClass(
+      'Polaris-SkeletonDisplayText--sizeSmall',
+      'size unsupported - does not apply small size'
+    );
+    text.hasClass(
+      'Polaris-SkeletonDisplayText--sizeMedium',
+      'size unsupported - applies medium size'
+    );
+    text.hasNoClass(
+      'Polaris-SkeletonDisplayText--sizeLarge',
+      'size unsupported - does not apply large size'
+    );
+    text.hasNoClass(
+      'Polaris-SkeletonDisplayText--sizeExtraLarge',
+      'size unsupported - does not apply extra-large size'
+    );
+  });
 });

--- a/tests/integration/components/polaris-stack-test.js
+++ b/tests/integration/components/polaris-stack-test.js
@@ -1,285 +1,329 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { findAll, find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { findAll, find } from 'ember-native-dom-helpers';
 
-moduleForComponent('polaris-stack', 'Integration | Component | polaris stack', {
-  integration: true,
-});
+module('Integration | Component | polaris stack', function(hooks) {
+  setupRenderingTest(hooks);
 
-const stackSelector = 'div.Polaris-Stack';
-const stackItemSelector = 'div.Polaris-Stack__Item';
+  const stackSelector = 'div.Polaris-Stack';
+  const stackItemSelector = 'div.Polaris-Stack__Item';
 
-test('it renders the correct HTML with default attributes', function(assert) {
-  this.render(hbs`
-    {{#polaris-stack}}
-      <p>Paragraph</p>
-      <div>
-        Outer div
-        <div>Inner div</div>
-      </div>
-    {{/polaris-stack}}
-  `);
+  test('it renders the correct HTML with default attributes', async function(assert) {
+    await render(hbs`
+      {{#polaris-stack}}
+        <p>Paragraph</p>
+        <div>
+          Outer div
+          <div>Inner div</div>
+        </div>
+      {{/polaris-stack}}
+    `);
 
-  const stacks = findAll(stackSelector);
-  assert.equal(stacks.length, 1, 'renders the correct number of stacks');
+    const stacks = findAll(stackSelector);
+    assert.equal(stacks.length, 1, 'renders the correct number of stacks');
 
-  const stackItems = findAll(stackItemSelector);
-  assert.equal(
-    stackItems.length,
-    2,
-    'renders the correct number of stack items'
-  );
+    const stackItems = findAll(stackItemSelector);
+    assert.equal(
+      stackItems.length,
+      2,
+      'renders the correct number of stack items'
+    );
 
-  // Check the first stack item.
-  let stackItem = stackItems[0];
-  let stackItemChildren = stackItem.children;
-  assert.equal(
-    stackItemChildren.length,
-    1,
-    'first stack item - renders the correct number of children'
-  );
+    // Check the first stack item.
+    let stackItem = stackItems[0];
+    let stackItemChildren = stackItem.children;
+    assert.equal(
+      stackItemChildren.length,
+      1,
+      'first stack item - renders the correct number of children'
+    );
 
-  let stackItemChild = stackItemChildren[0];
-  assert.equal(
-    stackItemChild.tagName.toLowerCase(),
-    'p',
-    'first stack item - renders the correct child element'
-  );
-  assert.equal(
-    stackItemChild.textContent.trim(),
-    'Paragraph',
-    'first stack item - renders the correct child content'
-  );
+    let stackItemChild = stackItemChildren[0];
+    assert.equal(
+      stackItemChild.tagName.toLowerCase(),
+      'p',
+      'first stack item - renders the correct child element'
+    );
+    assert
+      .dom(stackItemChild)
+      .hasText(
+        'Paragraph',
+        'first stack item - renders the correct child content'
+      );
 
-  // Check the second stack item.
-  stackItem = stackItems[1];
-  stackItemChildren = stackItem.children;
-  assert.equal(
-    stackItemChildren.length,
-    1,
-    'second stack item - renders the correct number of children'
-  );
+    // Check the second stack item.
+    stackItem = stackItems[1];
+    stackItemChildren = stackItem.children;
+    assert.equal(
+      stackItemChildren.length,
+      1,
+      'second stack item - renders the correct number of children'
+    );
 
-  stackItemChild = stackItemChildren[0];
-  assert.equal(
-    stackItemChild.tagName.toLowerCase(),
-    'div',
-    'second stack item - renders the correct child element'
-  );
-  assert.ok(
-    stackItemChild.textContent.trim().indexOf('Outer div') > -1,
-    'second stack item - renders the correct child content'
-  );
-});
+    stackItemChild = stackItemChildren[0];
+    assert.equal(
+      stackItemChild.tagName.toLowerCase(),
+      'div',
+      'second stack item - renders the correct child element'
+    );
+    assert.ok(
+      stackItemChild.textContent.trim().indexOf('Outer div') > -1,
+      'second stack item - renders the correct child content'
+    );
+  });
 
-test('it renders the correct HTML with vertical attribute', function(assert) {
-  this.set('vertical', true);
-  this.render(hbs`{{polaris-stack vertical=vertical}}`);
+  test('it renders the correct HTML with vertical attribute', async function(assert) {
+    this.set('vertical', true);
+    await render(hbs`{{polaris-stack vertical=vertical}}`);
 
-  const stack = find(stackSelector);
-  assert.ok(
-    stack.classList.contains('Polaris-Stack--vertical'),
-    'vertical=true - adds the vertical class'
-  );
+    const stack = find(stackSelector);
+    assert
+      .dom(stack)
+      .hasClass(
+        'Polaris-Stack--vertical',
+        'vertical=true - adds the vertical class'
+      );
 
-  this.set('vertical', false);
-  assert.notOk(
-    stack.classList.contains('Polaris-Stack--vertical'),
-    'vertical=true - does not add the vertical class'
-  );
-});
+    this.set('vertical', false);
+    assert
+      .dom(stack)
+      .hasNoClass(
+        'Polaris-Stack--vertical',
+        'vertical=true - does not add the vertical class'
+      );
+  });
 
-test('it renders the correct HTML with spacing attribute', function(assert) {
-  this.set('spacing', null);
-  this.render(hbs`{{polaris-stack spacing=spacing}}`);
+  test('it renders the correct HTML with spacing attribute', async function(assert) {
+    this.set('spacing', null);
+    await render(hbs`{{polaris-stack spacing=spacing}}`);
 
-  const stack = find(stackSelector);
-  assert.equal(
-    stack.className.indexOf('Polaris-Stack--spacing'),
-    -1,
-    'spacing=null - does not add any spacing class'
-  );
+    const stack = find(stackSelector);
+    assert.equal(
+      stack.className.indexOf('Polaris-Stack--spacing'),
+      -1,
+      'spacing=null - does not add any spacing class'
+    );
 
-  this.set('spacing', 'none');
-  assert.ok(
-    stack.classList.contains('Polaris-Stack--spacingNone'),
-    'spacing=none - adds the correct spacing class'
-  );
+    this.set('spacing', 'none');
+    assert
+      .dom(stack)
+      .hasClass(
+        'Polaris-Stack--spacingNone',
+        'spacing=none - adds the correct spacing class'
+      );
 
-  this.set('spacing', 'loose');
-  assert.ok(
-    stack.classList.contains('Polaris-Stack--spacingLoose'),
-    'spacing=loose - adds the correct spacing class'
-  );
+    this.set('spacing', 'loose');
+    assert
+      .dom(stack)
+      .hasClass(
+        'Polaris-Stack--spacingLoose',
+        'spacing=loose - adds the correct spacing class'
+      );
 
-  this.set('spacing', 'tight');
-  assert.ok(
-    stack.classList.contains('Polaris-Stack--spacingTight'),
-    'spacing=tight - adds the correct spacing class'
-  );
-});
+    this.set('spacing', 'tight');
+    assert
+      .dom(stack)
+      .hasClass(
+        'Polaris-Stack--spacingTight',
+        'spacing=tight - adds the correct spacing class'
+      );
+  });
 
-test('it renders the correct HTML with alignment attribute', function(assert) {
-  this.set('alignment', null);
-  this.render(hbs`{{polaris-stack alignment=alignment}}`);
+  test('it renders the correct HTML with alignment attribute', async function(assert) {
+    this.set('alignment', null);
+    await render(hbs`{{polaris-stack alignment=alignment}}`);
 
-  const stack = find(stackSelector);
-  assert.equal(
-    stack.className.indexOf('Polaris-Stack--alignment'),
-    -1,
-    'alignment=null - does not add any alignment class'
-  );
+    const stack = find(stackSelector);
+    assert.equal(
+      stack.className.indexOf('Polaris-Stack--alignment'),
+      -1,
+      'alignment=null - does not add any alignment class'
+    );
 
-  this.set('alignment', 'leading');
-  assert.ok(
-    stack.classList.contains('Polaris-Stack--alignmentLeading'),
-    'alignment=leading - adds the correct alignment class'
-  );
+    this.set('alignment', 'leading');
+    assert
+      .dom(stack)
+      .hasClass(
+        'Polaris-Stack--alignmentLeading',
+        'alignment=leading - adds the correct alignment class'
+      );
 
-  this.set('alignment', 'trailing');
-  assert.ok(
-    stack.classList.contains('Polaris-Stack--alignmentTrailing'),
-    'alignment=trailing - adds the correct alignment class'
-  );
+    this.set('alignment', 'trailing');
+    assert
+      .dom(stack)
+      .hasClass(
+        'Polaris-Stack--alignmentTrailing',
+        'alignment=trailing - adds the correct alignment class'
+      );
 
-  this.set('alignment', 'center');
-  assert.ok(
-    stack.classList.contains('Polaris-Stack--alignmentCenter'),
-    'alignment=center - adds the correct alignment class'
-  );
+    this.set('alignment', 'center');
+    assert
+      .dom(stack)
+      .hasClass(
+        'Polaris-Stack--alignmentCenter',
+        'alignment=center - adds the correct alignment class'
+      );
 
-  this.set('alignment', 'fill');
-  assert.ok(
-    stack.classList.contains('Polaris-Stack--alignmentFill'),
-    'alignment=fill - adds the correct alignment class'
-  );
+    this.set('alignment', 'fill');
+    assert
+      .dom(stack)
+      .hasClass(
+        'Polaris-Stack--alignmentFill',
+        'alignment=fill - adds the correct alignment class'
+      );
 
-  this.set('alignment', 'baseline');
-  assert.ok(
-    stack.classList.contains('Polaris-Stack--alignmentBaseline'),
-    'alignment=baseline - adds the correct alignment class'
-  );
-});
+    this.set('alignment', 'baseline');
+    assert
+      .dom(stack)
+      .hasClass(
+        'Polaris-Stack--alignmentBaseline',
+        'alignment=baseline - adds the correct alignment class'
+      );
+  });
 
-test('it renders the correct HTML with distribution attribute', function(assert) {
-  this.set('distribution', 'baseline');
-  this.render(hbs`{{polaris-stack distribution=distribution}}`);
+  test('it renders the correct HTML with distribution attribute', async function(assert) {
+    this.set('distribution', 'baseline');
+    await render(hbs`{{polaris-stack distribution=distribution}}`);
 
-  const stack = find(stackSelector);
-  assert.equal(
-    stack.className.indexOf('Polaris-Stack--distribution'),
-    -1,
-    'distribution=baseline - does not add any distribution class'
-  );
+    const stack = find(stackSelector);
+    assert.equal(
+      stack.className.indexOf('Polaris-Stack--distribution'),
+      -1,
+      'distribution=baseline - does not add any distribution class'
+    );
 
-  this.set('distribution', 'leading');
-  assert.ok(
-    stack.classList.contains('Polaris-Stack--distributionLeading'),
-    'distribution=leading - adds the correct distribution class'
-  );
+    this.set('distribution', 'leading');
+    assert
+      .dom(stack)
+      .hasClass(
+        'Polaris-Stack--distributionLeading',
+        'distribution=leading - adds the correct distribution class'
+      );
 
-  this.set('distribution', 'trailing');
-  assert.ok(
-    stack.classList.contains('Polaris-Stack--distributionTrailing'),
-    'distribution=trailing - adds the correct distribution class'
-  );
+    this.set('distribution', 'trailing');
+    assert
+      .dom(stack)
+      .hasClass(
+        'Polaris-Stack--distributionTrailing',
+        'distribution=trailing - adds the correct distribution class'
+      );
 
-  this.set('distribution', 'center');
-  assert.ok(
-    stack.classList.contains('Polaris-Stack--distributionCenter'),
-    'distribution=center - adds the correct distribution class'
-  );
+    this.set('distribution', 'center');
+    assert
+      .dom(stack)
+      .hasClass(
+        'Polaris-Stack--distributionCenter',
+        'distribution=center - adds the correct distribution class'
+      );
 
-  this.set('distribution', 'fill');
-  assert.ok(
-    stack.classList.contains('Polaris-Stack--distributionFill'),
-    'distribution=fill - adds the correct distribution class'
-  );
+    this.set('distribution', 'fill');
+    assert
+      .dom(stack)
+      .hasClass(
+        'Polaris-Stack--distributionFill',
+        'distribution=fill - adds the correct distribution class'
+      );
 
-  this.set('distribution', 'fillEvenly');
-  assert.ok(
-    stack.classList.contains('Polaris-Stack--distributionFillEvenly'),
-    'distribution=fillEvenly - adds the correct distribution class'
-  );
-});
+    this.set('distribution', 'fillEvenly');
+    assert
+      .dom(stack)
+      .hasClass(
+        'Polaris-Stack--distributionFillEvenly',
+        'distribution=fillEvenly - adds the correct distribution class'
+      );
+  });
 
-test('it renders the correct HTML with wrap attribute', function(assert) {
-  this.render(hbs`{{polaris-stack wrap=wrap}}`);
+  test('it renders the correct HTML with wrap attribute', async function(assert) {
+    await render(hbs`{{polaris-stack wrap=wrap}}`);
 
-  const stack = find(stackSelector);
-  assert.notOk(
-    stack.classList.contains('Polaris-Stack--noWrap'),
-    'wrap=undefined - does not add the no-wrap class'
-  );
+    const stack = find(stackSelector);
+    assert
+      .dom(stack)
+      .hasNoClass(
+        'Polaris-Stack--noWrap',
+        'wrap=undefined - does not add the no-wrap class'
+      );
 
-  this.set('wrap', true);
-  assert.notOk(
-    stack.classList.contains('Polaris-Stack--noWrap'),
-    'wrap=true - does not add the no-wrap class'
-  );
+    this.set('wrap', true);
+    assert
+      .dom(stack)
+      .hasNoClass(
+        'Polaris-Stack--noWrap',
+        'wrap=true - does not add the no-wrap class'
+      );
 
-  this.set('wrap', false);
-  assert.ok(
-    stack.classList.contains('Polaris-Stack--noWrap'),
-    'wrap=false - adds the no-wrap class'
-  );
-});
+    this.set('wrap', false);
+    assert
+      .dom(stack)
+      .hasClass('Polaris-Stack--noWrap', 'wrap=false - adds the no-wrap class');
+  });
 
-test('it renders the correct HTML in block usage', function(assert) {
-  this.render(hbs`
-    {{#polaris-stack as |stack|}}
-      {{#stack.item fill=true}}
-        Block item with fill
-      {{/stack.item}}
+  test('it renders the correct HTML in block usage', async function(assert) {
+    await render(hbs`
+      {{#polaris-stack as |stack|}}
+        {{#stack.item fill=true}}
+          Block item with fill
+        {{/stack.item}}
 
-      {{stack.item text="Inline item"}}
+        {{stack.item text="Inline item"}}
 
-      <div>
-        <p>Paragraph inside a magically wrapped item</p>
-      </div>
-    {{/polaris-stack}}
-  `);
+        <div>
+          <p>Paragraph inside a magically wrapped item</p>
+        </div>
+      {{/polaris-stack}}
+    `);
 
-  const stackItems = findAll(stackItemSelector);
-  assert.equal(
-    stackItems.length,
-    3,
-    'renders the correct number of stack items'
-  );
+    const stackItems = findAll(stackItemSelector);
+    assert.equal(
+      stackItems.length,
+      3,
+      'renders the correct number of stack items'
+    );
 
-  // Check the first stack item.
-  let stackItem = stackItems[0];
-  assert.ok(
-    stackItem.classList.contains('Polaris-Stack__Item--fill'),
-    'first stack item - has fill class'
-  );
-  assert.equal(
-    stackItem.textContent.trim(),
-    'Block item with fill',
-    'first stack item - renders the correct content'
-  );
+    // Check the first stack item.
+    let stackItem = stackItems[0];
+    assert
+      .dom(stackItem)
+      .hasClass(
+        'Polaris-Stack__Item--fill',
+        'first stack item - has fill class'
+      );
+    assert
+      .dom(stackItem)
+      .hasText(
+        'Block item with fill',
+        'first stack item - renders the correct content'
+      );
 
-  // Check the second stack item.
-  stackItem = stackItems[1];
-  assert.notOk(
-    stackItem.classList.contains('Polaris-Stack__Item--fill'),
-    'second stack item - does not have fill class'
-  );
-  assert.equal(
-    stackItem.textContent.trim(),
-    'Inline item',
-    'second stack item - renders the correct content'
-  );
+    // Check the second stack item.
+    stackItem = stackItems[1];
+    assert
+      .dom(stackItem)
+      .hasNoClass(
+        'Polaris-Stack__Item--fill',
+        'second stack item - does not have fill class'
+      );
+    assert
+      .dom(stackItem)
+      .hasText(
+        'Inline item',
+        'second stack item - renders the correct content'
+      );
 
-  // Check the third stack item.
-  stackItem = stackItems[2];
-  assert.notOk(
-    stackItem.classList.contains('Polaris-Stack__Item--fill'),
-    'third stack item - does not have fill class'
-  );
-  assert.equal(
-    stackItem.textContent.trim(),
-    'Paragraph inside a magically wrapped item',
-    'third stack item - renders the correct content'
-  );
+    // Check the third stack item.
+    stackItem = stackItems[2];
+    assert
+      .dom(stackItem)
+      .hasNoClass(
+        'Polaris-Stack__Item--fill',
+        'third stack item - does not have fill class'
+      );
+    assert
+      .dom(stackItem)
+      .hasText(
+        'Paragraph inside a magically wrapped item',
+        'third stack item - renders the correct content'
+      );
+  });
 });

--- a/tests/integration/components/polaris-subheading-test.js
+++ b/tests/integration/components/polaris-subheading-test.js
@@ -1,78 +1,70 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { find, findAll } from 'ember-native-dom-helpers';
 
-moduleForComponent(
-  'polaris-subheading',
-  'Integration | Component | polaris subheading',
-  {
-    integration: true,
-  }
-);
+module('Integration | Component | polaris subheading', function(hooks) {
+  setupRenderingTest(hooks);
 
-test('it renders the correct HTML', function(assert) {
-  // Inline form with defaults.
-  this.render(hbs`{{polaris-subheading text="This is a subheading"}}`);
+  test('it renders the correct HTML', async function(assert) {
+    // Inline form with defaults.
+    await render(hbs`{{polaris-subheading text="This is a subheading"}}`);
 
-  let subheadings = findAll('h3.Polaris-Subheading');
-  assert.equal(
-    subheadings.length,
-    1,
-    'inline with defaults - renders one h3 subheading'
-  );
+    let subheading = assert.dom('h3.Polaris-Subheading');
+    subheading.exists(
+      { count: 1 },
+      'inline with defaults - renders one h3 subheading'
+    );
 
-  let subheading = subheadings[0];
-  assert.equal(
-    subheading.textContent.trim(),
-    'This is a subheading',
-    'inline with defaults - renders correct text'
-  );
-  assert.equal(
-    subheading.attributes['aria-label'].value,
-    'This is a subheading',
-    'inline with defaults - adds correct label'
-  );
+    subheading.hasText(
+      'This is a subheading',
+      'inline with defaults - renders correct text'
+    );
+    subheading.hasAttribute(
+      'aria-label',
+      'This is a subheading',
+      'inline with defaults - adds correct label'
+    );
 
-  // Block form with element specified.
-  this.set('subheadingText', 'This is an underlined subheading');
-  this.render(hbs`
-    {{#polaris-subheading tagName="u"}}
-      {{subheadingText}}
-    {{/polaris-subheading}}
-  `);
+    // Block form with element specified.
+    this.set('subheadingText', 'This is an underlined subheading');
+    await render(hbs`
+      {{#polaris-subheading tagName="u"}}
+        {{subheadingText}}
+      {{/polaris-subheading}}
+    `);
 
-  const subheadingSelector = 'u.Polaris-Subheading';
-  subheadings = findAll(subheadingSelector);
-  assert.equal(
-    subheadings.length,
-    1,
-    'block with customisation - renders one underlined subheading'
-  );
+    const subheadingSelector = 'u.Polaris-Subheading';
+    subheading = assert.dom(subheadingSelector);
+    subheading.exists(
+      { count: 1 },
+      'block with customisation - renders one underlined subheading'
+    );
 
-  subheading = subheadings[0];
-  assert.equal(
-    subheading.textContent.trim(),
-    'This is an underlined subheading',
-    'block with customisation - renders correct text'
-  );
-  assert.equal(
-    subheading.attributes['aria-label'].value,
-    'This is an underlined subheading',
-    'block with customisation - adds correct label'
-  );
+    subheading.hasText(
+      'This is an underlined subheading',
+      'block with customisation - renders correct text'
+    );
 
-  // Update the content of the subheading.
-  this.set('subheadingText', 'This is an updated subheading');
+    subheading.hasAttribute(
+      'aria-label',
+      'This is an underlined subheading',
+      'block with customisation - adds correct label'
+    );
 
-  subheading = find(subheadingSelector);
-  assert.equal(
-    subheading.textContent.trim(),
-    'This is an updated subheading',
-    'updating block content - updates text'
-  );
-  assert.equal(
-    subheading.attributes['aria-label'].value,
-    'This is an updated subheading',
-    'updating block content - updates label'
-  );
+    // Update the content of the subheading.
+    this.set('subheadingText', 'This is an updated subheading');
+
+    subheading = assert.dom(subheadingSelector);
+    subheading.hasText(
+      'This is an updated subheading',
+      'updating block content - updates text'
+    );
+
+    subheading.hasAttribute(
+      'aria-label',
+      'This is an updated subheading',
+      'updating block content - updates label'
+    );
+  });
 });

--- a/tests/integration/components/polaris-text-container-test.js
+++ b/tests/integration/components/polaris-text-container-test.js
@@ -1,86 +1,98 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { findAll } from 'ember-native-dom-helpers';
 
-moduleForComponent(
-  'polaris-text-container',
-  'Integration | Component | polaris text container',
-  {
-    integration: true,
-  }
-);
+module('Integration | Component | polaris text container', function(hooks) {
+  setupRenderingTest(hooks);
 
-const textContainerSelector = 'div.Polaris-TextContainer';
+  const textContainerSelector = 'div.Polaris-TextContainer';
 
-test('it renders the correct HTML in inline form', function(assert) {
-  this.render(hbs`{{polaris-text-container text="This is some inline text"}}`);
+  test('it renders the correct HTML in inline form', async function(assert) {
+    await render(
+      hbs`{{polaris-text-container text="This is some inline text"}}`
+    );
 
-  const textContainers = findAll(textContainerSelector);
-  assert.equal(textContainers.length, 1, 'renders one text container');
-  assert.equal(
-    textContainers[0].textContent.trim(),
-    'This is some inline text',
-    'renders the correct content'
-  );
-});
+    const textContainer = assert.dom(textContainerSelector);
+    textContainer.exists({ count: 1 }, 'renders one text container');
+    textContainer.hasText(
+      'This is some inline text',
+      'renders the correct content'
+    );
+  });
 
-test('it renders the correct HTML in block form', function(assert) {
-  this.render(
-    hbs`{{#polaris-text-container}}This is some block text{{/polaris-text-container}}`
-  );
+  test('it renders the correct HTML in block form', async function(assert) {
+    await render(
+      hbs`{{#polaris-text-container}}This is some block text{{/polaris-text-container}}`
+    );
 
-  const textContainers = findAll(textContainerSelector);
-  assert.equal(textContainers.length, 1, 'renders one text container');
-  assert.equal(
-    textContainers[0].textContent.trim(),
-    'This is some block text',
-    'renders the correct content'
-  );
-});
+    const textContainer = assert.dom(textContainerSelector);
+    textContainer.exists({ count: 1 }, 'renders one text container');
+    textContainer.hasText(
+      'This is some block text',
+      'renders the correct content'
+    );
+  });
 
-test('it handles spacing correctly', function(assert) {
-  this.render(hbs`{{polaris-text-container spacing=spacing}}`);
+  test('it handles spacing correctly', async function(assert) {
+    await render(hbs`{{polaris-text-container spacing=spacing}}`);
 
-  const textContainers = findAll(textContainerSelector);
-  assert.equal(textContainers.length, 1, 'renders one text container');
+    const textContainer = assert.dom(textContainerSelector);
+    textContainer.exists({ count: 1 }, 'renders one text container');
 
-  const textContainer = textContainers[0];
-  assert.notOk(
-    textContainer.classList.contains('Polaris-TextContainer--spacingLoose'),
-    'unset spacing - does not apply loose spacing class'
-  );
-  assert.notOk(
-    textContainer.classList.contains('Polaris-TextContainer--spacingTight'),
-    'unset spacing - does not apply tight spacing class'
-  );
+    assert
+      .dom(textContainer)
+      .hasNoClass(
+        'Polaris-TextContainer--spacingLoose',
+        'unset spacing - does not apply loose spacing class'
+      );
+    assert
+      .dom(textContainer)
+      .hasNoClass(
+        'Polaris-TextContainer--spacingTight',
+        'unset spacing - does not apply tight spacing class'
+      );
 
-  this.set('spacing', 'loose');
-  assert.ok(
-    textContainer.classList.contains('Polaris-TextContainer--spacingLoose'),
-    'loose spacing - applies loose spacing class'
-  );
-  assert.notOk(
-    textContainer.classList.contains('Polaris-TextContainer--spacingTight'),
-    'loose spacing - does not apply tight spacing class'
-  );
+    this.set('spacing', 'loose');
+    assert
+      .dom(textContainer)
+      .hasClass(
+        'Polaris-TextContainer--spacingLoose',
+        'loose spacing - applies loose spacing class'
+      );
+    assert
+      .dom(textContainer)
+      .hasNoClass(
+        'Polaris-TextContainer--spacingTight',
+        'loose spacing - does not apply tight spacing class'
+      );
 
-  this.set('spacing', 'tight');
-  assert.notOk(
-    textContainer.classList.contains('Polaris-TextContainer--spacingLoose'),
-    'tight spacing - does not apply loose spacing class'
-  );
-  assert.ok(
-    textContainer.classList.contains('Polaris-TextContainer--spacingTight'),
-    'tight spacing - applies tight spacing class'
-  );
+    this.set('spacing', 'tight');
+    assert
+      .dom(textContainer)
+      .hasNoClass(
+        'Polaris-TextContainer--spacingLoose',
+        'tight spacing - does not apply loose spacing class'
+      );
+    assert
+      .dom(textContainer)
+      .hasClass(
+        'Polaris-TextContainer--spacingTight',
+        'tight spacing - applies tight spacing class'
+      );
 
-  this.set('spacing', 'unsupported');
-  assert.notOk(
-    textContainer.classList.contains('Polaris-TextContainer--spacingLoose'),
-    'unsupported spacing - does not apply loose spacing class'
-  );
-  assert.notOk(
-    textContainer.classList.contains('Polaris-TextContainer--spacingTight'),
-    'unsupported spacing - does not apply tight spacing class'
-  );
+    this.set('spacing', 'unsupported');
+    assert
+      .dom(textContainer)
+      .hasNoClass(
+        'Polaris-TextContainer--spacingLoose',
+        'unsupported spacing - does not apply loose spacing class'
+      );
+    assert
+      .dom(textContainer)
+      .hasNoClass(
+        'Polaris-TextContainer--spacingTight',
+        'unsupported spacing - does not apply tight spacing class'
+      );
+  });
 });

--- a/tests/integration/components/polaris-text-container-test.js
+++ b/tests/integration/components/polaris-text-container-test.js
@@ -40,59 +40,43 @@ module('Integration | Component | polaris text container', function(hooks) {
     const textContainer = assert.dom(textContainerSelector);
     textContainer.exists({ count: 1 }, 'renders one text container');
 
-    assert
-      .dom(textContainer)
-      .hasNoClass(
-        'Polaris-TextContainer--spacingLoose',
-        'unset spacing - does not apply loose spacing class'
-      );
-    assert
-      .dom(textContainer)
-      .hasNoClass(
-        'Polaris-TextContainer--spacingTight',
-        'unset spacing - does not apply tight spacing class'
-      );
+    textContainer.hasNoClass(
+      'Polaris-TextContainer--spacingLoose',
+      'unset spacing - does not apply loose spacing class'
+    );
+    textContainer.hasNoClass(
+      'Polaris-TextContainer--spacingTight',
+      'unset spacing - does not apply tight spacing class'
+    );
 
     this.set('spacing', 'loose');
-    assert
-      .dom(textContainer)
-      .hasClass(
-        'Polaris-TextContainer--spacingLoose',
-        'loose spacing - applies loose spacing class'
-      );
-    assert
-      .dom(textContainer)
-      .hasNoClass(
-        'Polaris-TextContainer--spacingTight',
-        'loose spacing - does not apply tight spacing class'
-      );
+    textContainer.hasClass(
+      'Polaris-TextContainer--spacingLoose',
+      'loose spacing - applies loose spacing class'
+    );
+    textContainer.hasNoClass(
+      'Polaris-TextContainer--spacingTight',
+      'loose spacing - does not apply tight spacing class'
+    );
 
     this.set('spacing', 'tight');
-    assert
-      .dom(textContainer)
-      .hasNoClass(
-        'Polaris-TextContainer--spacingLoose',
-        'tight spacing - does not apply loose spacing class'
-      );
-    assert
-      .dom(textContainer)
-      .hasClass(
-        'Polaris-TextContainer--spacingTight',
-        'tight spacing - applies tight spacing class'
-      );
+    textContainer.hasNoClass(
+      'Polaris-TextContainer--spacingLoose',
+      'tight spacing - does not apply loose spacing class'
+    );
+    textContainer.hasClass(
+      'Polaris-TextContainer--spacingTight',
+      'tight spacing - applies tight spacing class'
+    );
 
     this.set('spacing', 'unsupported');
-    assert
-      .dom(textContainer)
-      .hasNoClass(
-        'Polaris-TextContainer--spacingLoose',
-        'unsupported spacing - does not apply loose spacing class'
-      );
-    assert
-      .dom(textContainer)
-      .hasNoClass(
-        'Polaris-TextContainer--spacingTight',
-        'unsupported spacing - does not apply tight spacing class'
-      );
+    textContainer.hasNoClass(
+      'Polaris-TextContainer--spacingLoose',
+      'unsupported spacing - does not apply loose spacing class'
+    );
+    textContainer.hasNoClass(
+      'Polaris-TextContainer--spacingTight',
+      'unsupported spacing - does not apply tight spacing class'
+    );
   });
 });

--- a/tests/integration/components/polaris-text-field-test.js
+++ b/tests/integration/components/polaris-text-field-test.js
@@ -50,60 +50,44 @@ module('Integration | Component | polaris-text-field', function(hooks) {
       .dom(buildNestedSelector(textFieldSelector, fieldSelector, inputSelector))
       .exists('renders text field input correctly');
     assert.dom(labelSelector).hasText(label, 'it renders the passed-in label');
-    assert
-      .dom(fieldSelector)
-      .hasClass('Polaris-TextField', 'input wrapper has correct class');
-    assert
-      .dom(fieldSelector)
-      .hasNoClass(
-        'Polaris-TextField--multiline',
-        'input wrapper has no multiline class'
-      );
-    assert
-      .dom(fieldSelector)
-      .hasNoClass(
-        'Polaris-TextField--readOnly',
-        'input wrapper has no readOnly class'
-      );
-    assert
-      .dom(fieldSelector)
-      .hasNoClass(
-        'Polaris-TextField--hasValue',
-        'input wrapper has no value class applied'
-      );
-    assert
-      .dom(fieldSelector)
-      .hasNoClass(
-        'Polaris-TextField--error',
-        'input wrapper has no error class applied'
-      );
-    assert
-      .dom(inputSelector)
-      .hasClass('Polaris-TextField__Input', 'input has correct class');
-    assert
-      .dom(inputSelector)
-      .hasNoAttribute(
-        'aria-multiline',
-        'input element has no aria-multiline attribute'
-      );
-    assert
-      .dom(inputSelector)
-      .hasNoAttribute(
-        'aria-invalid',
-        'input element has no aria-invalid attribute'
-      );
-    assert
-      .dom(inputSelector)
-      .hasNoClass(
-        'Polaris-TextField__Input--suffixed',
-        'input element has no suffixed class'
-      );
+
+    let field = assert.dom(fieldSelector);
+    field.hasClass('Polaris-TextField', 'input wrapper has correct class');
+    field.hasNoClass(
+      'Polaris-TextField--multiline',
+      'input wrapper has no multiline class'
+    );
+    field.hasNoClass(
+      'Polaris-TextField--readOnly',
+      'input wrapper has no readOnly class'
+    );
+    field.hasNoClass(
+      'Polaris-TextField--hasValue',
+      'input wrapper has no value class applied'
+    );
+    field.hasNoClass(
+      'Polaris-TextField--error',
+      'input wrapper has no error class applied'
+    );
+
+    let input = assert.dom(inputSelector);
+    input.hasClass('Polaris-TextField__Input', 'input has correct class');
+    input.hasNoAttribute(
+      'aria-multiline',
+      'input element has no aria-multiline attribute'
+    );
+    input.hasNoAttribute(
+      'aria-invalid',
+      'input element has no aria-invalid attribute'
+    );
+    input.hasNoClass(
+      'Polaris-TextField__Input--suffixed',
+      'input element has no suffixed class'
+    );
   });
 
   test('it supports focused property', async function(assert) {
-    this.set('focused', false);
-
-    await render(hbs`{{polaris-text-field focused=focused}}`);
+    await render(hbs`{{polaris-text-field focused=false}}`);
 
     assert
       .dom(fieldSelector)
@@ -115,7 +99,7 @@ module('Integration | Component | polaris-text-field', function(hooks) {
       .dom(inputSelector)
       .isNotFocused('when focused is false - input is not focused');
 
-    this.set('focused', true);
+    await render(hbs`{{polaris-text-field focused=true}}`);
 
     assert
       .dom(fieldSelector)

--- a/tests/integration/components/polaris-thumbnail-test.js
+++ b/tests/integration/components/polaris-thumbnail-test.js
@@ -1,164 +1,155 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { find } from 'ember-native-dom-helpers';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
-moduleForComponent(
-  'polaris-thumbnail',
-  'Integration | Component | polaris thumbnail',
-  {
-    integration: true,
-  }
-);
+module('Integration | Component | polaris thumbnail', function(hooks) {
+  setupRenderingTest(hooks);
 
-const SRC = 'image.jpg';
-const ALT = 'Polaris thumbnail component';
-const THUMB_SELECTOR = 'span.Polaris-Thumbnail';
+  const SRC = 'image.jpg';
+  const ALT = 'Polaris thumbnail component';
+  const THUMB_SELECTOR = 'span.Polaris-Thumbnail';
 
-test('it renders the correct HTML when all attributes are passed in', function(assert) {
-  this.setProperties({
-    src: SRC,
-    alt: ALT,
-    size: 'small',
+  test('it renders the correct HTML when all attributes are passed in', async function(assert) {
+    this.setProperties({
+      src: SRC,
+      alt: ALT,
+      size: 'small',
+    });
+
+    await render(hbs`{{polaris-thumbnail size=size source=src alt=alt}}`);
+
+    let thumbnailSpan = assert.dom(THUMB_SELECTOR);
+
+    // Container properties:
+    thumbnailSpan.exists('thumbnail container element is rendered');
+    thumbnailSpan.hasClass(
+      'Polaris-Thumbnail--sizeSmall',
+      'correct size class is applied to container element'
+    );
+
+    let imageSelector = buildNestedSelector(
+      THUMB_SELECTOR,
+      '.Polaris-Thumbnail__Image'
+    );
+    let image = assert.dom(imageSelector);
+
+    // Thumbnail image properties:
+    image.exists('image element is rendered');
+    image.hasAttribute(
+      'src',
+      SRC,
+      'correct source attribute is applied to image node'
+    );
+    image.hasAttribute('alt', ALT, 'correct alt text is applied to image node');
   });
 
-  this.render(hbs`{{polaris-thumbnail size=size source=src alt=alt}}`);
+  test('it renders a correctly-sized thumbnail', async function(assert) {
+    await render(hbs`{{polaris-thumbnail}}`);
 
-  let thumbnailSpan = find(THUMB_SELECTOR);
-  let imageSelector = buildNestedSelector(
-    THUMB_SELECTOR,
-    '.Polaris-Thumbnail__Image'
-  );
-  let image = find(imageSelector);
+    let thumbnailSpan = assert.dom(THUMB_SELECTOR);
 
-  // Container properties:
-  assert.ok(thumbnailSpan, 'thumbnail container element is rendered');
-  assert.ok(
-    thumbnailSpan.classList.contains('Polaris-Thumbnail--sizeSmall'),
-    'correct size class is applied to container element'
-  );
+    thumbnailSpan.hasNoClass(
+      'Polaris-Thumbnail--sizeSmall',
+      'no size - does not apply small size class'
+    );
+    thumbnailSpan.hasClass(
+      'Polaris-Thumbnail--sizeMedium',
+      'no size - applies medium size class by default'
+    );
+    thumbnailSpan.hasNoClass(
+      'Polaris-Thumbnail--sizeLarge',
+      'no size - does not apply large size class'
+    );
 
-  // Thumbnail image properties:
-  assert.ok(image, 'image element is rendered');
-  assert.equal(
-    image.getAttribute('src'),
-    SRC,
-    'correct source attribute is applied to image node'
-  );
-  assert.equal(
-    image.getAttribute('alt'),
-    ALT,
-    'correct alt text is applied to image node'
-  );
-});
+    this.set('size', 'small');
+    await render(hbs`{{polaris-thumbnail size=size}}`);
 
-test('it renders a correctly-sized thumbnail', function(assert) {
-  this.render(hbs`{{polaris-thumbnail}}`);
+    thumbnailSpan = assert.dom(THUMB_SELECTOR);
 
-  let thumbnailSpan = find(THUMB_SELECTOR);
+    thumbnailSpan.hasClass(
+      'Polaris-Thumbnail--sizeSmall',
+      'size small - applies small size class'
+    );
+    thumbnailSpan.hasNoClass(
+      'Polaris-Thumbnail--sizeMedium',
+      'size small - does not apply medium size class'
+    );
+    thumbnailSpan.hasNoClass(
+      'Polaris-Thumbnail--sizeLarge',
+      'size small - does not apply large size class'
+    );
 
-  assert.notOk(
-    thumbnailSpan.classList.contains('Polaris-Thumbnail--sizeSmall'),
-    'no size - does not apply small size class'
-  );
-  assert.ok(
-    thumbnailSpan.classList.contains('Polaris-Thumbnail--sizeMedium'),
-    'no size - applies medium size class by default'
-  );
-  assert.notOk(
-    thumbnailSpan.classList.contains('Polaris-Thumbnail--sizeLarge'),
-    'no size - does not apply large size class'
-  );
+    this.set('size', 'medium');
+    thumbnailSpan.hasNoClass(
+      'Polaris-Thumbnail--sizeSmall',
+      'size medium - does not apply small size class'
+    );
+    thumbnailSpan.hasClass(
+      'Polaris-Thumbnail--sizeMedium',
+      'size medium - applies medium size class'
+    );
+    thumbnailSpan.hasNoClass(
+      'Polaris-Thumbnail--sizeLarge',
+      'size medium - does not apply large size class'
+    );
 
-  this.set('size', 'small');
-  this.render(hbs`{{polaris-thumbnail size=size}}`);
+    this.set('size', 'large');
+    thumbnailSpan.hasNoClass(
+      'Polaris-Thumbnail--sizeSmall',
+      'size large - does not apply small size class'
+    );
+    thumbnailSpan.hasNoClass(
+      'Polaris-Thumbnail--sizeMedium',
+      'size large - does not apply medium size class'
+    );
+    thumbnailSpan.hasClass(
+      'Polaris-Thumbnail--sizeLarge',
+      'size large - applies large size class'
+    );
 
-  thumbnailSpan = find(THUMB_SELECTOR);
+    this.set('size', 'unsupported');
+    thumbnailSpan.hasNoClass(
+      'Polaris-Thumbnail--sizeSmall',
+      'unsupported size - does not apply small size class'
+    );
+    thumbnailSpan.hasClass(
+      'Polaris-Thumbnail--sizeMedium',
+      'unsupported size - falls back to applying medium size class'
+    );
+    thumbnailSpan.hasNoClass(
+      'Polaris-Thumbnail--sizeLarge',
+      'unsupported size - does not apply large size class'
+    );
+  });
 
-  assert.ok(
-    thumbnailSpan.classList.contains('Polaris-Thumbnail--sizeSmall'),
-    'size small - applies small size class'
-  );
-  assert.notOk(
-    thumbnailSpan.classList.contains('Polaris-Thumbnail--sizeMedium'),
-    'size small - does not apply medium size class'
-  );
-  assert.notOk(
-    thumbnailSpan.classList.contains('Polaris-Thumbnail--sizeLarge'),
-    'size small - does not apply large size class'
-  );
+  test('it does not apply alt text if `alt` is not passed in', async function(assert) {
+    await render(hbs`{{polaris-thumbnail}}`);
 
-  this.set('size', 'medium');
-  assert.notOk(
-    thumbnailSpan.classList.contains('Polaris-Thumbnail--sizeSmall'),
-    'size medium - does not apply small size class'
-  );
-  assert.ok(
-    thumbnailSpan.classList.contains('Polaris-Thumbnail--sizeMedium'),
-    'size medium - applies medium size class'
-  );
-  assert.notOk(
-    thumbnailSpan.classList.contains('Polaris-Thumbnail--sizeLarge'),
-    'size medium - does not apply large size class'
-  );
+    let imageSelector = buildNestedSelector(
+      THUMB_SELECTOR,
+      '.Polaris-Thumbnail__Image'
+    );
 
-  this.set('size', 'large');
-  assert.notOk(
-    thumbnailSpan.classList.contains('Polaris-Thumbnail--sizeSmall'),
-    'size large - does not apply small size class'
-  );
-  assert.notOk(
-    thumbnailSpan.classList.contains('Polaris-Thumbnail--sizeMedium'),
-    'size large - does not apply medium size class'
-  );
-  assert.ok(
-    thumbnailSpan.classList.contains('Polaris-Thumbnail--sizeLarge'),
-    'size large - applies large size class'
-  );
+    assert
+      .dom(imageSelector)
+      .doesNotHaveAttribute(
+        'alt',
+        'no alt text - alt text is not applied to image'
+      );
+  });
 
-  this.set('size', 'unsupported');
-  assert.notOk(
-    thumbnailSpan.classList.contains('Polaris-Thumbnail--sizeSmall'),
-    'unsupported size - does not apply small size class'
-  );
-  assert.ok(
-    thumbnailSpan.classList.contains('Polaris-Thumbnail--sizeMedium'),
-    'unsupported size - falls back to applying medium size class'
-  );
-  assert.notOk(
-    thumbnailSpan.classList.contains('Polaris-Thumbnail--sizeLarge'),
-    'unsupported size - does not apply large size class'
-  );
-});
+  test('it does not apply src if `source` is not passed in', async function(assert) {
+    await render(hbs`{{polaris-thumbnail}}`);
 
-test('it does not apply alt text if `alt` is not passed in', function(assert) {
-  this.render(hbs`{{polaris-thumbnail}}`);
+    let imageSelector = buildNestedSelector(
+      THUMB_SELECTOR,
+      '.Polaris-Thumbnail__Image'
+    );
 
-  let imageSelector = buildNestedSelector(
-    THUMB_SELECTOR,
-    '.Polaris-Thumbnail__Image'
-  );
-  let image = find(imageSelector);
-
-  assert.equal(
-    image.getAttribute('alt'),
-    null,
-    'no alt text - alt text is not applied to image'
-  );
-});
-
-test('it does not apply src if `source` is not passed in', function(assert) {
-  this.render(hbs`{{polaris-thumbnail}}`);
-
-  let imageSelector = buildNestedSelector(
-    THUMB_SELECTOR,
-    '.Polaris-Thumbnail__Image'
-  );
-  let image = find(imageSelector);
-
-  assert.equal(
-    image.getAttribute('src'),
-    null,
-    'no source - src is not applied to image'
-  );
+    assert
+      .dom(imageSelector)
+      .doesNotHaveAttribute('src', 'no source - src is not applied to image');
+  });
 });

--- a/tests/integration/components/polaris-visually-hidden-test.js
+++ b/tests/integration/components/polaris-visually-hidden-test.js
@@ -1,51 +1,45 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { findAll } from 'ember-native-dom-helpers';
 
-moduleForComponent(
-  'polaris-visually-hidden',
-  'Integration | Component | polaris visually hidden',
-  {
-    integration: true,
-  }
-);
+module('Integration | Component | polaris visually hidden', function(hooks) {
+  setupRenderingTest(hooks);
 
-const visuallyHiddenSelector = 'span.Polaris-VisuallyHidden';
+  const visuallyHiddenSelector = 'span.Polaris-VisuallyHidden';
 
-test('it renders the correct HTML in basic inline usage', function(assert) {
-  this.render(
-    hbs`{{polaris-visually-hidden text="Inline visually hidden content"}}`
-  );
+  test('it renders the correct HTML in basic inline usage', async function(assert) {
+    await render(
+      hbs`{{polaris-visually-hidden text="Inline visually hidden content"}}`
+    );
 
-  const visuallyHiddens = findAll(visuallyHiddenSelector);
-  assert.equal(
-    visuallyHiddens.length,
-    1,
-    'renders one visually hidden component'
-  );
-  assert.equal(
-    visuallyHiddens[0].textContent.trim(),
-    'Inline visually hidden content',
-    'renders correct visually hidden content'
-  );
-});
+    const visuallyHidden = assert.dom(visuallyHiddenSelector);
+    visuallyHidden.exists(
+      { count: 1 },
+      'renders one visually hidden component'
+    );
+    visuallyHidden.hasText(
+      'Inline visually hidden content',
+      'renders correct visually hidden content'
+    );
+  });
 
-test('it renders the correct HTML in basic block usage', function(assert) {
-  this.render(hbs`
-    {{#polaris-visually-hidden}}
-      Block visually hidden content
-    {{/polaris-visually-hidden}}
-  `);
+  test('it renders the correct HTML in basic block usage', async function(assert) {
+    await render(hbs`
+      {{#polaris-visually-hidden}}
+        Block visually hidden content
+      {{/polaris-visually-hidden}}
+    `);
 
-  const visuallyHiddens = findAll(visuallyHiddenSelector);
-  assert.equal(
-    visuallyHiddens.length,
-    1,
-    'renders one visually hidden component'
-  );
-  assert.equal(
-    visuallyHiddens[0].textContent.trim(),
-    'Block visually hidden content',
-    'renders correct visually hidden content'
-  );
+    const visuallyHidden = assert.dom(visuallyHiddenSelector);
+
+    visuallyHidden.exists(
+      { count: 1 },
+      'renders one visually hidden component'
+    );
+    visuallyHidden.hasText(
+      'Block visually hidden content',
+      'renders correct visually hidden content'
+    );
+  });
 });

--- a/tests/integration/components/render-content-test.js
+++ b/tests/integration/components/render-content-test.js
@@ -3,7 +3,6 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { find } from 'ember-native-dom-helpers';
 
 module('Integration | Component | render-content', function(hooks) {
   setupRenderingTest(hooks);
@@ -26,7 +25,7 @@ module('Integration | Component | render-content', function(hooks) {
       </div>
     `);
 
-    assert.equal(find('#render-content-test').textContent.trim(), 'blah');
+    assert.dom('#render-content-test').hasText('blah');
   });
 
   test('it renders correctly when content is a hash of component name and props', async function(assert) {
@@ -41,10 +40,7 @@ module('Integration | Component | render-content', function(hooks) {
       }}
     `);
 
-    assert.equal(
-      find('.my-test-component').textContent.trim(),
-      'component content here'
-    );
+    assert.dom('.my-test-component').hasText('component content here');
   });
 
   test('it renders correctly when content is a component definition', async function(assert) {
@@ -52,9 +48,6 @@ module('Integration | Component | render-content', function(hooks) {
       {{render-content (component "my-component" text="component content here")}}
     `);
 
-    assert.equal(
-      find('.my-test-component').textContent.trim(),
-      'component content here'
-    );
+    assert.dom('.my-test-component').hasText('component content here');
   });
 });

--- a/tests/unit/utils/color-test.js
+++ b/tests/unit/utils/color-test.js
@@ -7,58 +7,58 @@ import {
   hexToRgb,
 } from '@smile-io/ember-polaris/utils/color';
 
-module('Unit | Utility | color');
+module('Unit | Utility | color', function() {
+  test('rgbaString() correctly converts an RGB(a) object color to string', function(assert) {
+    let result = rgbaString({ red: 194, green: 204, blue: 143 });
+    assert.equal(result, 'rgb(194, 204, 143)');
 
-test('rgbaString() correctly converts an RGB(a) object color to string', function(assert) {
-  let result = rgbaString({ red: 194, green: 204, blue: 143 });
-  assert.equal(result, 'rgb(194, 204, 143)');
+    result = rgbaString({ red: 194, green: 204, blue: 143, alpha: 0.75 });
+    assert.equal(result, 'rgba(194, 204, 143, 0.75)');
+  });
 
-  result = rgbaString({ red: 194, green: 204, blue: 143, alpha: 0.75 });
-  assert.equal(result, 'rgba(194, 204, 143, 0.75)');
-});
+  test('hsbaToRgba() correctly converts HSB(a) colors to RGB(a)', function(assert) {
+    let result = hsbaToRgba({ hue: 70, saturation: 0.3, brightness: 0.8 });
+    assert.deepEqual(result, { red: 194, green: 204, blue: 143, alpha: 1 });
+  });
 
-test('hsbaToRgba() correctly converts HSB(a) colors to RGB(a)', function(assert) {
-  let result = hsbaToRgba({ hue: 70, saturation: 0.3, brightness: 0.8 });
-  assert.deepEqual(result, { red: 194, green: 204, blue: 143, alpha: 1 });
-});
+  test('rgbaToHsb() correctly converts RGB(a) colors to HSB(a)', function(assert) {
+    let result = rgbaToHsb({ red: 194, green: 204, blue: 143, alpha: 1 });
 
-test('rgbaToHsb() correctly converts RGB(a) colors to HSB(a)', function(assert) {
-  let result = rgbaToHsb({ red: 194, green: 204, blue: 143, alpha: 1 });
+    assert.equal(result.hue, 70);
+    // Need to round here to match
+    assert.equal(result.saturation.toFixed(1), 0.3);
+    assert.equal(result.brightness, 0.8);
+    assert.equal(result.alpha, 1);
+  });
 
-  assert.equal(result.hue, 70);
-  // Need to round here to match
-  assert.equal(result.saturation.toFixed(1), 0.3);
-  assert.equal(result.brightness, 0.8);
-  assert.equal(result.alpha, 1);
-});
+  test('rgbaToHex() correctly converts RGB(a) colors to HEX', function(assert) {
+    let result = rgbaToHex({ red: 65, green: 131, blue: 196 });
+    assert.equal(result, '4183c4');
 
-test('rgbaToHex() correctly converts RGB(a) colors to HEX', function(assert) {
-  let result = rgbaToHex({ red: 65, green: 131, blue: 196 });
-  assert.equal(result, '4183c4');
+    result = rgbaToHex(65, 131, 196);
+    assert.equal(result, '4183c4');
 
-  result = rgbaToHex(65, 131, 196);
-  assert.equal(result, '4183c4');
+    result = rgbaToHex('rgb(40, 42, 54)');
+    assert.equal(result, '282a36');
 
-  result = rgbaToHex('rgb(40, 42, 54)');
-  assert.equal(result, '282a36');
+    result = rgbaToHex(65, 131, 196, 0.2);
+    assert.equal(result, '4183c433');
 
-  result = rgbaToHex(65, 131, 196, 0.2);
-  assert.equal(result, '4183c433');
+    result = rgbaToHex(40, 42, 54, '75%');
+    assert.equal(result, '282a36bf');
 
-  result = rgbaToHex(40, 42, 54, '75%');
-  assert.equal(result, '282a36bf');
+    result = rgbaToHex('rgba(40, 42, 54, 75%)');
+    assert.equal(result, '282a36bf');
+  });
 
-  result = rgbaToHex('rgba(40, 42, 54, 75%)');
-  assert.equal(result, '282a36bf');
-});
+  test('hexToRgb() correctly converts HEX colors to RGB', function(assert) {
+    let result = hexToRgb('4183c4');
+    assert.deepEqual(result, { red: 65, green: 131, blue: 196 });
 
-test('hexToRgb() correctly converts HEX colors to RGB', function(assert) {
-  let result = hexToRgb('4183c4');
-  assert.deepEqual(result, { red: 65, green: 131, blue: 196 });
+    result = hexToRgb('#4183c4');
+    assert.deepEqual(result, { red: 65, green: 131, blue: 196 });
 
-  result = hexToRgb('#4183c4');
-  assert.deepEqual(result, { red: 65, green: 131, blue: 196 });
-
-  result = hexToRgb('#fff');
-  assert.deepEqual(result, { red: 255, green: 255, blue: 255 });
+    result = hexToRgb('#fff');
+    assert.deepEqual(result, { red: 255, green: 255, blue: 255 });
+  });
 });

--- a/tests/unit/utils/focus-test.js
+++ b/tests/unit/utils/focus-test.js
@@ -1,19 +1,19 @@
 import focus from 'dummy/utils/focus';
 import { module, test } from 'qunit';
 
-module('Unit | Utility | focus');
-
-test("handleMouseUpByBlurring calls blur on the passed in event's currentTarget", function(assert) {
-  let blurCalled = false;
-  let mockEvent = {
-    currentTarget: {
-      blur() {
-        blurCalled = true;
+module('Unit | Utility | focus', function() {
+  test("handleMouseUpByBlurring calls blur on the passed in event's currentTarget", function(assert) {
+    let blurCalled = false;
+    let mockEvent = {
+      currentTarget: {
+        blur() {
+          blurCalled = true;
+        },
       },
-    },
-  };
+    };
 
-  focus.handleMouseUpByBlurring(mockEvent);
+    focus.handleMouseUpByBlurring(mockEvent);
 
-  assert.ok(blurCalled, "blur called on event's currentTarget");
+    assert.ok(blurCalled, "blur called on event's currentTarget");
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2900,7 +2900,7 @@ broccoli-funnel-reducer@^1.0.0:
   resolved "https://registry.yarnpkg.com/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz#11365b2a785aec9b17972a36df87eef24c5cc0ea"
   integrity sha1-ETZbKnha7JsXlyo234fu8kxcwOo=
 
-broccoli-funnel@^1.0.1, broccoli-funnel@^1.1.0:
+broccoli-funnel@^1.0.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz#cddc3afc5ff1685a8023488fff74ce6fb5a51296"
   integrity sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=
@@ -5260,14 +5260,6 @@ ember-maybe-in-element@^0.2.0:
   integrity sha512-R5e6N8yDbfNbA/3lMZsFs2KEzv/jt80TsATiKMCqdqKuSG82KrD25cRdU5VkaE8dTQbziyBeuJs90bBiqOnakQ==
   dependencies:
     ember-cli-babel "^7.1.0"
-
-ember-native-dom-helpers@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/ember-native-dom-helpers/-/ember-native-dom-helpers-0.6.2.tgz#ad1f82d64ac9abdd612022f4f390bdb6653b3d39"
-  integrity sha512-J4SfukTITFFsCYbOxG/sjGBTcZVrxgbMyFKrrTcB2cKfrglyTZSwqs9jBUpF91FEwetzmYP02Nh9N4WzcJ8cRQ==
-  dependencies:
-    broccoli-funnel "^1.1.0"
-    ember-cli-babel "^6.6.0"
 
 ember-qunit@^4.4.1:
   version "4.4.1"


### PR DESCRIPTION
Removed `ember-native-dom-helpers` which was supposed to be a predecessor for `@ember/test-helpers`. Also refactored a bunch of tests to use the verbose `qunit-dom`api.

Additionally bumped up the minimum supported ember version to ember-source@3.10. So we should publish a major release of this addon once this is merged.