### PR TITLE
Remove jquery dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,11 +37,10 @@ jobs:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
     - stage: 'Additional Tests'
-      env: EMBER_TRY_SCENARIO=ember-3.10
+      env: EMBER_TRY_SCENARIO=ember-lts-3.12
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
-    - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash

--- a/addon/components/polaris-color-picker/slidable.js
+++ b/addon/components/polaris-color-picker/slidable.js
@@ -1,4 +1,3 @@
-import $Ember from 'jquery';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { isNone, typeOf } from '@ember/utils';
@@ -11,21 +10,28 @@ function startDrag(event) {
   this.handleMove(event);
 
   // Set up global event listeners to handle dragging outside the slidable area.
-  $Ember(window).on('mousemove', (...moveArgs) => {
-    this.handleMove(...moveArgs);
-  });
-  $Ember(window).on('mouseup', () => {
-    this.handleDragEnd();
-  });
+  let mousemove = window.addEventListener('mousemove', (...moveArgs) =>
+    this.handleMove(...moveArgs)
+  );
 
-  $Ember(window).on('touchmove', (...moveArgs) => {
-    this.handleMove(...moveArgs);
-  });
-  $Ember(window).on('touchend', () => {
-    this.handleDragEnd();
-  });
-  $Ember(window).on('touchcancel', () => {
-    this.handleDragEnd();
+  let mouseup = window.addEventListener('mouseup', () => this.handleDragEnd());
+
+  let touchmove = window.addEventListener('touchmove', (...moveArgs) =>
+    this.handleMove(...moveArgs)
+  );
+  let touchend = window.addEventListener('touchend', () =>
+    this.handleDragEnd()
+  );
+  let touchcancel = window.addEventListener('touchcancel', () =>
+    this.handleDragEnd()
+  );
+
+  this.set('globalEventListeners', {
+    mousemove,
+    mouseup,
+    touchmove,
+    touchend,
+    touchcancel,
   });
 }
 
@@ -118,13 +124,12 @@ export default Component.extend({
   handleDragEnd() {
     this.set('isDragging', false);
 
-    // Remove our global event listeners.
-    $Ember(window).off('mousemove');
-    $Ember(window).off('mouseup');
+    let { globalEventListeners } = this;
 
-    $Ember(window).off('touchmove');
-    $Ember(window).off('touchend');
-    $Ember(window).off('touchcancel');
+    // Remove our global event listeners.
+    Object.keys(globalEventListeners).map((eventType) =>
+      window.removeEventListener(eventType, globalEventListeners[eventType])
+    );
   },
 
   /**

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,65 +2,58 @@
 
 const getChannelURL = require('ember-source-channel-url');
 
-module.exports = async function() {
-  return {
-    useYarn: true,
-    scenarios: [
-      {
-        name: 'ember-3.10',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.10.2',
+module.exports = function() {
+  return Promise.all([
+    getChannelURL('release'),
+    getChannelURL('beta'),
+    getChannelURL('canary'),
+  ]).then((urls) => {
+    return {
+      useYarn: true,
+      scenarios: [
+        {
+          name: 'ember-lts-3.12',
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.12.0',
+            },
           },
         },
-      },
-      {
-        name: 'ember-release',
-        npm: {
-          devDependencies: {
-            'ember-source': await getChannelURL('release'),
+        {
+          name: 'ember-release',
+          npm: {
+            devDependencies: {
+              'ember-source': urls[0],
+            },
           },
         },
-      },
-      {
-        name: 'ember-beta',
-        npm: {
-          devDependencies: {
-            'ember-source': await getChannelURL('beta'),
+        {
+          name: 'ember-beta',
+          npm: {
+            devDependencies: {
+              'ember-source': urls[1],
+            },
           },
         },
-      },
-      {
-        name: 'ember-canary',
-        npm: {
-          devDependencies: {
-            'ember-source': await getChannelURL('canary'),
+        {
+          name: 'ember-canary',
+          npm: {
+            devDependencies: {
+              'ember-source': urls[2],
+            },
           },
         },
-      },
-      // The default `.travis.yml` runs this scenario via `npm test`,
-      // not via `ember try`. It's still included here so that running
-      // `ember try:each` manually or from a customized CI config will run it
-      // along with all the other scenarios.
-      {
-        name: 'ember-default',
-        npm: {
-          devDependencies: {},
-        },
-      },
-      {
-        name: 'ember-default-with-jquery',
-        env: {
-          EMBER_OPTIONAL_FEATURES: JSON.stringify({
-            'jquery-integration': true,
-          }),
-        },
-        npm: {
-          devDependencies: {
-            '@ember/jquery': '^0.5.1',
+        // The default `.travis.yml` runs this scenario via `yarn test`,
+        // not via `ember try`. It's still included here so that running
+        // `ember try:each` manually or from a customized CI config will run it
+        // along with all the other scenarios.
+        {
+          name: 'ember-default',
+          npm: {
+            devDependencies: {},
           },
         },
-      },
-    ],
-  };
+      ],
+    };
+  });
 };

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "rsvp": "^4.8.5"
   },
   "devDependencies": {
-    "@ember/jquery": "^1.1.0",
     "@ember/optional-features": "^0.7.0",
     "@smile-io/changelog-generator": "^2.1.0",
     "@smile-io/ember-styleguide": "^9.1.0",

--- a/tests/dummy/app/controllers/color-picker.js
+++ b/tests/dummy/app/controllers/color-picker.js
@@ -1,0 +1,35 @@
+import Controller from '@ember/controller';
+import { htmlSafe } from '@ember/template';
+import { computed } from '@ember/object';
+import { hsbaToHex } from '@smile-io/ember-polaris/utils/color';
+
+export default class ColorPickerController extends Controller {
+  color = {
+    alpha: 1,
+    brightness: 0.8,
+    hue: 255,
+    saturation: 0.5,
+  };
+
+  updateColor(color) {
+    this.set('color', color);
+  }
+
+  @computed('color')
+  get previewBoxStyle() {
+    return htmlSafe(
+      [
+        `background-color: #${hsbaToHex(this.color)}`,
+        'height: 100px',
+        'width: 100px',
+        'margin: 1rem',
+        'display: flex',
+        'justify-content: center',
+        'align-items: center',
+        'font-size: 5rem',
+        'border-radius: 50%',
+        'box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23)',
+      ].join(';')
+    );
+  }
+}

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -20,6 +20,7 @@ Router.map(function() {
   this.route('select');
 
   this.route('resource-list', function() {});
+  this.route('color-picker');
 });
 
 export default Router;

--- a/tests/dummy/app/routes/color-picker.js
+++ b/tests/dummy/app/routes/color-picker.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({});

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -22,6 +22,10 @@ const samplePages = [
     text: 'Select',
   },
   {
+    path: 'color-picker',
+    text: 'Color picker',
+  },
+  {
     path: 'test',
     text: 'Go to test route',
   },

--- a/tests/dummy/app/templates/color-picker.hbs
+++ b/tests/dummy/app/templates/color-picker.hbs
@@ -1,0 +1,16 @@
+<PolarisPage
+  @title="Color picker example"
+  @singleColumn={{true}}
+>
+  <PolarisCard @sectioned={{true}}>
+    <PolarisStack @distribution="center" @alignment="center">
+      <PolarisColorPicker
+        @color={{this.color}}
+        @onChange={{action updateColor}}
+      />
+      <div style={{this.previewBoxStyle}}>
+        👻
+      </div>
+    </PolarisStack>
+  </PolarisCard>
+</PolarisPage>

--- a/tests/dummy/config/optional-features.json
+++ b/tests/dummy/config/optional-features.json
@@ -1,3 +1,3 @@
 {
-  "jquery-integration": true
+  "jquery-integration": false
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -735,18 +735,6 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ember/jquery@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@ember/jquery/-/jquery-1.1.0.tgz#33d062610a5ceaa5c5c8a3187f870d47d6595940"
-  integrity sha512-zePT3LiK4/2bS4xafrbOlwoLJrDFseOZ95OOuVDyswv8RjFL+9lar+uxX6+jxRb0w900BcQSWP/4nuFSK6HXXw==
-  dependencies:
-    broccoli-funnel "^2.0.2"
-    broccoli-merge-trees "^3.0.2"
-    ember-cli-babel "^7.11.1"
-    ember-cli-version-checker "^3.1.3"
-    jquery "^3.4.1"
-    resolve "^1.11.1"
-
 "@ember/optional-features@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@ember/optional-features/-/optional-features-0.7.0.tgz#f65a858007020ddfb8342f586112750c32abd2d9"
@@ -4637,7 +4625,7 @@ ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.16.0, ember-cli-babel@^6.6.0, 
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.11.0, ember-cli-babel@^7.11.1, ember-cli-babel@^7.2.0, ember-cli-babel@^7.7.0, ember-cli-babel@^7.7.3, ember-cli-babel@^7.8.0:
+ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.11.0, ember-cli-babel@^7.2.0, ember-cli-babel@^7.7.0, ember-cli-babel@^7.7.3, ember-cli-babel@^7.8.0:
   version "7.12.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.12.0.tgz#064997d199384be8c88d251f30ef67953d3bddc5"
   integrity sha512-+EGQsbPvh19nNXHCm6rVBx2CdlxQlzxMyhey5hsGViDPriDI4PFYXYaFWdGizDrmZoDcG/Ywpeph3hl0NxGQTg==


### PR DESCRIPTION
- Replaced jquery usage in color picker's code with native equivalents
- Added a test page that has an example of a color picker
- Removed jquery dependency & disabled it in optional features
- Updated ember-try config.


Screenshot of the test page:
![localhost_4200_color-picker](https://user-images.githubusercontent.com/604117/66806278-c6955200-ef44-11e9-98b9-491fbce5c313.png)
