### PR TITLE
Modernize polaris-range-slider component

### DIFF
--- a/addon/components/polaris-range-slider.js
+++ b/addon/components/polaris-range-slider.js
@@ -1,6 +1,8 @@
+import classic from 'ember-classic-decorator';
+import { tagName, layout as templateLayout } from '@ember-decorators/component';
+import { action, computed } from '@ember/object';
 import Component from '@ember/component';
 import { guidFor } from '@ember/object/internals';
-import { computed } from '@ember/object';
 import { dasherize, htmlSafe } from '@ember/string';
 import { assign } from '@ember/polyfills';
 import { errorId, helpTextId } from '@smile-io/ember-polaris/utils/id';
@@ -20,11 +22,10 @@ function invertNumber(number) {
  * Polaris range slider component.
  * See https://polaris.shopify.com/components/forms/range-slider
  */
-export default Component.extend({
-  tagName: '',
-
-  layout,
-
+@classic
+@tagName('')
+@templateLayout(layout)
+export default class PolarisRangeSlider extends Component {
   /**
    * ID for range input
    *
@@ -34,9 +35,10 @@ export default Component.extend({
    * @type {String}
    * @public
    */
-  id: computed(function() {
+  @computed
+  get id() {
     return guidFor(this);
-  }),
+  }
 
   /**
    * Label for the range input
@@ -45,7 +47,7 @@ export default Component.extend({
    * @type {String}
    * @public
    */
-  label: null,
+  label = null;
 
   /**
    * Adds an action to the label
@@ -54,7 +56,7 @@ export default Component.extend({
    * @type {Object}
    * @public
    */
-  labelAction: null,
+  labelAction = null;
 
   /**
    * Visually hide the label
@@ -64,7 +66,7 @@ export default Component.extend({
    * @default false
    * @public
    */
-  labelHidden: false,
+  labelHidden = false;
 
   /**
    * Initial value for range input
@@ -74,7 +76,7 @@ export default Component.extend({
    * @default 0
    * @public
    */
-  value: 0,
+  value = 0;
 
   /**
    * Minimum possible value for range input
@@ -84,7 +86,7 @@ export default Component.extend({
    * @default 0
    * @public
    */
-  min: 0,
+  min = 0;
 
   /**
    * Maximum possible value for range input
@@ -94,7 +96,7 @@ export default Component.extend({
    * @default 100
    * @public
    */
-  max: 100,
+  max = 100;
 
   /**
    * Increment value for range input changes
@@ -104,7 +106,7 @@ export default Component.extend({
    * @default null
    * @public
    */
-  step: null,
+  step = null;
 
   /**
    * Provide a tooltip while sliding, indicating the current value
@@ -114,7 +116,7 @@ export default Component.extend({
    * @default false
    * @public
    */
-  output: false,
+  output = false;
 
   /**
    * Additional text to aid in use
@@ -123,7 +125,7 @@ export default Component.extend({
    * @type {String|Component}
    * @public
    */
-  helpText: null,
+  helpText = null;
 
   /**
    * Display an error message
@@ -132,7 +134,7 @@ export default Component.extend({
    * @type {String|Component}
    * @public
    */
-  error: null,
+  error = null;
 
   /**
    * Disable input
@@ -142,7 +144,7 @@ export default Component.extend({
    * @default false
    * @public
    */
-  disabled: false,
+  disabled = false;
 
   /**
    * Element to display before the input
@@ -152,7 +154,7 @@ export default Component.extend({
    * @default null
    * @public
    */
-  prefix: null,
+  prefix = null;
 
   /**
    * Element to display after the input
@@ -162,7 +164,7 @@ export default Component.extend({
    * @default null
    * @public
    */
-  suffix: null,
+  suffix = null;
 
   /**
    * Callback when the range input is changed
@@ -172,7 +174,7 @@ export default Component.extend({
    * @default no-op
    * @public
    */
-  onChange() {},
+  onChange() {}
 
   /**
    * Callback when range input is focused
@@ -182,7 +184,7 @@ export default Component.extend({
    * @default no-op
    * @public
    */
-  onFocus() {},
+  onFocus() {}
 
   /**
    * Callback when focus is removed
@@ -192,9 +194,9 @@ export default Component.extend({
    * @default no-op
    * @public
    */
-  onBlur() {},
+  onBlur() {}
 
-  dataTestRangeSlider: true,
+  dataTestRangeSlider = true;
 
   /**
    * Class names for the range wrapper div
@@ -203,7 +205,8 @@ export default Component.extend({
    * @type {String}
    * @private
    */
-  rangeWrapperClassNames: computed('error', 'disabled', function() {
+  @(computed('error', 'disabled').readOnly())
+  get rangeWrapperClassNames() {
     let { error, disabled } = this.getProperties('error', 'disabled');
     let classNames = ['Polaris-RangeSlider'];
 
@@ -216,7 +219,7 @@ export default Component.extend({
     }
 
     return classNames.join(' ');
-  }).readOnly(),
+  }
 
   /**
    * Style for the range wrapper div
@@ -225,38 +228,33 @@ export default Component.extend({
    * @type {String}
    * @private
    */
-  rangeWrapperStyle: computed(
-    'min',
-    'max',
-    'value',
-    'sliderProgress',
-    function() {
-      let { min, max, value: current, sliderProgress } = this.getProperties(
-        'min',
-        'max',
-        'value',
-        'sliderProgress'
-      );
-      let styleProps = assign(
-        { min, max, current },
-        {
-          progress: `${sliderProgress}%`,
-          outputFactor: invertNumber((sliderProgress - 50) / 100),
-        }
-      );
+  @(computed('min', 'max', 'value', 'sliderProgress').readOnly())
+  get rangeWrapperStyle() {
+    let { min, max, value: current, sliderProgress } = this.getProperties(
+      'min',
+      'max',
+      'value',
+      'sliderProgress'
+    );
+    let styleProps = assign(
+      { min, max, current },
+      {
+        progress: `${sliderProgress}%`,
+        outputFactor: invertNumber((sliderProgress - 50) / 100),
+      }
+    );
 
-      let styleString = Object.keys(styleProps).reduce(
-        (styleString, propName) => {
-          return `${styleString} --Polaris-RangeSlider-${dasherize(propName)}:${
-            styleProps[propName]
-          };`;
-        },
-        ''
-      );
+    let styleString = Object.keys(styleProps).reduce(
+      (styleString, propName) => {
+        return `${styleString} --Polaris-RangeSlider-${dasherize(propName)}:${
+          styleProps[propName]
+        };`;
+      },
+      ''
+    );
 
-      return htmlSafe(styleString.trim());
-    }
-  ).readOnly(),
+    return htmlSafe(styleString.trim());
+  }
 
   /**
    * Slider progress percentage
@@ -265,10 +263,11 @@ export default Component.extend({
    * @type {Number}
    * @private
    */
-  sliderProgress: computed('min', 'max', 'value', function() {
+  @(computed('min', 'max', 'value').readOnly())
+  get sliderProgress() {
     let { min, max, value } = this.getProperties('min', 'max', 'value');
     return ((value - min) * 100) / (max - min);
-  }).readOnly(),
+  }
 
   /**
    * Stringified boolean flag indicating whether an error is present
@@ -277,9 +276,10 @@ export default Component.extend({
    * @type {String}
    * @private
    */
-  hasError: computed('error', function() {
+  @(computed('error').readOnly())
+  get hasError() {
     return Boolean(this.get('error')).toString();
-  }).readOnly(),
+  }
 
   /**
    * Accessibility
@@ -288,7 +288,8 @@ export default Component.extend({
    * @type {Boolean}
    * @private
    */
-  ariaDescribedBy: computed('error', 'helpText', function() {
+  @(computed('error', 'helpText').readOnly())
+  get ariaDescribedBy() {
     let { error, helpText, id } = this.getProperties('error', 'helpText', 'id');
     let describedBy = [];
 
@@ -301,7 +302,7 @@ export default Component.extend({
     }
 
     return describedBy.length ? describedBy.join(' ') : undefined;
-  }).readOnly(),
+  }
 
   /**
    * Boolean flag indicating whether the output value should be displayed
@@ -310,17 +311,17 @@ export default Component.extend({
    * @type {Boolean}
    * @private
    */
-  shouldShowOutput: computed('disabled', 'output', function() {
+  @(computed('disabled', 'output').readOnly())
+  get shouldShowOutput() {
     let { disabled, output } = this.getProperties('disabled', 'output');
     return !disabled && output;
-  }).readOnly(),
+  }
 
-  actions: {
-    handleChange(event) {
-      this.get('onChange')(
-        parseFloat(event.currentTarget.value),
-        this.get('id')
-      );
-    },
-  },
-});
+  @action
+  handleChange(event) {
+    this.get('onChange')(
+      parseFloat(event.currentTarget.value),
+      this.get('id')
+    );
+  }
+}

--- a/addon/components/polaris-range-slider.js
+++ b/addon/components/polaris-range-slider.js
@@ -1,9 +1,8 @@
-import classic from 'ember-classic-decorator';
-import { tagName, layout as templateLayout } from '@ember-decorators/component';
-import { action, computed } from '@ember/object';
 import Component from '@ember/component';
+import { action, computed } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { dasherize, htmlSafe } from '@ember/string';
+import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import { assign } from '@ember/polyfills';
 import { errorId, helpTextId } from '@smile-io/ember-polaris/utils/id';
 import layout from '../templates/components/polaris-range-slider';
@@ -22,7 +21,6 @@ function invertNumber(number) {
  * Polaris range slider component.
  * See https://polaris.shopify.com/components/forms/range-slider
  */
-@classic
 @tagName('')
 @templateLayout(layout)
 export default class PolarisRangeSlider extends Component {
@@ -207,7 +205,7 @@ export default class PolarisRangeSlider extends Component {
    */
   @(computed('error', 'disabled').readOnly())
   get rangeWrapperClassNames() {
-    let { error, disabled } = this.getProperties('error', 'disabled');
+    let { error, disabled } = this;
     let classNames = ['Polaris-RangeSlider'];
 
     if (error) {
@@ -230,12 +228,8 @@ export default class PolarisRangeSlider extends Component {
    */
   @(computed('min', 'max', 'value', 'sliderProgress').readOnly())
   get rangeWrapperStyle() {
-    let { min, max, value: current, sliderProgress } = this.getProperties(
-      'min',
-      'max',
-      'value',
-      'sliderProgress'
-    );
+    let { min, max, value: current, sliderProgress } = this;
+
     let styleProps = assign(
       { min, max, current },
       {
@@ -265,7 +259,7 @@ export default class PolarisRangeSlider extends Component {
    */
   @(computed('min', 'max', 'value').readOnly())
   get sliderProgress() {
-    let { min, max, value } = this.getProperties('min', 'max', 'value');
+    let { min, max, value } = this;
     return ((value - min) * 100) / (max - min);
   }
 
@@ -278,7 +272,7 @@ export default class PolarisRangeSlider extends Component {
    */
   @(computed('error').readOnly())
   get hasError() {
-    return Boolean(this.get('error')).toString();
+    return Boolean(this.error).toString();
   }
 
   /**
@@ -290,7 +284,7 @@ export default class PolarisRangeSlider extends Component {
    */
   @(computed('error', 'helpText').readOnly())
   get ariaDescribedBy() {
-    let { error, helpText, id } = this.getProperties('error', 'helpText', 'id');
+    let { error, helpText, id } = this;
     let describedBy = [];
 
     if (error) {
@@ -313,15 +307,12 @@ export default class PolarisRangeSlider extends Component {
    */
   @(computed('disabled', 'output').readOnly())
   get shouldShowOutput() {
-    let { disabled, output } = this.getProperties('disabled', 'output');
+    let { disabled, output } = this;
     return !disabled && output;
   }
 
   @action
   handleChange(event) {
-    this.get('onChange')(
-      parseFloat(event.currentTarget.value),
-      this.get('id')
-    );
+    this.onChange(parseFloat(event.currentTarget.value), this.id);
   }
 }

--- a/addon/templates/components/polaris-range-slider.hbs
+++ b/addon/templates/components/polaris-range-slider.hbs
@@ -1,6 +1,6 @@
 <PolarisLabelled
-  @dataTestLabelled={{dataTestRangeSlider}}
-  @id={{@id}}
+  @dataTestLabelled={{this.dataTestRangeSlider}}
+  @id={{this.id}}
   @label={{@label}}
   @error={{@error}}
   @action={{@labelAction}}
@@ -23,18 +23,18 @@
         data-test-range-slider-input
         type="range"
         class="Polaris-RangeSlider__Input"
-        id={{@id}}
-        name={{@id}}
-        min={{@min}}
-        max={{@max}}
+        id={{this.id}}
+        name={{this.id}}
+        min={{this.min}}
+        max={{this.max}}
         step={{@step}}
         value={{@value}}
         disabled={{@disabled}}
         oninput={{fn this.handleChange}}
         onfocus={{fn this.onFocus}}
         onblur={{fn this.onBlur}}
-        aria-valuemin={{@min}}
-        aria-valuemax={{@max}}
+        aria-valuemin={{this.min}}
+        aria-valuemax={{this.max}}
         aria-valuenow={{@value}}
         aria-invalid={{this.hasError}}
         aria-describedby={{this.ariaDescribedBy}}
@@ -43,7 +43,7 @@
       {{#if this.shouldShowOutput}}
         <output
           data-test-range-slider-output
-          htmlFor={{@id}}
+          htmlFor={{this.id}}
           class="Polaris-RangeSlider__Output"
         >
           <div class="Polaris-RangeSlider__OutputBubble">

--- a/addon/templates/components/polaris-range-slider.hbs
+++ b/addon/templates/components/polaris-range-slider.hbs
@@ -1,12 +1,20 @@
-<PolarisLabelled @dataTestLabelled={{dataTestRangeSlider}} @id={{id}} @label={{label}} @error={{error}} @action={{labelAction}} @labelHidden={{labelHidden}} @helpText={{helpText}}>
+<PolarisLabelled
+  @dataTestLabelled={{dataTestRangeSlider}}
+  @id={{@id}}
+  @label={{@label}}
+  @error={{@error}}
+  @action={{@labelAction}}
+  @labelHidden={{@labelHidden}}
+  @helpText={{@helpText}}
+>
   <div
     data-test-range-slider-wrapper
-    class={{rangeWrapperClassNames}}
-    style={{rangeWrapperStyle}}
+    class={{this.rangeWrapperClassNames}}
+    style={{this.rangeWrapperStyle}}
   >
-    {{#if prefix}}
+    {{#if @prefix}}
       <div data-test-range-slider-prefix class="Polaris-RangeSlider__Prefix">
-        {{render-content prefix}}
+        {{render-content @prefix}}
       </div>
     {{/if}}
 
@@ -15,39 +23,39 @@
         data-test-range-slider-input
         type="range"
         class="Polaris-RangeSlider__Input"
-        id={{id}}
-        name={{id}}
-        min={{min}}
-        max={{max}}
-        step={{step}}
-        value={{value}}
-        disabled={{disabled}}
-        oninput={{action "handleChange"}}
-        onfocus={{action onFocus}}
-        onblur={{action onBlur}}
-        aria-valuemin={{min}}
-        aria-valuemax={{max}}
-        aria-valuenow={{value}}
-        aria-invalid={{hasError}}
-        aria-describedby={{ariaDescribedBy}}
+        id={{@id}}
+        name={{@id}}
+        min={{@min}}
+        max={{@max}}
+        step={{@step}}
+        value={{@value}}
+        disabled={{@disabled}}
+        oninput={{fn this.handleChange}}
+        onfocus={{fn this.onFocus}}
+        onblur={{fn this.onBlur}}
+        aria-valuemin={{@min}}
+        aria-valuemax={{@max}}
+        aria-valuenow={{@value}}
+        aria-invalid={{this.hasError}}
+        aria-describedby={{this.ariaDescribedBy}}
       >
 
-      {{#if shouldShowOutput}}
+      {{#if this.shouldShowOutput}}
         <output
           data-test-range-slider-output
-          htmlFor={{id}}
+          htmlFor={{@id}}
           class="Polaris-RangeSlider__Output"
         >
           <div class="Polaris-RangeSlider__OutputBubble">
-            <span class="Polaris-RangeSlider__OutputText">{{value}}</span>
+            <span class="Polaris-RangeSlider__OutputText">{{@value}}</span>
           </div>
         </output>
       {{/if}}
     </div>
 
-    {{#if suffix}}
+    {{#if @suffix}}
       <div data-test-range-slider-suffix class="Polaris-RangeSlider__Suffix">
-        {{render-content suffix}}
+        {{render-content @suffix}}
       </div>
     {{/if}}
   </div>

--- a/addon/templates/components/polaris-range-slider.hbs
+++ b/addon/templates/components/polaris-range-slider.hbs
@@ -1,12 +1,4 @@
-{{#polaris-labelled
-  dataTestLabelled=dataTestRangeSlider
-  id=id
-  label=label
-  error=error
-  action=labelAction
-  labelHidden=labelHidden
-  helpText=helpText
-}}
+<PolarisLabelled @dataTestLabelled={{dataTestRangeSlider}} @id={{id}} @label={{label}} @error={{error}} @action={{labelAction}} @labelHidden={{labelHidden}} @helpText={{helpText}}>
   <div
     data-test-range-slider-wrapper
     class={{rangeWrapperClassNames}}
@@ -59,4 +51,4 @@
       </div>
     {{/if}}
   </div>
-{{/polaris-labelled}}
+</PolarisLabelled>

--- a/addon/templates/components/polaris-range-slider.hbs
+++ b/addon/templates/components/polaris-range-slider.hbs
@@ -1,6 +1,6 @@
 <PolarisLabelled
   @dataTestLabelled={{this.dataTestRangeSlider}}
-  @id={{this.id}}
+  @id={{or @id this.id}}
   @label={{@label}}
   @error={{@error}}
   @action={{@labelAction}}
@@ -23,18 +23,18 @@
         data-test-range-slider-input
         type="range"
         class="Polaris-RangeSlider__Input"
-        id={{this.id}}
-        name={{this.id}}
-        min={{this.min}}
-        max={{this.max}}
+        id={{or @id this.id}}
+        name={{or @id this.id}}
+        min={{or @min this.min}}
+        max={{or @max this.max}}
         step={{@step}}
         value={{@value}}
         disabled={{@disabled}}
         oninput={{fn this.handleChange}}
-        onfocus={{fn this.onFocus}}
-        onblur={{fn this.onBlur}}
-        aria-valuemin={{this.min}}
-        aria-valuemax={{this.max}}
+        onfocus={{fn (or @onFocus this.onFocus)}}
+        onblur={{fn (or @onBlur this.onBlur)}}
+        aria-valuemin={{or @min this.min}}
+        aria-valuemax={{or @max this.max}}
         aria-valuenow={{@value}}
         aria-invalid={{this.hasError}}
         aria-describedby={{this.ariaDescribedBy}}
@@ -43,7 +43,7 @@
       {{#if this.shouldShowOutput}}
         <output
           data-test-range-slider-output
-          htmlFor={{this.id}}
+          htmlFor={{or @id this.id}}
           class="Polaris-RangeSlider__Output"
         >
           <div class="Polaris-RangeSlider__OutputBubble">


### PR DESCRIPTION
[DEV-77](https://smileio.atlassian.net/secure/RapidBoard.jspa?rapidView=6&modal=detail&selectedIssue=DEV-77)

Updates `PolarisRangeSlider` to tagless component, ES6 classes, and angle bracket syntax.

Dummy app:

![range](https://user-images.githubusercontent.com/2292367/74188807-d2ec9b80-4c14-11ea-921a-cf85bb7a4ce5.gif)

^ I'm not sure what's going on with the positioning here but this is also happening on `master` but not in any apps that actually use `ember-polaris`, so I'm guessing it's just something weird with the way styles are being pulled from Polaris into the dummy app.