### PR TITLE
Fix component definition detection

### DIFF
--- a/addon/components/render-content.js
+++ b/addon/components/render-content.js
@@ -2,6 +2,7 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { notEmpty } from '@ember/object/computed';
 import layout from '../templates/components/render-content';
+import { isComponentDefinition } from '@smile-io/ember-polaris/helpers/is-component-definition';
 
 export default Component.extend({
   tagName: '',
@@ -13,8 +14,7 @@ export default Component.extend({
   contentIsComponentHash: notEmpty('content.componentName').readOnly(),
 
   contentIsComponentDefinition: computed('content', function() {
-    let contentConstructorName = this.get('content.constructor.name') || '';
-    return contentConstructorName.indexOf('ComponentDefinition') > -1;
+    return isComponentDefinition(this.get('content'));
   }).readOnly(),
 }).reopenClass({
   positionalParams: ['content'],

--- a/addon/helpers/is-component-definition.js
+++ b/addon/helpers/is-component-definition.js
@@ -1,7 +1,7 @@
 import { helper } from '@ember/component/helper';
 import { typeOf } from '@ember/utils';
 
-export function isComponentDefinition([content]) {
+export function isComponentDefinition(content) {
   if (typeOf(content) !== 'object') {
     return false;
   }
@@ -10,4 +10,4 @@ export function isComponentDefinition([content]) {
   return contentConstructorName.indexOf('ComponentDefinition') > -1;
 }
 
-export default helper(isComponentDefinition);
+export default helper(([content]) => isComponentDefinition(content));

--- a/addon/helpers/is-component-definition.js
+++ b/addon/helpers/is-component-definition.js
@@ -6,8 +6,12 @@ export function isComponentDefinition(content) {
     return false;
   }
 
-  let contentConstructorName = content.constructor.name || '';
-  return contentConstructorName.indexOf('ComponentDefinition') > -1;
+  let contentPropNames = Object.keys(content);
+  return Boolean(
+    contentPropNames.find(
+      (propName) => propName.indexOf('COMPONENT DEFINITION') > -1
+    )
+  );
 }
 
 export default helper(([content]) => isComponentDefinition(content));


### PR DESCRIPTION
Found that our method of detecting component definitions was broken in production builds where constructor names seem to be getting minified. This method follows Glimmer's [way](https://github.com/glimmerjs/glimmer-vm/blob/master/packages/@glimmer/runtime/lib/component/curried-component.ts#L11) of detecting component definitions (thx @vladucu!) to avoid such issues 🙏 

Also DRYs up the component definition detection in `render-content` so we won't face any additional surprises if this breaks again in the future 😅 