### PR TITLE
Modernize polaris-resource-list components

### DIFF
--- a/addon/components/polaris-resource-list.js
+++ b/addon/components/polaris-resource-list.js
@@ -1,9 +1,10 @@
 import Component from '@ember/component';
-import { computed, get } from '@ember/object';
-import { guidFor } from '@ember/object/internals';
 import { gt } from '@ember/object/computed';
+import { get, computed } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
 import { htmlSafe } from '@ember/string';
 import { assert } from '@ember/debug';
+import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import ContextBoundEventListenersMixin from 'ember-lifeline/mixins/dom';
 import ContextBoundTasksMixin from 'ember-lifeline/mixins/run';
 import createContext from 'ember-context';
@@ -28,809 +29,779 @@ const LARGE_SPINNER_HEIGHT = 45;
  * Polaris resource list component.
  * See https://polaris.shopify.com/components/lists-and-tables/resource-list
  */
-export default Component.extend(
-  ContextBoundEventListenersMixin,
-  ContextBoundTasksMixin,
-  {
-    tagName: '',
+@tagName('')
+@templateLayout(layout)
+export default class PolarisResourceList extends Component.extend(ContextBoundEventListenersMixin, ContextBoundTasksMixin) {
+  /**
+   * Item data; each item is passed to renderItem
+   *
+   * @property items
+   * @type {Array}
+   * @default null
+   * @public
+   */
+  items = null;
 
-    layout,
+  /**
+   * @property filterControl
+   * @type {String|Component|Object}
+   * @default null
+   * @public
+   */
+  filterControl = null;
 
-    /**
-     * Item data; each item is passed to renderItem
-     *
-     * @property items
-     * @type {Array}
-     * @default null
-     * @public
-     */
-    items: null,
+  /**
+   * Name of the resource, such as customers or products
+   * Object with `singular` and `plural` properties
+   *
+   * @property resourceName
+   * @type {Object}
+   * @default null
+   * @public
+   */
+  resourceName = null;
 
-    /**
-     * @property filterControl
-     * @type {String|Component|Object}
-     * @default null
-     * @public
-     */
-    filterControl: null,
+  /**
+   * Up to 2 bulk actions that will be given more prominence
+   * Array of objects with properties:
+   *  id
+   *  content
+   *  accessibilityLabel
+   *  url
+   *  external
+   *  disabled
+   *  onAction
+   *
+   * @property promotedBulkActions
+   * @type {Object[]}
+   * @default null
+   * @public
+   */
+  promotedBulkActions = null;
 
-    /**
-     * Name of the resource, such as customers or products
-     * Object with `singular` and `plural` properties
-     *
-     * @property resourceName
-     * @type {Object}
-     * @default null
-     * @public
-     */
-    resourceName: null,
+  /**
+   * Actions available on the currently selected items
+   * Array of action objects with properties:
+   *  id
+   *  content
+   *  accessibilityLabel
+   *  url
+   *  external
+   *  disabled
+   *  onAction
+   *
+   * or section object with properties:
+   *  title
+   *  items
+   *
+   * where items is a list of action objects
+   *
+   * @property bulkActions
+   * @type {Object[]}
+   * @default null
+   * @public
+   */
+  bulkActions = null;
 
-    /**
-     * Up to 2 bulk actions that will be given more prominence
-     * Array of objects with properties:
-     *  id
-     *  content
-     *  accessibilityLabel
-     *  url
-     *  external
-     *  disabled
-     *  onAction
-     *
-     * @property promotedBulkActions
-     * @type {Object[]}
-     * @default null
-     * @public
-     */
-    promotedBulkActions: null,
+  /**
+   * Collection of IDs for the currently selected items
+   * Can be either an array of IDs, or the string literal 'All'
+   *
+   * @property selectedItems
+   * @type {String|String[]}
+   * @default null
+   * @public
+   */
+  selectedItems = null;
 
-    /**
-     * Actions available on the currently selected items
-     * Array of action objects with properties:
-     *  id
-     *  content
-     *  accessibilityLabel
-     *  url
-     *  external
-     *  disabled
-     *  onAction
-     *
-     * or section object with properties:
-     *  title
-     *  items
-     *
-     * where items is a list of action objects
-     *
-     * @property bulkActions
-     * @type {Object[]}
-     * @default null
-     * @public
-     */
-    bulkActions: null,
+  /**
+   * If there are more items than currently in the list
+   *
+   * @property hasMoreItems
+   * @type {Boolean}
+   * @default false
+   * @public
+   */
+  hasMoreItems = false;
 
-    /**
-     * Collection of IDs for the currently selected items
-     * Can be either an array of IDs, or the string literal 'All'
-     *
-     * @property selectedItems
-     * @type {String|String[]}
-     * @default null
-     * @public
-     */
-    selectedItems: null,
+  /**
+   * Overlays item list with a spinner while a background action is being performed
+   *
+   * @property loading
+   * @type {Boolean}
+   * @default false
+   * @public
+   */
+  loading = false;
 
-    /**
-     * If there are more items than currently in the list
-     *
-     * @property hasMoreItems
-     * @type {Boolean}
-     * @default false
-     * @public
-     */
-    hasMoreItems: false,
+  /**
+   * Boolean to show or hide the header
+   *
+   * @property showHeader
+   * @type {Boolean}
+   * @default false
+   * @public
+   */
+  showHeader = false;
 
-    /**
-     * Overlays item list with a spinner while a background action is being performed
-     *
-     * @property loading
-     * @type {Boolean}
-     * @default false
-     * @public
-     */
-    loading: false,
+  /**
+   * Current value of the sort control
+   *
+   * @property sortValue
+   * @type {String}
+   * @default null
+   * @public
+   */
+  sortValue = null;
 
-    /**
-     * Boolean to show or hide the header
-     *
-     * @property showHeader
-     * @type {Boolean}
-     * @default false
-     * @public
-     */
-    showHeader: false,
+  /**
+   * Collection of sort options to choose from
+   * Properties are the same as for polaris-select's options
+   *
+   * @property sortOptions
+   * @type {(String|Object)[]}
+   * @default null
+   * @public
+   */
+  sortOptions = null;
 
-    /**
-     * Current value of the sort control
-     *
-     * @property sortValue
-     * @type {String}
-     * @default null
-     * @public
-     */
-    sortValue: null,
+  /**
+   * Component to display instead of the sort control
+   *
+   * @property alternateTool
+   * @type {Component|Object}
+   * @default null
+   * @public
+   */
+  alternateTool = null;
 
-    /**
-     * Collection of sort options to choose from
-     * Properties are the same as for polaris-select's options
-     *
-     * @property sortOptions
-     * @type {(String|Object)[]}
-     * @default null
-     * @public
-     */
-    sortOptions: null,
+  /**
+   * Component to render each list item
+   * This is in place of the React implementation's
+   * renderItem property
+   *
+   * @property itemComponent
+   * @type {String|Component}
+   * @default null
+   * @public
+   * @required
+   */
+  itemComponent = null;
 
-    /**
-     * Component to display instead of the sort control
-     *
-     * @property alternateTool
-     * @type {Component|Object}
-     * @default null
-     * @public
-     */
-    alternateTool: null,
+  /**
+   * Callback when selection is changed
+   *
+   * @property onSelectionChange
+   * @type {Function}
+   * @default null
+   * @public
+   */
+  onSelectionChange = null;
 
-    /**
-     * Component to render each list item
-     * This is in place of the React implementation's
-     * renderItem property
-     *
-     * @property itemComponent
-     * @type {String|Component}
-     * @default null
-     * @public
-     * @required
-     */
-    itemComponent: null,
+  /**
+   * Function to customize the unique ID for each item
+   *
+   * @property idForItem
+   * @type {Function}
+   * @default null
+   * @public
+   */
+  idForItem = null;
 
-    /**
-     * Callback when selection is changed
-     *
-     * @property onSelectionChange
-     * @type {Function}
-     * @default null
-     * @public
-     */
-    onSelectionChange: null,
+  /**
+   * Callback when sort option is changed
+   *
+   * @property onSortChange
+   * @type {Function}
+   * @default noop
+   * @public
+   */
+  onSortChange() {}
 
-    /**
-     * Function to customize the unique ID for each item
-     *
-     * @property idForItem
-     * @type {Function}
-     * @default null
-     * @public
-     */
-    idForItem: null,
+  /**
+   * @property selectMode
+   * @type {Boolean}
+   * @default false
+   * @private
+   */
+  selectMode = false;
 
-    /**
-     * Callback when sort option is changed
-     *
-     * @property onSortChange
-     * @type {Function}
-     * @default noop
-     * @public
-     */
-    onSortChange() {},
+  /**
+   * @property loadingPosition
+   * @type {Number}
+   * @default 0
+   * @private
+   */
+  loadingPosition = 0;
 
-    /**
-     * @property selectMode
-     * @type {Boolean}
-     * @default false
-     * @private
-     */
-    selectMode: false,
+  /**
+   * Reference to the `ul` element that makes up the main list.
+   * This is used in place of the React implementation's `listRef`.
+   *
+   * @property listNode
+   * @type {HTMLUListElement}
+   * @default null
+   * @private
+   */
+  listNode = null;
 
-    /**
-     * @property loadingPosition
-     * @type {Number}
-     * @default 0
-     * @private
-     */
-    loadingPosition: 0,
+  /**
+   * @property defaultResourceName
+   * @type {Object}
+   * @private
+   */
+  defaultResourceName = null;
 
-    /**
-     * Reference to the `ul` element that makes up the main list.
-     * This is used in place of the React implementation's `listRef`.
-     *
-     * @property listNode
-     * @type {HTMLUListElement}
-     * @default null
-     * @private
-     */
-    listNode: null,
+  /**
+   * Internal property used to recreate React implementation's
+   * `componentDidUpdate` behaviour.
+   *
+   * @property previousLoading
+   * @type {Boolean}
+   * @private
+   */
+  previousLoading = false;
 
-    /**
-     * @property defaultResourceName
-     * @type {Object}
-     * @private
-     */
-    defaultResourceName: null,
+  /**
+   * Internal property used to recreate React implementation's
+   * `componentWillReceiveProps` behaviour.
+   *
+   * @property previousSelectedItems
+   * @type {String|String[]}
+   * @private
+   */
+  previousSelectedItems = null;
 
-    /**
-     * Internal property used to recreate React implementation's
-     * `componentDidUpdate` behaviour.
-     *
-     * @property previousLoading
-     * @type {Boolean}
-     * @private
-     */
-    previousLoading: false,
+  @(gt('items.length', 0).readOnly())
+  itemsExist;
 
-    /**
-     * Internal property used to recreate React implementation's
-     * `componentWillReceiveProps` behaviour.
-     *
-     * @property previousSelectedItems
-     * @type {String|String[]}
-     * @private
-     */
-    previousSelectedItems: null,
+  @(computedIdVariation('id', 'Select').readOnly())
+  selectId;
 
-    itemsExist: gt('items.length', 0).readOnly(),
+  /**
+   * ID used to identify our wrapper element from other instances
+   */
+  @(computed.readOnly())
+  get wrapperId() {
+    return guidFor(this);
+  }
 
-    selectId: computedIdVariation('id', 'Select').readOnly(),
+  /**
+   * List of item/id tuples needed for rendering items
+   */
+  @(computed('items.[]', 'idForItem').readOnly())
+  get itemsWithId() {
+    let { items, idForItem } = this.getProperties('items', 'idForItem');
+    items = items || [];
+    idForItem = idForItem || defaultIdForItem;
 
-    /**
-     * ID used to identify our wrapper element from other instances
-     */
-    wrapperId: computed(function() {
-      return guidFor(this);
-    }).readOnly(),
+    return items.map((item, index) => {
+      return {
+        item,
+        id: idForItem(item, index),
+      };
+    });
+  }
 
-    /**
-     * List of item/id tuples needed for rendering items
-     */
-    itemsWithId: computed('items.[]', 'idForItem', function() {
-      let { items, idForItem } = this.getProperties('items', 'idForItem');
-      items = items || [];
-      idForItem = idForItem || defaultIdForItem;
-
-      return items.map((item, index) => {
-        return {
-          item,
-          id: idForItem(item, index),
-        };
-      });
-    }).readOnly(),
-
-    needsHeader: computed(
+  @(computed('selectable', 'sortOptions.length', 'alternateTool').readOnly())
+  get needsHeader() {
+    let { selectable, sortOptions, alternateTool } = this.getProperties(
       'selectable',
-      'sortOptions.length',
-      'alternateTool',
-      function() {
-        let { selectable, sortOptions, alternateTool } = this.getProperties(
-          'selectable',
-          'sortOptions',
-          'alternateTool'
-        );
-        return (
-          selectable || (sortOptions && sortOptions.length > 0) || alternateTool
-        );
-      }
-    ).readOnly(),
+      'sortOptions',
+      'alternateTool'
+    );
+    return (
+      selectable || (sortOptions && sortOptions.length > 0) || alternateTool
+    );
+  }
 
-    selectable: computed(
-      'promotedBulkActions.length',
-      'bulkActions.length',
-      function() {
-        let { promotedBulkActions, bulkActions } = this.getProperties(
-          'promotedBulkActions',
-          'bulkActions'
-        );
-        return Boolean(
-          (promotedBulkActions && promotedBulkActions.length > 0) ||
-            (bulkActions && bulkActions.length > 0)
-        );
-      }
-    ).readOnly(),
+  @(computed('promotedBulkActions.length', 'bulkActions.length').readOnly())
+  get selectable() {
+    let { promotedBulkActions, bulkActions } = this.getProperties(
+      'promotedBulkActions',
+      'bulkActions'
+    );
+    return Boolean(
+      (promotedBulkActions && promotedBulkActions.length > 0) ||
+        (bulkActions && bulkActions.length > 0)
+    );
+  }
 
-    bulkSelectState: computed(
-      'selectedItems.length',
-      'items.length',
-      function() {
-        let { selectedItems, items } = this.getProperties(
-          'selectedItems',
-          'items'
-        );
-        let selectState = 'indeterminate';
-        if (
-          !selectedItems ||
-          (Array.isArray(selectedItems) && selectedItems.length === 0)
-        ) {
-          selectState = false;
-        } else if (
-          selectedItems === SELECT_ALL_ITEMS ||
-          (Array.isArray(selectedItems) &&
-            selectedItems.length === items.length)
-        ) {
-          selectState = true;
-        }
-        return selectState;
-      }
-    ).readOnly(),
+  @(computed('selectedItems.length', 'items.length').readOnly())
+  get bulkSelectState() {
+    let { selectedItems, items } = this.getProperties(
+      'selectedItems',
+      'items'
+    );
+    let selectState = 'indeterminate';
+    if (
+      !selectedItems ||
+      (Array.isArray(selectedItems) && selectedItems.length === 0)
+    ) {
+      selectState = false;
+    } else if (
+      selectedItems === SELECT_ALL_ITEMS ||
+      (Array.isArray(selectedItems) &&
+        selectedItems.length === items.length)
+    ) {
+      selectState = true;
+    }
+    return selectState;
+  }
 
-    headerTitle: computed(
-      'resourceName.{singular,plural}',
-      'items.length',
-      'loading',
-      function() {
-        let { resourceName, items, loading } = this.getProperties(
-          'resourceName',
-          'items',
-          'loading'
-        );
-        resourceName = resourceName || this.get('defaultResourceName');
+  @(
+    computed('resourceName.{singular,plural}', 'items.length', 'loading').readOnly()
+  )
+  get headerTitle() {
+    let { resourceName, items, loading } = this.getProperties(
+      'resourceName',
+      'items',
+      'loading'
+    );
+    resourceName = resourceName || this.get('defaultResourceName');
 
-        let itemsCount = items.length;
-        let resource =
-          itemsCount === 1 && !loading
-            ? get(resourceName, 'singular')
-            : get(resourceName, 'plural');
+    let itemsCount = items.length;
+    let resource =
+      itemsCount === 1 && !loading
+        ? get(resourceName, 'singular')
+        : get(resourceName, 'plural');
 
-        return loading
-          ? `Loading ${resource}`
-          : `Showing ${itemsCount} ${resource}`;
-      }
-    ).readOnly(),
+    return loading
+      ? `Loading ${resource}`
+      : `Showing ${itemsCount} ${resource}`;
+  }
 
-    bulkActionsLabel: computed(
-      'selectedItems.length',
-      'items.length',
-      function() {
-        let { selectedItems, items } = this.getProperties(
-          'selectedItems',
-          'items'
-        );
-        selectedItems = selectedItems || [];
+  @(computed('selectedItems.length', 'items.length').readOnly())
+  get bulkActionsLabel() {
+    let { selectedItems, items } = this.getProperties(
+      'selectedItems',
+      'items'
+    );
+    selectedItems = selectedItems || [];
 
-        let selectedItemsCount =
-          selectedItems === SELECT_ALL_ITEMS
-            ? `${items.length}+`
-            : selectedItems.length;
+    let selectedItemsCount =
+      selectedItems === SELECT_ALL_ITEMS
+        ? `${items.length}+`
+        : selectedItems.length;
 
-        return `${selectedItemsCount} selected`;
-      }
-    ).readOnly(),
+    return `${selectedItemsCount} selected`;
+  }
 
-    bulkActionsAccessibilityLabel: computed(
-      'resourceName.{singular,plural}',
-      'selectedItems.length',
-      'items.length',
-      function() {
-        let { resourceName, selectedItems, items } = this.getProperties(
-          'resourceName',
-          'selectedItems',
-          'items'
-        );
-        resourceName = resourceName || this.get('defaultResourceName');
-        selectedItems = selectedItems || [];
+  @(
+    computed('resourceName.{singular,plural}', 'selectedItems.length', 'items.length').readOnly()
+  )
+  get bulkActionsAccessibilityLabel() {
+    let { resourceName, selectedItems, items } = this.getProperties(
+      'resourceName',
+      'selectedItems',
+      'items'
+    );
+    resourceName = resourceName || this.get('defaultResourceName');
+    selectedItems = selectedItems || [];
 
-        let selectedItemsCount = selectedItems.length;
-        let totalItemsCount = items.length;
-        let allSelected = selectedItemsCount === totalItemsCount;
+    let selectedItemsCount = selectedItems.length;
+    let totalItemsCount = items.length;
+    let allSelected = selectedItemsCount === totalItemsCount;
 
-        if (totalItemsCount === 1 && allSelected) {
-          return `Deselect ${get(resourceName, 'singular')}`;
-        } else if (totalItemsCount === 1) {
-          return `Select ${get(resourceName, 'singular')}`;
-        } else if (allSelected) {
-          return `Deselect all ${items.length} ${get(resourceName, 'plural')}`;
-        } else {
-          return `Select all ${items.length} ${get(resourceName, 'plural')}`;
-        }
-      }
-    ).readOnly(),
+    if (totalItemsCount === 1 && allSelected) {
+      return `Deselect ${get(resourceName, 'singular')}`;
+    } else if (totalItemsCount === 1) {
+      return `Select ${get(resourceName, 'singular')}`;
+    } else if (allSelected) {
+      return `Deselect all ${items.length} ${get(resourceName, 'plural')}`;
+    } else {
+      return `Select all ${items.length} ${get(resourceName, 'plural')}`;
+    }
+  }
 
-    paginatedSelectAllText: computed(
+  @(
+    computed('hasMoreItems', 'selectedItems', 'items.length', 'resourceName.plural').readOnly()
+  )
+  get paginatedSelectAllText() {
+    let {
+      hasMoreItems,
+      selectedItems,
+      items,
+      resourceName,
+    } = this.getProperties(
       'hasMoreItems',
       'selectedItems',
-      'items.length',
-      'resourceName.plural',
-      function() {
-        let {
-          hasMoreItems,
-          selectedItems,
-          items,
-          resourceName,
-        } = this.getProperties(
-          'hasMoreItems',
-          'selectedItems',
-          'items',
-          'resourceName'
-        );
-        resourceName = resourceName || this.get('defaultResourceName');
+      'items',
+      'resourceName'
+    );
+    resourceName = resourceName || this.get('defaultResourceName');
 
-        if (!this.get('selectable') || !hasMoreItems) {
-          return null;
-        }
+    if (!this.get('selectable') || !hasMoreItems) {
+      return null;
+    }
 
-        if (selectedItems === SELECT_ALL_ITEMS) {
-          return `All ${items.length}+ ${get(
+    if (selectedItems === SELECT_ALL_ITEMS) {
+      return `All ${items.length}+ ${get(
+        resourceName,
+        'plural'
+      )} in your store are selected.`;
+    }
+
+    return null;
+  }
+
+  @(
+    computed('hasMoreItems', 'selectedItems', 'items.length', 'resourceName.plural').readOnly()
+  )
+  get paginatedSelectAllAction() {
+    let {
+      hasMoreItems,
+      selectedItems,
+      items,
+      resourceName,
+    } = this.getProperties(
+      'hasMoreItems',
+      'selectedItems',
+      'items',
+      'resourceName'
+    );
+    resourceName = resourceName || this.get('defaultResourceName');
+
+    if (!this.get('selectable') || !hasMoreItems) {
+      return;
+    }
+
+    let actionText =
+      selectedItems === SELECT_ALL_ITEMS
+        ? 'Undo'
+        : `Select all ${items.length}+ ${get(
             resourceName,
             'plural'
-          )} in your store are selected.`;
-        }
+          )} in your store`;
 
-        return null;
-      }
-    ).readOnly(),
+    return {
+      content: actionText,
+      onAction: () => this.handleSelectAllItemsInStore,
+    };
+  }
 
-    paginatedSelectAllAction: computed(
-      'hasMoreItems',
-      'selectedItems',
-      'items.length',
-      'resourceName.plural',
-      function() {
-        let {
-          hasMoreItems,
-          selectedItems,
-          items,
-          resourceName,
-        } = this.getProperties(
-          'hasMoreItems',
-          'selectedItems',
-          'items',
-          'resourceName'
-        );
-        resourceName = resourceName || this.get('defaultResourceName');
+  @(computed('resourceName.plural').readOnly())
+  get emptySearchResultTitle() {
+    let resourceName =
+      this.get('resourceName') || this.get('defaultResourceName');
 
-        if (!this.get('selectable') || !hasMoreItems) {
-          return;
-        }
+    return `No ${get(resourceName, 'plural')} found`;
+  }
 
-        let actionText =
-          selectedItems === SELECT_ALL_ITEMS
-            ? 'Undo'
-            : `Select all ${items.length}+ ${get(
-                resourceName,
-                'plural'
-              )} in your store`;
-
-        return {
-          content: actionText,
-          onAction: () => this.handleSelectAllItemsInStore,
-        };
-      }
-    ).readOnly(),
-
-    emptySearchResultTitle: computed('resourceName.plural', function() {
-      let resourceName =
-        this.get('resourceName') || this.get('defaultResourceName');
-
-      return `No ${get(resourceName, 'plural')} found`;
-    }).readOnly(),
-
-    showEmptyState: computed(
+  @(computed('filterControl', 'itemsExist', 'loading').readOnly())
+  get showEmptyState() {
+    let { filterControl, itemsExist, loading } = this.getProperties(
       'filterControl',
       'itemsExist',
-      'loading',
-      function() {
-        let { filterControl, itemsExist, loading } = this.getProperties(
-          'filterControl',
-          'itemsExist',
-          'loading'
-        );
+      'loading'
+    );
 
-        return filterControl && !itemsExist && !loading;
-      }
-    ).readOnly(),
+    return filterControl && !itemsExist && !loading;
+  }
 
-    spinnerStyle: computed('loadingPosition', function() {
-      let loadingPosition = this.get('loadingPosition');
-      let defaultTopPadding = 8;
-      let topPadding =
-        loadingPosition > 0 ? loadingPosition : defaultTopPadding;
-      return htmlSafe(`padding-top: ${topPadding}px`);
-    }).readOnly(),
+  @(computed('loadingPosition').readOnly())
+  get spinnerStyle() {
+    let loadingPosition = this.get('loadingPosition');
+    let defaultTopPadding = 8;
+    let topPadding =
+      loadingPosition > 0 ? loadingPosition : defaultTopPadding;
+    return htmlSafe(`padding-top: ${topPadding}px`);
+  }
 
-    spinnerSize: computed('items.length', function() {
-      return this.get('items.length') < 2 ? 'small' : 'large';
-    }).readOnly(),
+  @(computed('items.length').readOnly())
+  get spinnerSize() {
+    return this.get('items.length') < 2 ? 'small' : 'large';
+  }
 
-    context: computed(
-      'selectedItems.[]',
+  @(
+    computed('selectedItems.[]', 'resourceName', 'loading', 'selectMode', 'selectable').readOnly()
+  )
+  get context() {
+    let {
+      selectedItems,
+      resourceName,
+      loading,
+      selectMode,
+      selectable,
+    } = this.getProperties(
+      'selectedItems',
       'resourceName',
       'loading',
       'selectMode',
-      'selectable',
-      function() {
-        let {
-          selectedItems,
-          resourceName,
-          loading,
-          selectMode,
-          selectable,
-        } = this.getProperties(
-          'selectedItems',
-          'resourceName',
-          'loading',
-          'selectMode',
-          'selectable'
-        );
-        resourceName = resourceName || this.get('defaultResourceName');
-        return {
-          selectable,
-          selectedItems,
-          selectMode,
-          resourceName,
-          loading,
-          onSelectionChange: (...args) => {
-            return this.handleSelectionChange(...args);
-          },
-        };
-      }
-    ).readOnly(),
-
-    handleResize() {
-      // This is needed to replicate the React implementation's `@debounce` decorator.
-      this.debounceTask('debouncedHandleResize', 0);
-    },
-
-    debouncedHandleResize() {
-      // In the React implementation, the resize event listener
-      // is only rendered when `selectable` is truthy. We handle
-      // that by bombing out of this handler when that condition
-      // is met rather than dynamically managing event listeners.
-      if (!this.get('selectable')) {
-        return;
-      }
-
-      let { selectedItems, selectMode } = this.getProperties(
-        'selectedItems',
-        'selectMode'
-      );
-
-      if (
-        selectedItems &&
-        selectedItems.length === 0 &&
-        selectMode &&
-        !isSmallScreen()
-      ) {
-        this.handleSelectMode(false);
-      }
-    },
-
-    setLoadingPosition() {
-      let listNode = this.get('listNode');
-
-      if (listNode != null) {
-        if (typeof window === 'undefined') {
-          return;
-        }
-
-        let overlay = listNode.getBoundingClientRect();
-        let viewportHeight = Math.max(
-          document.documentElement ? document.documentElement.clientHeight : 0,
-          window.innerHeight || 0
-        );
-
-        let overflow = viewportHeight - overlay.height;
-
-        let spinnerHeight =
-          this.get('items.length') === 1
-            ? SMALL_SPINNER_HEIGHT
-            : LARGE_SPINNER_HEIGHT;
-
-        let spinnerPosition =
-          overflow > 0
-            ? (overlay.height - spinnerHeight) / 2
-            : (viewportHeight - overlay.top - spinnerHeight) / 2;
-
-        this.set('loadingPosition', spinnerPosition);
-      }
-    },
-
-    handleSelectAllItemsInStore() {
-      let {
-        onSelectionChange,
-        selectedItems,
-        items,
-        idForItem,
-      } = this.getProperties(
-        'onSelectionChange',
-        'selectedItems',
-        'items',
-        'idForItem'
-      );
-      idForItem = idForItem || defaultIdForItem;
-
-      let newlySelectedItems =
-        selectedItems === SELECT_ALL_ITEMS
-          ? getAllItemsOnPage(items, idForItem)
-          : SELECT_ALL_ITEMS;
-
-      if (onSelectionChange) {
-        onSelectionChange(newlySelectedItems);
-      }
-    },
-
-    handleSelectionChange(selected, id) {
-      let {
-        onSelectionChange,
-        selectedItems,
-        items,
-        idForItem,
-      } = this.getProperties(
-        'onSelectionChange',
-        'selectedItems',
-        'items',
-        'idForItem'
-      );
-      idForItem = idForItem || defaultIdForItem;
-
-      if (selectedItems == null || onSelectionChange == null) {
-        return;
-      }
-
-      let newlySelectedItems =
-        selectedItems === SELECT_ALL_ITEMS
-          ? getAllItemsOnPage(items, idForItem)
-          : [...selectedItems];
-
-      if (selected) {
-        newlySelectedItems.push(id);
-      } else {
-        newlySelectedItems.splice(newlySelectedItems.indexOf(id), 1);
-      }
-
-      if (newlySelectedItems.length === 0 && !isSmallScreen()) {
-        this.handleSelectMode(false);
-      } else if (newlySelectedItems.length > 0) {
-        this.handleSelectMode(true);
-      }
-
-      if (onSelectionChange) {
-        onSelectionChange(newlySelectedItems);
-      }
-    },
-
-    handleSelectMode(selectMode) {
-      let onSelectionChange = this.get('onSelectionChange');
-      this.set('selectMode', selectMode);
-      if (!selectMode && onSelectionChange) {
-        onSelectionChange([]);
-      }
-    },
-
-    handleToggleAll() {
-      let {
-        onSelectionChange,
-        selectedItems,
-        items,
-        idForItem,
-      } = this.getProperties(
-        'onSelectionChange',
-        'selectedItems',
-        'items',
-        'idForItem'
-      );
-      idForItem = idForItem || defaultIdForItem;
-
-      let newlySelectedItems = [];
-
-      if (
-        (Array.isArray(selectedItems) &&
-          selectedItems.length === items.length) ||
-        selectedItems === SELECT_ALL_ITEMS
-      ) {
-        newlySelectedItems = [];
-      } else {
-        newlySelectedItems = items.map((item, index) => {
-          let id = idForItem(item, index);
-          return id;
-        });
-      }
-
-      if (newlySelectedItems.length === 0 && !isSmallScreen()) {
-        this.handleSelectMode(false);
-      } else if (newlySelectedItems.length > 0) {
-        this.handleSelectMode(true);
-      }
-
-      if (onSelectionChange) {
-        onSelectionChange(newlySelectedItems);
-      }
-    },
-
-    setListNode() {
-      let listNode =
-        document.querySelector(
-          `#${this.get('wrapperId')} ul.Polaris-ResourceList`
-        ) || null;
-      this.set('listNode', listNode);
-    },
-
-    init() {
-      this._super(...arguments);
-
-      let selectedItems = this.get('selectedItems');
-      this.setProperties({
-        defaultResourceName: {
-          singular: 'item',
-          plural: 'items',
-        },
-        selectMode: Boolean(selectedItems && selectedItems.length > 0),
-      });
-    },
-
-    didReceiveAttrs() {
-      this._super(...arguments);
-
-      assert(
-        'ember-polaris::polaris-resource-list - itemComponent must be a component name or definition',
-        this.get('itemComponent')
-      );
-
-      // This logic is in the React implementation's
-      // `componentWillReceiveProps` hook.
-      let { selectedItems, previousSelectedItems } = this.getProperties(
-        'selectedItems',
-        'previousSelectedItems'
-      );
-
-      if (
-        previousSelectedItems &&
-        previousSelectedItems.length > 0 &&
-        (!selectedItems || selectedItems.length === 0) &&
-        !isSmallScreen()
-      ) {
-        this.set('selectMode', false);
-      }
-
-      // This logic is in the React implementation's
-      // `componentDidUpdate` hook.
-
-      // TODO: check if we need this that's in the React implementation.
-      // if (
-      //    this.listRef.current &&
-      //    this.itemsExist() &&
-      //    !this.itemsExist(prevItems)
-      //  ) {
-      //    this.forceUpdate(); -> triggers rerender of component.
-      //  }
-
-      let { loading, previousLoading } = this.getProperties(
-        'loading',
-        'previousLoading'
-      );
-
-      if (loading && !previousLoading) {
-        this.setLoadingPosition();
-      }
-
-      this.setProperties({
-        previousSelectedItems: selectedItems,
-        previousLoading: loading,
-      });
-    },
-
-    didInsertElement() {
-      this._super(...arguments);
-
-      this.addEventListener(window, 'resize', this.handleResize);
-
-      if (this.get('loading')) {
-        this.setLoadingPosition();
-      }
-    },
-
-    didRender() {
-      this._super(...arguments);
-
-      this.setListNode();
-    },
+      'selectable'
+    );
+    resourceName = resourceName || this.get('defaultResourceName');
+    return {
+      selectable,
+      selectedItems,
+      selectMode,
+      resourceName,
+      loading,
+      onSelectionChange: (...args) => {
+        return this.handleSelectionChange(...args);
+      },
+    };
   }
-);
+
+  handleResize() {
+    // This is needed to replicate the React implementation's `@debounce` decorator.
+    this.debounceTask('debouncedHandleResize', 0);
+  }
+
+  debouncedHandleResize() {
+    // In the React implementation, the resize event listener
+    // is only rendered when `selectable` is truthy. We handle
+    // that by bombing out of this handler when that condition
+    // is met rather than dynamically managing event listeners.
+    if (!this.get('selectable')) {
+      return;
+    }
+
+    let { selectedItems, selectMode } = this.getProperties(
+      'selectedItems',
+      'selectMode'
+    );
+
+    if (
+      selectedItems &&
+      selectedItems.length === 0 &&
+      selectMode &&
+      !isSmallScreen()
+    ) {
+      this.handleSelectMode(false);
+    }
+  }
+
+  setLoadingPosition() {
+    let listNode = this.get('listNode');
+
+    if (listNode != null) {
+      if (typeof window === 'undefined') {
+        return;
+      }
+
+      let overlay = listNode.getBoundingClientRect();
+      let viewportHeight = Math.max(
+        document.documentElement ? document.documentElement.clientHeight : 0,
+        window.innerHeight || 0
+      );
+
+      let overflow = viewportHeight - overlay.height;
+
+      let spinnerHeight =
+        this.get('items.length') === 1
+          ? SMALL_SPINNER_HEIGHT
+          : LARGE_SPINNER_HEIGHT;
+
+      let spinnerPosition =
+        overflow > 0
+          ? (overlay.height - spinnerHeight) / 2
+          : (viewportHeight - overlay.top - spinnerHeight) / 2;
+
+      this.set('loadingPosition', spinnerPosition);
+    }
+  }
+
+  handleSelectAllItemsInStore() {
+    let {
+      onSelectionChange,
+      selectedItems,
+      items,
+      idForItem,
+    } = this.getProperties(
+      'onSelectionChange',
+      'selectedItems',
+      'items',
+      'idForItem'
+    );
+    idForItem = idForItem || defaultIdForItem;
+
+    let newlySelectedItems =
+      selectedItems === SELECT_ALL_ITEMS
+        ? getAllItemsOnPage(items, idForItem)
+        : SELECT_ALL_ITEMS;
+
+    if (onSelectionChange) {
+      onSelectionChange(newlySelectedItems);
+    }
+  }
+
+  handleSelectionChange(selected, id) {
+    let {
+      onSelectionChange,
+      selectedItems,
+      items,
+      idForItem,
+    } = this.getProperties(
+      'onSelectionChange',
+      'selectedItems',
+      'items',
+      'idForItem'
+    );
+    idForItem = idForItem || defaultIdForItem;
+
+    if (selectedItems == null || onSelectionChange == null) {
+      return;
+    }
+
+    let newlySelectedItems =
+      selectedItems === SELECT_ALL_ITEMS
+        ? getAllItemsOnPage(items, idForItem)
+        : [...selectedItems];
+
+    if (selected) {
+      newlySelectedItems.push(id);
+    } else {
+      newlySelectedItems.splice(newlySelectedItems.indexOf(id), 1);
+    }
+
+    if (newlySelectedItems.length === 0 && !isSmallScreen()) {
+      this.handleSelectMode(false);
+    } else if (newlySelectedItems.length > 0) {
+      this.handleSelectMode(true);
+    }
+
+    if (onSelectionChange) {
+      onSelectionChange(newlySelectedItems);
+    }
+  }
+
+  handleSelectMode(selectMode) {
+    let onSelectionChange = this.get('onSelectionChange');
+    this.set('selectMode', selectMode);
+    if (!selectMode && onSelectionChange) {
+      onSelectionChange([]);
+    }
+  }
+
+  handleToggleAll() {
+    let {
+      onSelectionChange,
+      selectedItems,
+      items,
+      idForItem,
+    } = this.getProperties(
+      'onSelectionChange',
+      'selectedItems',
+      'items',
+      'idForItem'
+    );
+    idForItem = idForItem || defaultIdForItem;
+
+    let newlySelectedItems = [];
+
+    if (
+      (Array.isArray(selectedItems) &&
+        selectedItems.length === items.length) ||
+      selectedItems === SELECT_ALL_ITEMS
+    ) {
+      newlySelectedItems = [];
+    } else {
+      newlySelectedItems = items.map((item, index) => {
+        let id = idForItem(item, index);
+        return id;
+      });
+    }
+
+    if (newlySelectedItems.length === 0 && !isSmallScreen()) {
+      this.handleSelectMode(false);
+    } else if (newlySelectedItems.length > 0) {
+      this.handleSelectMode(true);
+    }
+
+    if (onSelectionChange) {
+      onSelectionChange(newlySelectedItems);
+    }
+  }
+
+  setListNode() {
+    let listNode =
+      document.querySelector(
+        `#${this.get('wrapperId')} ul.Polaris-ResourceList`
+      ) || null;
+    this.set('listNode', listNode);
+  }
+
+  init() {
+    super.init(...arguments);
+
+    let selectedItems = this.get('selectedItems');
+    this.setProperties({
+      defaultResourceName: {
+        singular: 'item',
+        plural: 'items',
+      },
+      selectMode: Boolean(selectedItems && selectedItems.length > 0),
+    });
+  }
+
+  didReceiveAttrs() {
+    super.didReceiveAttrs(...arguments);
+
+    assert(
+      'ember-polaris::polaris-resource-list - itemComponent must be a component name or definition',
+      this.get('itemComponent')
+    );
+
+    // This logic is in the React implementation's
+    // `componentWillReceiveProps` hook.
+    let { selectedItems, previousSelectedItems } = this.getProperties(
+      'selectedItems',
+      'previousSelectedItems'
+    );
+
+    if (
+      previousSelectedItems &&
+      previousSelectedItems.length > 0 &&
+      (!selectedItems || selectedItems.length === 0) &&
+      !isSmallScreen()
+    ) {
+      this.set('selectMode', false);
+    }
+
+    // This logic is in the React implementation's
+    // `componentDidUpdate` hook.
+
+    // TODO: check if we need this that's in the React implementation.
+    // if (
+    //    this.listRef.current &&
+    //    this.itemsExist() &&
+    //    !this.itemsExist(prevItems)
+    //  ) {
+    //    this.forceUpdate(); -> triggers rerender of component.
+    //  }
+
+    let { loading, previousLoading } = this.getProperties(
+      'loading',
+      'previousLoading'
+    );
+
+    if (loading && !previousLoading) {
+      this.setLoadingPosition();
+    }
+
+    this.setProperties({
+      previousSelectedItems: selectedItems,
+      previousLoading: loading,
+    });
+  }
+
+  didInsertElement() {
+    super.didInsertElement(...arguments);
+
+    this.addEventListener(window, 'resize', this.handleResize);
+
+    if (this.get('loading')) {
+      this.setLoadingPosition();
+    }
+  }
+
+  didRender() {
+    super.didRender(...arguments);
+
+    this.setListNode();
+  }
+}
 
 function getAllItemsOnPage(items, idForItem) {
   return items.map((item, index) => {

--- a/addon/components/polaris-resource-list.js
+++ b/addon/components/polaris-resource-list.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import { gt } from '@ember/object/computed';
-import { get, computed } from '@ember/object';
+import { action, get, computed } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { htmlSafe } from '@ember/string';
 import { assert } from '@ember/debug';
@@ -31,7 +31,10 @@ const LARGE_SPINNER_HEIGHT = 45;
  */
 @tagName('')
 @templateLayout(layout)
-export default class PolarisResourceList extends Component.extend(ContextBoundEventListenersMixin, ContextBoundTasksMixin) {
+export default class PolarisResourceList extends Component.extend(
+  ContextBoundEventListenersMixin,
+  ContextBoundTasksMixin
+) {
   /**
    * Item data; each item is passed to renderItem
    *
@@ -281,7 +284,6 @@ export default class PolarisResourceList extends Component.extend(ContextBoundEv
   /**
    * ID used to identify our wrapper element from other instances
    */
-  @(computed.readOnly())
   get wrapperId() {
     return guidFor(this);
   }
@@ -291,7 +293,7 @@ export default class PolarisResourceList extends Component.extend(ContextBoundEv
    */
   @(computed('items.[]', 'idForItem').readOnly())
   get itemsWithId() {
-    let { items, idForItem } = this.getProperties('items', 'idForItem');
+    let { items, idForItem } = this;
     items = items || [];
     idForItem = idForItem || defaultIdForItem;
 
@@ -305,11 +307,7 @@ export default class PolarisResourceList extends Component.extend(ContextBoundEv
 
   @(computed('selectable', 'sortOptions.length', 'alternateTool').readOnly())
   get needsHeader() {
-    let { selectable, sortOptions, alternateTool } = this.getProperties(
-      'selectable',
-      'sortOptions',
-      'alternateTool'
-    );
+    let { selectable, sortOptions, alternateTool } = this;
     return (
       selectable || (sortOptions && sortOptions.length > 0) || alternateTool
     );
@@ -317,10 +315,7 @@ export default class PolarisResourceList extends Component.extend(ContextBoundEv
 
   @(computed('promotedBulkActions.length', 'bulkActions.length').readOnly())
   get selectable() {
-    let { promotedBulkActions, bulkActions } = this.getProperties(
-      'promotedBulkActions',
-      'bulkActions'
-    );
+    let { promotedBulkActions, bulkActions } = this;
     return Boolean(
       (promotedBulkActions && promotedBulkActions.length > 0) ||
         (bulkActions && bulkActions.length > 0)
@@ -329,10 +324,7 @@ export default class PolarisResourceList extends Component.extend(ContextBoundEv
 
   @(computed('selectedItems.length', 'items.length').readOnly())
   get bulkSelectState() {
-    let { selectedItems, items } = this.getProperties(
-      'selectedItems',
-      'items'
-    );
+    let { selectedItems, items } = this;
     let selectState = 'indeterminate';
     if (
       !selectedItems ||
@@ -341,24 +333,21 @@ export default class PolarisResourceList extends Component.extend(ContextBoundEv
       selectState = false;
     } else if (
       selectedItems === SELECT_ALL_ITEMS ||
-      (Array.isArray(selectedItems) &&
-        selectedItems.length === items.length)
+      (Array.isArray(selectedItems) && selectedItems.length === items.length)
     ) {
       selectState = true;
     }
     return selectState;
   }
 
-  @(
-    computed('resourceName.{singular,plural}', 'items.length', 'loading').readOnly()
-  )
+  @(computed(
+    'resourceName.{singular,plural}',
+    'items.length',
+    'loading'
+  ).readOnly())
   get headerTitle() {
-    let { resourceName, items, loading } = this.getProperties(
-      'resourceName',
-      'items',
-      'loading'
-    );
-    resourceName = resourceName || this.get('defaultResourceName');
+    let { resourceName, items, loading } = this;
+    resourceName = resourceName || this.defaultResourceName;
 
     let itemsCount = items.length;
     let resource =
@@ -373,10 +362,7 @@ export default class PolarisResourceList extends Component.extend(ContextBoundEv
 
   @(computed('selectedItems.length', 'items.length').readOnly())
   get bulkActionsLabel() {
-    let { selectedItems, items } = this.getProperties(
-      'selectedItems',
-      'items'
-    );
+    let { selectedItems, items } = this;
     selectedItems = selectedItems || [];
 
     let selectedItemsCount =
@@ -387,16 +373,14 @@ export default class PolarisResourceList extends Component.extend(ContextBoundEv
     return `${selectedItemsCount} selected`;
   }
 
-  @(
-    computed('resourceName.{singular,plural}', 'selectedItems.length', 'items.length').readOnly()
-  )
+  @(computed(
+    'resourceName.{singular,plural}',
+    'selectedItems.length',
+    'items.length'
+  ).readOnly())
   get bulkActionsAccessibilityLabel() {
-    let { resourceName, selectedItems, items } = this.getProperties(
-      'resourceName',
-      'selectedItems',
-      'items'
-    );
-    resourceName = resourceName || this.get('defaultResourceName');
+    let { resourceName, selectedItems, items } = this;
+    resourceName = resourceName || this.defaultResourceName;
     selectedItems = selectedItems || [];
 
     let selectedItemsCount = selectedItems.length;
@@ -414,24 +398,17 @@ export default class PolarisResourceList extends Component.extend(ContextBoundEv
     }
   }
 
-  @(
-    computed('hasMoreItems', 'selectedItems', 'items.length', 'resourceName.plural').readOnly()
-  )
+  @(computed(
+    'hasMoreItems',
+    'selectedItems',
+    'items.length',
+    'resourceName.plural'
+  ).readOnly())
   get paginatedSelectAllText() {
-    let {
-      hasMoreItems,
-      selectedItems,
-      items,
-      resourceName,
-    } = this.getProperties(
-      'hasMoreItems',
-      'selectedItems',
-      'items',
-      'resourceName'
-    );
-    resourceName = resourceName || this.get('defaultResourceName');
+    let { hasMoreItems, selectedItems, items, resourceName } = this;
+    resourceName = resourceName || this.defaultResourceName;
 
-    if (!this.get('selectable') || !hasMoreItems) {
+    if (!this.selectable || !hasMoreItems) {
       return null;
     }
 
@@ -445,25 +422,18 @@ export default class PolarisResourceList extends Component.extend(ContextBoundEv
     return null;
   }
 
-  @(
-    computed('hasMoreItems', 'selectedItems', 'items.length', 'resourceName.plural').readOnly()
-  )
+  @(computed(
+    'hasMoreItems',
+    'selectedItems',
+    'items.length',
+    'resourceName.plural'
+  ).readOnly())
   get paginatedSelectAllAction() {
-    let {
-      hasMoreItems,
-      selectedItems,
-      items,
-      resourceName,
-    } = this.getProperties(
-      'hasMoreItems',
-      'selectedItems',
-      'items',
-      'resourceName'
-    );
-    resourceName = resourceName || this.get('defaultResourceName');
+    let { hasMoreItems, selectedItems, items, resourceName } = this;
+    resourceName = resourceName || this.defaultResourceName;
 
-    if (!this.get('selectable') || !hasMoreItems) {
-      return;
+    if (!this.selectable || !hasMoreItems) {
+      return null;
     }
 
     let actionText =
@@ -482,55 +452,41 @@ export default class PolarisResourceList extends Component.extend(ContextBoundEv
 
   @(computed('resourceName.plural').readOnly())
   get emptySearchResultTitle() {
-    let resourceName =
-      this.get('resourceName') || this.get('defaultResourceName');
+    let resourceName = this.resourceName || this.defaultResourceName;
 
     return `No ${get(resourceName, 'plural')} found`;
   }
 
   @(computed('filterControl', 'itemsExist', 'loading').readOnly())
   get showEmptyState() {
-    let { filterControl, itemsExist, loading } = this.getProperties(
-      'filterControl',
-      'itemsExist',
-      'loading'
-    );
+    let { filterControl, itemsExist, loading } = this;
 
     return filterControl && !itemsExist && !loading;
   }
 
   @(computed('loadingPosition').readOnly())
   get spinnerStyle() {
-    let loadingPosition = this.get('loadingPosition');
+    let { loadingPosition } = this;
     let defaultTopPadding = 8;
-    let topPadding =
-      loadingPosition > 0 ? loadingPosition : defaultTopPadding;
+    let topPadding = loadingPosition > 0 ? loadingPosition : defaultTopPadding;
     return htmlSafe(`padding-top: ${topPadding}px`);
   }
 
   @(computed('items.length').readOnly())
   get spinnerSize() {
-    return this.get('items.length') < 2 ? 'small' : 'large';
+    return this.items.length < 2 ? 'small' : 'large';
   }
 
-  @(
-    computed('selectedItems.[]', 'resourceName', 'loading', 'selectMode', 'selectable').readOnly()
-  )
+  @(computed(
+    'selectedItems.[]',
+    'resourceName',
+    'loading',
+    'selectMode',
+    'selectable'
+  ).readOnly())
   get context() {
-    let {
-      selectedItems,
-      resourceName,
-      loading,
-      selectMode,
-      selectable,
-    } = this.getProperties(
-      'selectedItems',
-      'resourceName',
-      'loading',
-      'selectMode',
-      'selectable'
-    );
-    resourceName = resourceName || this.get('defaultResourceName');
+    let { selectedItems, resourceName, loading, selectMode, selectable } = this;
+    resourceName = resourceName || this.defaultResourceName;
     return {
       selectable,
       selectedItems,
@@ -553,14 +509,11 @@ export default class PolarisResourceList extends Component.extend(ContextBoundEv
     // is only rendered when `selectable` is truthy. We handle
     // that by bombing out of this handler when that condition
     // is met rather than dynamically managing event listeners.
-    if (!this.get('selectable')) {
+    if (!this.selectable) {
       return;
     }
 
-    let { selectedItems, selectMode } = this.getProperties(
-      'selectedItems',
-      'selectMode'
-    );
+    let { selectedItems, selectMode } = this;
 
     if (
       selectedItems &&
@@ -573,7 +526,7 @@ export default class PolarisResourceList extends Component.extend(ContextBoundEv
   }
 
   setLoadingPosition() {
-    let listNode = this.get('listNode');
+    let { listNode } = this;
 
     if (listNode != null) {
       if (typeof window === 'undefined') {
@@ -589,9 +542,7 @@ export default class PolarisResourceList extends Component.extend(ContextBoundEv
       let overflow = viewportHeight - overlay.height;
 
       let spinnerHeight =
-        this.get('items.length') === 1
-          ? SMALL_SPINNER_HEIGHT
-          : LARGE_SPINNER_HEIGHT;
+        this.items.length === 1 ? SMALL_SPINNER_HEIGHT : LARGE_SPINNER_HEIGHT;
 
       let spinnerPosition =
         overflow > 0
@@ -603,17 +554,7 @@ export default class PolarisResourceList extends Component.extend(ContextBoundEv
   }
 
   handleSelectAllItemsInStore() {
-    let {
-      onSelectionChange,
-      selectedItems,
-      items,
-      idForItem,
-    } = this.getProperties(
-      'onSelectionChange',
-      'selectedItems',
-      'items',
-      'idForItem'
-    );
+    let { onSelectionChange, selectedItems, items, idForItem } = this;
     idForItem = idForItem || defaultIdForItem;
 
     let newlySelectedItems =
@@ -627,17 +568,7 @@ export default class PolarisResourceList extends Component.extend(ContextBoundEv
   }
 
   handleSelectionChange(selected, id) {
-    let {
-      onSelectionChange,
-      selectedItems,
-      items,
-      idForItem,
-    } = this.getProperties(
-      'onSelectionChange',
-      'selectedItems',
-      'items',
-      'idForItem'
-    );
+    let { onSelectionChange, selectedItems, items, idForItem } = this;
     idForItem = idForItem || defaultIdForItem;
 
     if (selectedItems == null || onSelectionChange == null) {
@@ -667,7 +598,7 @@ export default class PolarisResourceList extends Component.extend(ContextBoundEv
   }
 
   handleSelectMode(selectMode) {
-    let onSelectionChange = this.get('onSelectionChange');
+    let { onSelectionChange } = this;
     this.set('selectMode', selectMode);
     if (!selectMode && onSelectionChange) {
       onSelectionChange([]);
@@ -675,24 +606,13 @@ export default class PolarisResourceList extends Component.extend(ContextBoundEv
   }
 
   handleToggleAll() {
-    let {
-      onSelectionChange,
-      selectedItems,
-      items,
-      idForItem,
-    } = this.getProperties(
-      'onSelectionChange',
-      'selectedItems',
-      'items',
-      'idForItem'
-    );
+    let { onSelectionChange, selectedItems, items, idForItem } = this;
     idForItem = idForItem || defaultIdForItem;
 
     let newlySelectedItems = [];
 
     if (
-      (Array.isArray(selectedItems) &&
-        selectedItems.length === items.length) ||
+      (Array.isArray(selectedItems) && selectedItems.length === items.length) ||
       selectedItems === SELECT_ALL_ITEMS
     ) {
       newlySelectedItems = [];
@@ -716,16 +636,15 @@ export default class PolarisResourceList extends Component.extend(ContextBoundEv
 
   setListNode() {
     let listNode =
-      document.querySelector(
-        `#${this.get('wrapperId')} ul.Polaris-ResourceList`
-      ) || null;
+      document.querySelector(`#${this.wrapperId} ul.Polaris-ResourceList`) ||
+      null;
     this.set('listNode', listNode);
   }
 
   init() {
     super.init(...arguments);
 
-    let selectedItems = this.get('selectedItems');
+    let { selectedItems } = this;
     this.setProperties({
       defaultResourceName: {
         singular: 'item',
@@ -735,20 +654,16 @@ export default class PolarisResourceList extends Component.extend(ContextBoundEv
     });
   }
 
-  didReceiveAttrs() {
-    super.didReceiveAttrs(...arguments);
-
+  @action
+  updateResourceList() {
     assert(
       'ember-polaris::polaris-resource-list - itemComponent must be a component name or definition',
-      this.get('itemComponent')
+      this.itemComponent
     );
 
     // This logic is in the React implementation's
     // `componentWillReceiveProps` hook.
-    let { selectedItems, previousSelectedItems } = this.getProperties(
-      'selectedItems',
-      'previousSelectedItems'
-    );
+    let { selectedItems, previousSelectedItems } = this;
 
     if (
       previousSelectedItems &&
@@ -771,10 +686,7 @@ export default class PolarisResourceList extends Component.extend(ContextBoundEv
     //    this.forceUpdate(); -> triggers rerender of component.
     //  }
 
-    let { loading, previousLoading } = this.getProperties(
-      'loading',
-      'previousLoading'
-    );
+    let { loading, previousLoading } = this;
 
     if (loading && !previousLoading) {
       this.setLoadingPosition();
@@ -786,18 +698,13 @@ export default class PolarisResourceList extends Component.extend(ContextBoundEv
     });
   }
 
-  didInsertElement() {
-    super.didInsertElement(...arguments);
-
+  @action
+  insertResourceList() {
     this.addEventListener(window, 'resize', this.handleResize);
 
-    if (this.get('loading')) {
+    if (this.loading) {
       this.setLoadingPosition();
     }
-  }
-
-  didRender() {
-    super.didRender(...arguments);
 
     this.setListNode();
   }

--- a/addon/components/polaris-resource-list.js
+++ b/addon/components/polaris-resource-list.js
@@ -1,7 +1,6 @@
 import Component from '@ember/component';
 import { gt } from '@ember/object/computed';
 import { action, get, computed } from '@ember/object';
-import { guidFor } from '@ember/object/internals';
 import { htmlSafe } from '@ember/string';
 import { assert } from '@ember/debug';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
@@ -280,13 +279,6 @@ export default class PolarisResourceList extends Component.extend(
 
   @(computedIdVariation('id', 'Select').readOnly())
   selectId;
-
-  /**
-   * ID used to identify our wrapper element from other instances
-   */
-  get wrapperId() {
-    return guidFor(this);
-  }
 
   /**
    * List of item/id tuples needed for rendering items
@@ -636,13 +628,6 @@ export default class PolarisResourceList extends Component.extend(
     }
   }
 
-  setListNode() {
-    let listNode =
-      document.querySelector(`#${this.wrapperId} ul.Polaris-ResourceList`) ||
-      null;
-    this.set('listNode', listNode);
-  }
-
   init() {
     super.init(...arguments);
 
@@ -707,8 +692,11 @@ export default class PolarisResourceList extends Component.extend(
     if (this.loading) {
       this.setLoadingPosition();
     }
+  }
 
-    this.setListNode();
+  @action
+  insertListNode(element) {
+    this.set('listNode', element);
   }
 }
 

--- a/addon/components/polaris-resource-list.js
+++ b/addon/components/polaris-resource-list.js
@@ -597,6 +597,7 @@ export default class PolarisResourceList extends Component.extend(
     }
   }
 
+  @action
   handleSelectMode(selectMode) {
     let { onSelectionChange } = this;
     this.set('selectMode', selectMode);
@@ -605,6 +606,7 @@ export default class PolarisResourceList extends Component.extend(
     }
   }
 
+  @action
   handleToggleAll() {
     let { onSelectionChange, selectedItems, items, idForItem } = this;
     idForItem = idForItem || defaultIdForItem;

--- a/addon/components/polaris-resource-list/bulk-actions.js
+++ b/addon/components/polaris-resource-list/bulk-actions.js
@@ -10,7 +10,10 @@ const MAX_PROMOTED_ACTIONS = 2;
 
 @tagName('')
 @templateLayout(layout)
-export default class BulkActions extends Component.extend(ContextBoundEventListenersMixin, ContextBoundTasksMixin) {
+export default class BulkActions extends Component.extend(
+  ContextBoundEventListenersMixin,
+  ContextBoundTasksMixin
+) {
   /**
    * Visually hidden text for screen readers
    *
@@ -109,7 +112,7 @@ export default class BulkActions extends Component.extend(ContextBoundEventListe
    * @property onSelectModeToggle
    * @public
    */
-  onSelectModeToggle/* selectMode **/() {}
+  onSelectModeToggle(/* selectMode **/) {}
 
   /**
    * Callback when the select all checkbox is clicked
@@ -121,26 +124,15 @@ export default class BulkActions extends Component.extend(ContextBoundEventListe
    */
   onToggleAll() {}
 
-  'data-test-bulk-actions' = true;
   containerWidth = 0;
   measuring = true;
   bulkActionsWidth = 0;
   addedMoreActionsWidthForMeasuring = 0;
-
-  @computed
-  get promotedActionsWidths() {
-    return [];
-  }
+  promotedActionsWidths = [];
 
   @computed('promotedActions', 'numberOfPromotedActionsToRender')
   get promotedActionsToRender() {
-    let {
-      promotedActions,
-      numberOfPromotedActionsToRender,
-    } = this.getProperties(
-      'promotedActions',
-      'numberOfPromotedActionsToRender'
-    );
+    let { promotedActions, numberOfPromotedActionsToRender } = this;
 
     if (promotedActions && numberOfPromotedActionsToRender > 0) {
       return promotedActions.slice(0, numberOfPromotedActionsToRender);
@@ -165,14 +157,7 @@ export default class BulkActions extends Component.extend(ContextBoundEventListe
       measuring,
       addedMoreActionsWidthForMeasuring,
       promotedActionsWidths,
-    } = this.getProperties(
-      'promotedActions',
-      'containerWidth',
-      'bulkActionsWidth',
-      'measuring',
-      'addedMoreActionsWidthForMeasuring',
-      'promotedActionsWidths'
-    );
+    } = this;
 
     if (!promotedActions) {
       return 0;
@@ -204,10 +189,7 @@ export default class BulkActions extends Component.extend(ContextBoundEventListe
 
   @computed('promotedActions', 'actionsCollection')
   get hasActions() {
-    let { promotedActions, actionsCollection } = this.getProperties(
-      'promotedActions',
-      'actionsCollection'
-    );
+    let { promotedActions, actionsCollection } = this;
 
     return Boolean(
       (promotedActions && promotedActions.length > 0) ||
@@ -217,13 +199,7 @@ export default class BulkActions extends Component.extend(ContextBoundEventListe
 
   @computed('promotedActions.length', 'numberOfPromotedActionsToRender')
   get rolledInPromotedActions() {
-    let {
-      promotedActions,
-      numberOfPromotedActionsToRender,
-    } = this.getProperties(
-      'promotedActions',
-      'numberOfPromotedActionsToRender'
-    );
+    let { promotedActions, numberOfPromotedActionsToRender } = this;
 
     if (
       promotedActions &&
@@ -237,21 +213,11 @@ export default class BulkActions extends Component.extend(ContextBoundEventListe
 
   @computed('promotedActions', 'numberOfPromotedActionsToRender', 'measuring')
   get activatorLabel() {
-    let {
-      promotedActions,
-      numberOfPromotedActionsToRender,
-      measuring,
-    } = this.getProperties(
-      'promotedActions',
-      'numberOfPromotedActionsToRender',
-      'measuring'
-    );
+    let { promotedActions, numberOfPromotedActionsToRender, measuring } = this;
 
     if (
       !promotedActions ||
-      (promotedActions &&
-        numberOfPromotedActionsToRender === 0 &&
-        !measuring)
+      (promotedActions && numberOfPromotedActionsToRender === 0 && !measuring)
     ) {
       return 'Actions';
     }
@@ -261,15 +227,7 @@ export default class BulkActions extends Component.extend(ContextBoundEventListe
 
   @computed('actionSections', 'rolledInPromotedActions.length', 'measuring')
   get shouldRenderActionsPopover() {
-    let {
-      actionSections,
-      rolledInPromotedActions,
-      measuring,
-    } = this.getProperties(
-      'actionSections',
-      'rolledInPromotedActions',
-      'measuring'
-    );
+    let { actionSections, rolledInPromotedActions, measuring } = this;
 
     return Boolean(
       actionSections || rolledInPromotedActions.length > 0 || measuring
@@ -278,7 +236,7 @@ export default class BulkActions extends Component.extend(ContextBoundEventListe
 
   @computed('actionsCollection.[]')
   get actionSections() {
-    let actionsCollection = this.get('actionsCollection');
+    let { actionsCollection } = this;
 
     if (!actionsCollection || actionsCollection.length === 0) {
       return null;
@@ -298,19 +256,12 @@ export default class BulkActions extends Component.extend(ContextBoundEventListe
   @computed('actionSections.[]', 'rolledInPromotedActions')
   get combinedActions() {
     let combinedActions = [];
-    let { actionSections, rolledInPromotedActions } = this.getProperties(
-      'actionSections',
-      'rolledInPromotedActions'
-    );
+    let { actionSections, rolledInPromotedActions } = this;
 
-    let rolledInPromotedActionsHasLength =
-      rolledInPromotedActions.length > 0;
+    let rolledInPromotedActionsHasLength = rolledInPromotedActions.length > 0;
 
     if (actionSections && rolledInPromotedActionsHasLength) {
-      combinedActions = [
-        { items: rolledInPromotedActions },
-        ...actionSections,
-      ];
+      combinedActions = [{ items: rolledInPromotedActions }, ...actionSections];
     } else if (actionSections) {
       combinedActions = actionSections;
     } else if (rolledInPromotedActionsHasLength) {
@@ -321,13 +272,13 @@ export default class BulkActions extends Component.extend(ContextBoundEventListe
   }
 
   get moreActionsNode() {
-    return this.element.querySelector(
+    return this.bulkActionsElement.querySelector(
       '.Polaris-ResourceList-BulkActions__Popover'
     );
   }
 
   get largeScreenButtonsNode() {
-    return this.element.querySelector(
+    return this.bulkActionsElement.querySelector(
       '.Polaris-ResourceList-BulkActions__Group--largeScreen'
     );
   }
@@ -349,7 +300,7 @@ export default class BulkActions extends Component.extend(ContextBoundEventListe
   }
 
   setContainerWidth() {
-    let containerWidth = this.element.getBoundingClientRect().width;
+    let containerWidth = this.bulkActionsElement.getBoundingClientRect().width;
 
     if (containerWidth > 0) {
       this.set('containerWidth', containerWidth);
@@ -361,21 +312,24 @@ export default class BulkActions extends Component.extend(ContextBoundEventListe
   }
 
   addResizeEventListener() {
-    let largeScreenGroupNode = this.get('largeScreenButtonsNode');
+    let { largeScreenGroupNode } = this;
 
     if (largeScreenGroupNode) {
-      this.addEventListener(
-        largeScreenGroupNode,
-        'resize',
-        this.handleResize
-      );
+      this.addEventListener(largeScreenGroupNode, 'resize', this.handleResize);
     }
   }
 
-  didInsertElement() {
-    super.didInsertElement(...arguments);
+  @action
+  insertBulkActions(element) {
+    this.set('bulkActionsElement', element);
 
-    let promotedActions = this.get('promotedActions');
+    let {
+      actionsCollection,
+      promotedActions,
+      moreActionsNode,
+      addedMoreActionsWidthForMeasuring,
+      largeScreenButtonsNode,
+    } = this;
 
     if (promotedActions && promotedActions.length > MAX_PROMOTED_ACTIONS) {
       warn(
@@ -388,24 +342,6 @@ export default class BulkActions extends Component.extend(ContextBoundEventListe
     }
 
     this.addResizeEventListener();
-  }
-
-  didRender() {
-    super.didRender(...arguments);
-
-    let {
-      actionsCollection,
-      promotedActions,
-      moreActionsNode,
-      addedMoreActionsWidthForMeasuring,
-      largeScreenButtonsNode,
-    } = this.getProperties(
-      'actionsCollection',
-      'promotedActions',
-      'moreActionsNode',
-      'addedMoreActionsWidthForMeasuring',
-      'largeScreenButtonsNode'
-    );
 
     if (promotedActions && !actionsCollection && moreActionsNode) {
       addedMoreActionsWidthForMeasuring = moreActionsNode.getBoundingClientRect()
@@ -420,22 +356,20 @@ export default class BulkActions extends Component.extend(ContextBoundEventListe
     this.set('bulkActionsWidth', bulkActionsWidth);
 
     this.setProperties({
-      containerWidth: this.element.getBoundingClientRect().width,
+      containerWidth: element.getBoundingClientRect().width,
       measuring: false,
     });
   }
 
   @action
   setSelectMode(val) {
-    this.get('onSelectModeToggle')(val);
+    this.onSelectModeToggle(val);
   }
 
   @action
   handleMeasurement(width) {
-    let measuring = this.get('measuring');
-
-    if (measuring) {
-      this.get('promotedActionsWidths').pushObject(width);
+    if (this.measuring) {
+      this.promotedActionsWidths.pushObject(width);
     }
   }
 }

--- a/addon/components/polaris-resource-list/bulk-actions.js
+++ b/addon/components/polaris-resource-list/bulk-actions.js
@@ -1,462 +1,441 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { action, computed } from '@ember/object';
 import { warn } from '@ember/debug';
+import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import ContextBoundEventListenersMixin from 'ember-lifeline/mixins/dom';
 import ContextBoundTasksMixin from 'ember-lifeline/mixins/run';
 import layout from '../../templates/components/polaris-resource-list/bulk-actions';
 
 const MAX_PROMOTED_ACTIONS = 2;
 
-export default Component.extend(
-  ContextBoundEventListenersMixin,
-  ContextBoundTasksMixin,
-  {
-    layout,
+@tagName('')
+@templateLayout(layout)
+export default class BulkActions extends Component.extend(ContextBoundEventListenersMixin, ContextBoundTasksMixin) {
+  /**
+   * Visually hidden text for screen readers
+   *
+   * @type {String}
+   * @default null
+   * @property accessibilityLabel
+   * @public
+   */
+  accessibilityLabel = null;
 
-    /**
-     * Visually hidden text for screen readers
-     *
-     * @type {String}
-     * @default null
-     * @property accessibilityLabel
-     * @public
-     */
-    accessibilityLabel: null,
+  /**
+   * Label for the bulk actions
+   *
+   * @type {String}
+   * @default ''
+   * @property label
+   * @public
+   */
+  label = '';
 
-    /**
-     * Label for the bulk actions
-     *
-     * @type {String}
-     * @default ''
-     * @property label
-     * @public
-     */
-    label: '',
+  /**
+   * State of the bulk actions checkbox
+   *
+   * @type {Boolean|String}
+   * @default null
+   * @property selected
+   * @public
+   */
+  selected = null;
 
-    /**
-     * State of the bulk actions checkbox
-     *
-     * @type {Boolean|String}
-     * @default null
-     * @property selected
-     * @public
-     */
-    selected: null,
+  /**
+   * List is in a selectable state
+   *
+   * @type {Boolean}
+   * @default false
+   * @property selectMode
+   * @public
+   */
+  selectMode = false;
 
-    /**
-     * List is in a selectable state
-     *
-     * @type {Boolean}
-     * @default false
-     * @property selectMode
-     * @public
-     */
-    selectMode: false,
+  /**
+   * Actions that will be given more prominence
+   *
+   * @type {Object[]}
+   * @default null
+   * @property promotedActions
+   * @public
+   */
+  promotedActions = null;
 
-    /**
-     * Actions that will be given more prominence
-     *
-     * @type {Object[]}
-     * @default null
-     * @property promotedActions
-     * @public
-     */
-    promotedActions: null,
+  /**
+   * List of actions
+   *
+   * @type {Object[]}
+   * @default null
+   * @property actionsCollection
+   * @public
+   */
+  actionsCollection = null;
 
-    /**
-     * List of actions
-     *
-     * @type {Object[]}
-     * @default null
-     * @property actionsCollection
-     * @public
-     */
-    actionsCollection: null,
+  /**
+   * Text to select all across pages
+   *
+   * @type {String}
+   * @default null
+   * @property paginatedSelectAllText
+   * @public
+   */
+  paginatedSelectAllText = null;
 
-    /**
-     * Text to select all across pages
-     *
-     * @type {String}
-     * @default null
-     * @property paginatedSelectAllText
-     * @public
-     */
-    paginatedSelectAllText: null,
+  /**
+   * Action for selecting all across pages
+   *
+   * @type {Function}
+   * @default null
+   * @property paginatedSelectAllAction
+   * @public
+   */
+  paginatedSelectAllAction = null;
 
-    /**
-     * Action for selecting all across pages
-     *
-     * @type {Function}
-     * @default null
-     * @property paginatedSelectAllAction
-     * @public
-     */
-    paginatedSelectAllAction: null,
+  /**
+   * Disables bulk actions
+   *
+   * @type {Boolean}
+   * @default null
+   * @property disabled
+   * @public
+   */
+  disabled = null;
 
-    /**
-     * Disables bulk actions
-     *
-     * @type {Boolean}
-     * @default null
-     * @property disabled
-     * @public
-     */
-    disabled: null,
+  /**
+   * Callback when selectable state of list is changed
+   *
+   * @type {Function}
+   * @default noop
+   * @property onSelectModeToggle
+   * @public
+   */
+  onSelectModeToggle/* selectMode **/() {}
 
-    /**
-     * Callback when selectable state of list is changed
-     *
-     * @type {Function}
-     * @default noop
-     * @property onSelectModeToggle
-     * @public
-     */
-    onSelectModeToggle(/* selectMode **/) {},
+  /**
+   * Callback when the select all checkbox is clicked
+   *
+   * @type {Function}
+   * @default noop
+   * @property onToggleAll
+   * @public
+   */
+  onToggleAll() {}
 
-    /**
-     * Callback when the select all checkbox is clicked
-     *
-     * @type {Function}
-     * @default noop
-     * @property onToggleAll
-     * @public
-     */
-    onToggleAll() {},
+  'data-test-bulk-actions' = true;
+  containerWidth = 0;
+  measuring = true;
+  bulkActionsWidth = 0;
+  addedMoreActionsWidthForMeasuring = 0;
 
-    'data-test-bulk-actions': true,
+  @computed
+  get promotedActionsWidths() {
+    return [];
+  }
 
-    containerWidth: 0,
-
-    measuring: true,
-
-    bulkActionsWidth: 0,
-
-    addedMoreActionsWidthForMeasuring: 0,
-
-    promotedActionsWidths: computed(function() {
-      return [];
-    }),
-
-    promotedActionsToRender: computed(
+  @computed('promotedActions', 'numberOfPromotedActionsToRender')
+  get promotedActionsToRender() {
+    let {
+      promotedActions,
+      numberOfPromotedActionsToRender,
+    } = this.getProperties(
       'promotedActions',
-      'numberOfPromotedActionsToRender',
-      function() {
-        let {
-          promotedActions,
-          numberOfPromotedActionsToRender,
-        } = this.getProperties(
-          'promotedActions',
-          'numberOfPromotedActionsToRender'
-        );
+      'numberOfPromotedActionsToRender'
+    );
 
-        if (promotedActions && numberOfPromotedActionsToRender > 0) {
-          return promotedActions.slice(0, numberOfPromotedActionsToRender);
-        }
+    if (promotedActions && numberOfPromotedActionsToRender > 0) {
+      return promotedActions.slice(0, numberOfPromotedActionsToRender);
+    }
 
-        return [];
-      }
-    ),
+    return [];
+  }
 
-    numberOfPromotedActionsToRender: computed(
-      'promotedActions.length',
+  @computed(
+    'promotedActions.length',
+    'containerWidth',
+    'bulkActionsWidth',
+    'measuring',
+    'addedMoreActionsWidthForMeasuring',
+    'promotedActionsWidths'
+  )
+  get numberOfPromotedActionsToRender() {
+    let {
+      promotedActions,
+      containerWidth,
+      bulkActionsWidth,
+      measuring,
+      addedMoreActionsWidthForMeasuring,
+      promotedActionsWidths,
+    } = this.getProperties(
+      'promotedActions',
       'containerWidth',
       'bulkActionsWidth',
       'measuring',
       'addedMoreActionsWidthForMeasuring',
-      'promotedActionsWidths',
-      function() {
-        let {
-          promotedActions,
-          containerWidth,
-          bulkActionsWidth,
-          measuring,
-          addedMoreActionsWidthForMeasuring,
-          promotedActionsWidths,
-        } = this.getProperties(
-          'promotedActions',
-          'containerWidth',
-          'bulkActionsWidth',
-          'measuring',
-          'addedMoreActionsWidthForMeasuring',
-          'promotedActionsWidths'
-        );
+      'promotedActionsWidths'
+    );
 
-        if (!promotedActions) {
-          return 0;
-        }
+    if (!promotedActions) {
+      return 0;
+    }
 
-        let promotedActionsLength = promotedActions.length;
+    let promotedActionsLength = promotedActions.length;
 
-        if (containerWidth >= bulkActionsWidth || measuring) {
-          return promotedActionsLength;
-        }
+    if (containerWidth >= bulkActionsWidth || measuring) {
+      return promotedActionsLength;
+    }
 
-        let sufficientSpace = false;
-        let counter = promotedActionsLength - 1;
-        let totalWidth = 0;
+    let sufficientSpace = false;
+    let counter = promotedActionsLength - 1;
+    let totalWidth = 0;
 
-        while (!sufficientSpace && counter >= 0) {
-          totalWidth += promotedActionsWidths[counter];
-          let widthWithRemovedAction =
-            bulkActionsWidth - totalWidth + addedMoreActionsWidthForMeasuring;
-          if (containerWidth >= widthWithRemovedAction) {
-            sufficientSpace = true;
-          } else {
-            counter--;
-          }
-        }
-
-        return counter;
+    while (!sufficientSpace && counter >= 0) {
+      totalWidth += promotedActionsWidths[counter];
+      let widthWithRemovedAction =
+        bulkActionsWidth - totalWidth + addedMoreActionsWidthForMeasuring;
+      if (containerWidth >= widthWithRemovedAction) {
+        sufficientSpace = true;
+      } else {
+        counter--;
       }
-    ),
+    }
 
-    hasActions: computed('promotedActions', 'actionsCollection', function() {
-      let { promotedActions, actionsCollection } = this.getProperties(
-        'promotedActions',
-        'actionsCollection'
-      );
+    return counter;
+  }
 
-      return Boolean(
-        (promotedActions && promotedActions.length > 0) ||
-          (actionsCollection && actionsCollection.length > 0)
-      );
-    }),
+  @computed('promotedActions', 'actionsCollection')
+  get hasActions() {
+    let { promotedActions, actionsCollection } = this.getProperties(
+      'promotedActions',
+      'actionsCollection'
+    );
 
-    rolledInPromotedActions: computed(
-      'promotedActions.length',
-      'numberOfPromotedActionsToRender',
-      function() {
-        let {
-          promotedActions,
-          numberOfPromotedActionsToRender,
-        } = this.getProperties(
-          'promotedActions',
-          'numberOfPromotedActionsToRender'
-        );
+    return Boolean(
+      (promotedActions && promotedActions.length > 0) ||
+        (actionsCollection && actionsCollection.length > 0)
+    );
+  }
 
-        if (
-          promotedActions &&
-          numberOfPromotedActionsToRender < promotedActions.length
-        ) {
-          return [...promotedActions].slice(numberOfPromotedActionsToRender);
-        }
+  @computed('promotedActions.length', 'numberOfPromotedActionsToRender')
+  get rolledInPromotedActions() {
+    let {
+      promotedActions,
+      numberOfPromotedActionsToRender,
+    } = this.getProperties(
+      'promotedActions',
+      'numberOfPromotedActionsToRender'
+    );
 
-        return [];
-      }
-    ),
+    if (
+      promotedActions &&
+      numberOfPromotedActionsToRender < promotedActions.length
+    ) {
+      return [...promotedActions].slice(numberOfPromotedActionsToRender);
+    }
 
-    activatorLabel: computed(
+    return [];
+  }
+
+  @computed('promotedActions', 'numberOfPromotedActionsToRender', 'measuring')
+  get activatorLabel() {
+    let {
+      promotedActions,
+      numberOfPromotedActionsToRender,
+      measuring,
+    } = this.getProperties(
       'promotedActions',
       'numberOfPromotedActionsToRender',
-      'measuring',
-      function() {
-        let {
-          promotedActions,
-          numberOfPromotedActionsToRender,
-          measuring,
-        } = this.getProperties(
-          'promotedActions',
-          'numberOfPromotedActionsToRender',
-          'measuring'
-        );
+      'measuring'
+    );
 
-        if (
-          !promotedActions ||
-          (promotedActions &&
-            numberOfPromotedActionsToRender === 0 &&
-            !measuring)
-        ) {
-          return 'Actions';
-        }
+    if (
+      !promotedActions ||
+      (promotedActions &&
+        numberOfPromotedActionsToRender === 0 &&
+        !measuring)
+    ) {
+      return 'Actions';
+    }
 
-        return 'More actions';
-      }
-    ),
-
-    shouldRenderActionsPopover: computed(
-      'actionSections',
-      'rolledInPromotedActions.length',
-      'measuring',
-      function() {
-        let {
-          actionSections,
-          rolledInPromotedActions,
-          measuring,
-        } = this.getProperties(
-          'actionSections',
-          'rolledInPromotedActions',
-          'measuring'
-        );
-
-        return Boolean(
-          actionSections || rolledInPromotedActions.length > 0 || measuring
-        );
-      }
-    ),
-
-    actionSections: computed('actionsCollection.[]', function() {
-      let actionsCollection = this.get('actionsCollection');
-
-      if (!actionsCollection || actionsCollection.length === 0) {
-        return null;
-      }
-
-      if (this.instanceOfBulkActionListSectionArray(actionsCollection)) {
-        return actionsCollection;
-      }
-
-      if (this.instanceOfBulkActionArray(actionsCollection)) {
-        return [{ items: actionsCollection }];
-      }
-
-      return null;
-    }),
-
-    combinedActions: computed(
-      'actionSections.[]',
-      'rolledInPromotedActions',
-      function() {
-        let combinedActions = [];
-        let { actionSections, rolledInPromotedActions } = this.getProperties(
-          'actionSections',
-          'rolledInPromotedActions'
-        );
-
-        let rolledInPromotedActionsHasLength =
-          rolledInPromotedActions.length > 0;
-
-        if (actionSections && rolledInPromotedActionsHasLength) {
-          combinedActions = [
-            { items: rolledInPromotedActions },
-            ...actionSections,
-          ];
-        } else if (actionSections) {
-          combinedActions = actionSections;
-        } else if (rolledInPromotedActionsHasLength) {
-          combinedActions = [{ items: rolledInPromotedActions }];
-        }
-
-        return combinedActions;
-      }
-    ),
-
-    get moreActionsNode() {
-      return this.element.querySelector(
-        '.Polaris-ResourceList-BulkActions__Popover'
-      );
-    },
-
-    get largeScreenButtonsNode() {
-      return this.element.querySelector(
-        '.Polaris-ResourceList-BulkActions__Group--largeScreen'
-      );
-    },
-
-    instanceOfBulkActionListSectionArray(actionsCollection) {
-      let validList = actionsCollection.filter((action) => {
-        return action.items;
-      });
-
-      return actionsCollection.length === validList.length;
-    },
-
-    instanceOfBulkActionArray(actionsCollection) {
-      let validList = actionsCollection.filter((action) => {
-        return !action.items;
-      });
-
-      return actionsCollection.length === validList.length;
-    },
-
-    setContainerWidth() {
-      let containerWidth = this.element.getBoundingClientRect().width;
-
-      if (containerWidth > 0) {
-        this.set('containerWidth', containerWidth);
-      }
-    },
-
-    handleResize() {
-      this.throttleTask('setContainerWidth', 50);
-    },
-
-    addResizeEventListener() {
-      let largeScreenGroupNode = this.get('largeScreenButtonsNode');
-
-      if (largeScreenGroupNode) {
-        this.addEventListener(
-          largeScreenGroupNode,
-          'resize',
-          this.handleResize
-        );
-      }
-    },
-
-    didInsertElement() {
-      this._super(...arguments);
-
-      let promotedActions = this.get('promotedActions');
-
-      if (promotedActions && promotedActions.length > MAX_PROMOTED_ACTIONS) {
-        warn(
-          `To provide a better user experience. There should only be a maximum of ${MAX_PROMOTED_ACTIONS} promoted actions.`,
-          {
-            id:
-              'ember-polaris.polaris-resource-list.bulk-actions.max-promoted-actions',
-          }
-        );
-      }
-
-      this.addResizeEventListener();
-    },
-
-    didRender() {
-      this._super(...arguments);
-
-      let {
-        actionsCollection,
-        promotedActions,
-        moreActionsNode,
-        addedMoreActionsWidthForMeasuring,
-        largeScreenButtonsNode,
-      } = this.getProperties(
-        'actionsCollection',
-        'promotedActions',
-        'moreActionsNode',
-        'addedMoreActionsWidthForMeasuring',
-        'largeScreenButtonsNode'
-      );
-
-      if (promotedActions && !actionsCollection && moreActionsNode) {
-        addedMoreActionsWidthForMeasuring = moreActionsNode.getBoundingClientRect()
-          .width;
-      }
-
-      let bulkActionsWidth = largeScreenButtonsNode
-        ? largeScreenButtonsNode.getBoundingClientRect().width -
-          addedMoreActionsWidthForMeasuring
-        : 0;
-
-      this.set('bulkActionsWidth', bulkActionsWidth);
-
-      this.setProperties({
-        containerWidth: this.element.getBoundingClientRect().width,
-        measuring: false,
-      });
-    },
-
-    actions: {
-      setSelectMode(val) {
-        this.get('onSelectModeToggle')(val);
-      },
-
-      handleMeasurement(width) {
-        let measuring = this.get('measuring');
-
-        if (measuring) {
-          this.get('promotedActionsWidths').pushObject(width);
-        }
-      },
-    },
+    return 'More actions';
   }
-);
+
+  @computed('actionSections', 'rolledInPromotedActions.length', 'measuring')
+  get shouldRenderActionsPopover() {
+    let {
+      actionSections,
+      rolledInPromotedActions,
+      measuring,
+    } = this.getProperties(
+      'actionSections',
+      'rolledInPromotedActions',
+      'measuring'
+    );
+
+    return Boolean(
+      actionSections || rolledInPromotedActions.length > 0 || measuring
+    );
+  }
+
+  @computed('actionsCollection.[]')
+  get actionSections() {
+    let actionsCollection = this.get('actionsCollection');
+
+    if (!actionsCollection || actionsCollection.length === 0) {
+      return null;
+    }
+
+    if (this.instanceOfBulkActionListSectionArray(actionsCollection)) {
+      return actionsCollection;
+    }
+
+    if (this.instanceOfBulkActionArray(actionsCollection)) {
+      return [{ items: actionsCollection }];
+    }
+
+    return null;
+  }
+
+  @computed('actionSections.[]', 'rolledInPromotedActions')
+  get combinedActions() {
+    let combinedActions = [];
+    let { actionSections, rolledInPromotedActions } = this.getProperties(
+      'actionSections',
+      'rolledInPromotedActions'
+    );
+
+    let rolledInPromotedActionsHasLength =
+      rolledInPromotedActions.length > 0;
+
+    if (actionSections && rolledInPromotedActionsHasLength) {
+      combinedActions = [
+        { items: rolledInPromotedActions },
+        ...actionSections,
+      ];
+    } else if (actionSections) {
+      combinedActions = actionSections;
+    } else if (rolledInPromotedActionsHasLength) {
+      combinedActions = [{ items: rolledInPromotedActions }];
+    }
+
+    return combinedActions;
+  }
+
+  get moreActionsNode() {
+    return this.element.querySelector(
+      '.Polaris-ResourceList-BulkActions__Popover'
+    );
+  }
+
+  get largeScreenButtonsNode() {
+    return this.element.querySelector(
+      '.Polaris-ResourceList-BulkActions__Group--largeScreen'
+    );
+  }
+
+  instanceOfBulkActionListSectionArray(actionsCollection) {
+    let validList = actionsCollection.filter((action) => {
+      return action.items;
+    });
+
+    return actionsCollection.length === validList.length;
+  }
+
+  instanceOfBulkActionArray(actionsCollection) {
+    let validList = actionsCollection.filter((action) => {
+      return !action.items;
+    });
+
+    return actionsCollection.length === validList.length;
+  }
+
+  setContainerWidth() {
+    let containerWidth = this.element.getBoundingClientRect().width;
+
+    if (containerWidth > 0) {
+      this.set('containerWidth', containerWidth);
+    }
+  }
+
+  handleResize() {
+    this.throttleTask('setContainerWidth', 50);
+  }
+
+  addResizeEventListener() {
+    let largeScreenGroupNode = this.get('largeScreenButtonsNode');
+
+    if (largeScreenGroupNode) {
+      this.addEventListener(
+        largeScreenGroupNode,
+        'resize',
+        this.handleResize
+      );
+    }
+  }
+
+  didInsertElement() {
+    super.didInsertElement(...arguments);
+
+    let promotedActions = this.get('promotedActions');
+
+    if (promotedActions && promotedActions.length > MAX_PROMOTED_ACTIONS) {
+      warn(
+        `To provide a better user experience. There should only be a maximum of ${MAX_PROMOTED_ACTIONS} promoted actions.`,
+        {
+          id:
+            'ember-polaris.polaris-resource-list.bulk-actions.max-promoted-actions',
+        }
+      );
+    }
+
+    this.addResizeEventListener();
+  }
+
+  didRender() {
+    super.didRender(...arguments);
+
+    let {
+      actionsCollection,
+      promotedActions,
+      moreActionsNode,
+      addedMoreActionsWidthForMeasuring,
+      largeScreenButtonsNode,
+    } = this.getProperties(
+      'actionsCollection',
+      'promotedActions',
+      'moreActionsNode',
+      'addedMoreActionsWidthForMeasuring',
+      'largeScreenButtonsNode'
+    );
+
+    if (promotedActions && !actionsCollection && moreActionsNode) {
+      addedMoreActionsWidthForMeasuring = moreActionsNode.getBoundingClientRect()
+        .width;
+    }
+
+    let bulkActionsWidth = largeScreenButtonsNode
+      ? largeScreenButtonsNode.getBoundingClientRect().width -
+        addedMoreActionsWidthForMeasuring
+      : 0;
+
+    this.set('bulkActionsWidth', bulkActionsWidth);
+
+    this.setProperties({
+      containerWidth: this.element.getBoundingClientRect().width,
+      measuring: false,
+    });
+  }
+
+  @action
+  setSelectMode(val) {
+    this.get('onSelectModeToggle')(val);
+  }
+
+  @action
+  handleMeasurement(width) {
+    let measuring = this.get('measuring');
+
+    if (measuring) {
+      this.get('promotedActionsWidths').pushObject(width);
+    }
+  }
+}

--- a/addon/components/polaris-resource-list/bulk-actions/bulk-action-button.js
+++ b/addon/components/polaris-resource-list/bulk-actions/bulk-action-button.js
@@ -1,79 +1,78 @@
 import Component from '@ember/component';
+import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../../templates/components/polaris-resource-list/bulk-actions/bulk-action-button';
 import { handleMouseUpByBlurring } from '../../../utils/focus';
 
-export default Component.extend({
-  tagName: '',
+@tagName('')
+@templateLayout(layout)
+export default class BulkActionButton extends Component {
+ /**
+  * Content the action displays
+  *
+  * @type {String|Component|Object}
+  * @default null
+  * @public
+  */
+ content = null;
 
-  layout,
+ /**
+  * Visually hidden text for screen readers
+  *
+  * @type {String}
+  * @default null
+  * @public
+  */
+ accessibilityLabel = null;
 
-  /**
-   * Content the action displays
-   *
-   * @type {String|Component|Object}
-   * @default null
-   * @public
-   */
-  content: null,
+ /**
+  * A destination to link to, rendered in the action
+  *
+  * @type {String}
+  * @default null
+  * @public
+  */
+ url = null;
 
-  /**
-   * Visually hidden text for screen readers
-   *
-   * @type {String}
-   * @default null
-   * @public
-   */
-  accessibilityLabel: null,
+ /**
+  * Forces url to open in a new tab
+  *
+  * @type {Boolean}
+  * @default false
+  * @public
+  */
+ external = false;
 
-  /**
-   * A destination to link to, rendered in the action
-   *
-   * @type {String}
-   * @default null
-   * @public
-   */
-  url: null,
+ /**
+  * Should the action be disabled
+  *
+  * @type {Boolean}
+  * @default false
+  * @public
+  */
+ disabled = false;
 
-  /**
-   * Forces url to open in a new tab
-   *
-   * @type {Boolean}
-   * @default false
-   * @public
-   */
-  external: false,
+ /**
+  * @type {Boolean}
+  * @default false
+  * @public
+  */
+ disclosure = false;
 
-  /**
-   * Should the action be disabled
-   *
-   * @type {Boolean}
-   * @default false
-   * @public
-   */
-  disabled: false,
+ /**
+  * @type {Function}
+  * @default noop
+  * @public
+  */
+ handleMeasurement() {}
 
-  /**
-   * @type {Boolean}
-   * @default false
-   * @public
-   */
-  disclosure: false,
+ /**
+  * Callback when an action takes place
+  *
+  * @type {Function}
+  * @default noop
+  * @public
+  */
+ onAction() {}
 
-  /**
-   * @type {Function}
-   * @default noop
-   * @public
-   */
-  handleMeasurement() {},
-
-  /**
-   * Callback when an action takes place
-   *
-   * @type {Function}
-   * @default noop
-   * @public
-   */
-  onAction() {},
-
-  handleMouseUpByBlurring,
-});
+ handleMouseUpByBlurring = handleMouseUpByBlurring;
+}

--- a/addon/components/polaris-resource-list/bulk-actions/bulk-action-button.js
+++ b/addon/components/polaris-resource-list/bulk-actions/bulk-action-button.js
@@ -6,73 +6,73 @@ import { handleMouseUpByBlurring } from '../../../utils/focus';
 @tagName('')
 @templateLayout(layout)
 export default class BulkActionButton extends Component {
- /**
-  * Content the action displays
-  *
-  * @type {String|Component|Object}
-  * @default null
-  * @public
-  */
- content = null;
+  /**
+   * Content the action displays
+   *
+   * @type {String|Component|Object}
+   * @default null
+   * @public
+   */
+  content = null;
 
- /**
-  * Visually hidden text for screen readers
-  *
-  * @type {String}
-  * @default null
-  * @public
-  */
- accessibilityLabel = null;
+  /**
+   * Visually hidden text for screen readers
+   *
+   * @type {String}
+   * @default null
+   * @public
+   */
+  accessibilityLabel = null;
 
- /**
-  * A destination to link to, rendered in the action
-  *
-  * @type {String}
-  * @default null
-  * @public
-  */
- url = null;
+  /**
+   * A destination to link to, rendered in the action
+   *
+   * @type {String}
+   * @default null
+   * @public
+   */
+  url = null;
 
- /**
-  * Forces url to open in a new tab
-  *
-  * @type {Boolean}
-  * @default false
-  * @public
-  */
- external = false;
+  /**
+   * Forces url to open in a new tab
+   *
+   * @type {Boolean}
+   * @default false
+   * @public
+   */
+  external = false;
 
- /**
-  * Should the action be disabled
-  *
-  * @type {Boolean}
-  * @default false
-  * @public
-  */
- disabled = false;
+  /**
+   * Should the action be disabled
+   *
+   * @type {Boolean}
+   * @default false
+   * @public
+   */
+  disabled = false;
 
- /**
-  * @type {Boolean}
-  * @default false
-  * @public
-  */
- disclosure = false;
+  /**
+   * @type {Boolean}
+   * @default false
+   * @public
+   */
+  disclosure = false;
 
- /**
-  * @type {Function}
-  * @default noop
-  * @public
-  */
- handleMeasurement() {}
+  /**
+   * @type {Function}
+   * @default noop
+   * @public
+   */
+  handleMeasurement() {}
 
- /**
-  * Callback when an action takes place
-  *
-  * @type {Function}
-  * @default noop
-  * @public
-  */
- onAction() {}
+  /**
+   * Callback when an action takes place
+   *
+   * @type {Function}
+   * @default noop
+   * @public
+   */
+  onAction() {}
 
- handleMouseUpByBlurring = handleMouseUpByBlurring;
+  handleMouseUpByBlurring = handleMouseUpByBlurring;
 }

--- a/addon/components/polaris-resource-list/checkable-button.js
+++ b/addon/components/polaris-resource-list/checkable-button.js
@@ -1,81 +1,81 @@
 import Component from '@ember/component';
-import { and, not } from '@ember/object/computed';
+import { not, and } from '@ember/object/computed';
+import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import mapEventToAction from '@smile-io/ember-polaris/utils/map-event-to-action';
 import layout from '../../templates/components/polaris-resource-list/checkable-button';
 
-export default Component.extend({
-  classNames: ['Polaris-ResourceList-CheckableButton'],
-
-  classNameBindings: [
-    'plain:Polaris-ResourceList-CheckableButton__CheckableButton--plain',
-    'shouldApplySelectModeClass:Polaris-ResourceList-CheckableButton__CheckableButton--selectMode',
-    'shouldApplySelectedClass:Polaris-ResourceList-CheckableButton__CheckableButton--selected',
-    'shouldApplyMeasuringClass:Polaris-ResourceList-CheckableButton__CheckableButton--measuring',
-  ],
-
-  layout,
+@tagName('')
+@templateLayout(layout)
+export default class CheckableButton extends Component {
+  /**
+  * @type {String}
+  * @default null
+  * @property accessibilityLabel
+  */
+  accessibilityLabel = null;
 
   /**
-   * @type {String}
-   * @default null
-   * @property accessibilityLabel
-   */
-  accessibilityLabel: null,
+  * @type {String}
+  * @default ''
+  * @property label
+  */
+  label = '';
 
   /**
-   * @type {String}
-   * @default ''
-   * @property label
-   */
-  label: '',
+  *
+  * Checkbox is selected. `indeterminate` shows a horizontal line in the checkbox
+  *
+  * @type {Boolean|String}
+  * @default null
+  * @property selected
+  */
+  selected = null;
 
   /**
-   *
-   * Checkbox is selected. `indeterminate` shows a horizontal line in the checkbox
-   *
-   * @type {Boolean|String}
-   * @default null
-   * @property selected
-   */
-  selected: null,
+  * @type {Boolean}
+  * @default false
+  * @property selectMode
+  */
+  selectMode = false;
 
   /**
-   * @type {Boolean}
-   * @default false
-   * @property selectMode
-   */
-  selectMode: false,
+  * @type {Boolean}
+  * @default false
+  * @property plain
+  */
+  plain = false;
 
   /**
-   * @type {Boolean}
-   * @default false
-   * @property plain
-   */
-  plain: false,
+  * @type {Boolean}
+  * @default false
+  * @property measuring
+  */
+  measuring = false;
 
   /**
-   * @type {Boolean}
-   * @default false
-   * @property measuring
-   */
-  measuring: false,
+  * @type {Boolean}
+  * @default false
+  * @property disabled
+  */
+  disabled = false;
 
   /**
-   * @type {Boolean}
-   * @default false
-   * @property disabled
-   */
-  disabled: false,
+  * @type {Function}
+  * @default noop
+  * @property onToggleAll
+  */
+  @mapEventToAction('onToggleAll')
+  click;
 
-  /**
-   * @type {Function}
-   * @default noop
-   * @property onToggleAll
-   */
-  click: mapEventToAction('onToggleAll'),
+  @not('plain')
+  isNotPlain;
 
-  isNotPlain: not('plain'),
-  shouldApplySelectModeClass: and('isNotPlain', 'selectMode'),
-  shouldApplySelectedClass: and('isNotPlain', 'selected'),
-  shouldApplyMeasuringClass: and('isNotPlain', 'measuring'),
-});
+  @and('isNotPlain', 'selectMode')
+  shouldApplySelectModeClass;
+
+  @and('isNotPlain', 'selected')
+  shouldApplySelectedClass;
+
+  @and('isNotPlain', 'measuring')
+  shouldApplyMeasuringClass;
+}

--- a/addon/components/polaris-resource-list/checkable-button.js
+++ b/addon/components/polaris-resource-list/checkable-button.js
@@ -1,71 +1,69 @@
 import Component from '@ember/component';
 import { not, and } from '@ember/object/computed';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
-import mapEventToAction from '@smile-io/ember-polaris/utils/map-event-to-action';
 import layout from '../../templates/components/polaris-resource-list/checkable-button';
 
 @tagName('')
 @templateLayout(layout)
 export default class CheckableButton extends Component {
   /**
-  * @type {String}
-  * @default null
-  * @property accessibilityLabel
-  */
+   * @type {String}
+   * @default null
+   * @property accessibilityLabel
+   */
   accessibilityLabel = null;
 
   /**
-  * @type {String}
-  * @default ''
-  * @property label
-  */
+   * @type {String}
+   * @default ''
+   * @property label
+   */
   label = '';
 
   /**
-  *
-  * Checkbox is selected. `indeterminate` shows a horizontal line in the checkbox
-  *
-  * @type {Boolean|String}
-  * @default null
-  * @property selected
-  */
+   *
+   * Checkbox is selected. `indeterminate` shows a horizontal line in the checkbox
+   *
+   * @type {Boolean|String}
+   * @default null
+   * @property selected
+   */
   selected = null;
 
   /**
-  * @type {Boolean}
-  * @default false
-  * @property selectMode
-  */
+   * @type {Boolean}
+   * @default false
+   * @property selectMode
+   */
   selectMode = false;
 
   /**
-  * @type {Boolean}
-  * @default false
-  * @property plain
-  */
+   * @type {Boolean}
+   * @default false
+   * @property plain
+   */
   plain = false;
 
   /**
-  * @type {Boolean}
-  * @default false
-  * @property measuring
-  */
+   * @type {Boolean}
+   * @default false
+   * @property measuring
+   */
   measuring = false;
 
   /**
-  * @type {Boolean}
-  * @default false
-  * @property disabled
-  */
+   * @type {Boolean}
+   * @default false
+   * @property disabled
+   */
   disabled = false;
 
   /**
-  * @type {Function}
-  * @default noop
-  * @property onToggleAll
-  */
-  @mapEventToAction('onToggleAll')
-  click;
+   * @type {Function}
+   * @default noop
+   * @property onToggleAll
+   */
+  onToggleAll() {}
 
   @not('plain')
   isNotPlain;

--- a/addon/components/polaris-resource-list/checkable-button.js
+++ b/addon/components/polaris-resource-list/checkable-button.js
@@ -10,6 +10,7 @@ export default class CheckableButton extends Component {
    * @type {String}
    * @default null
    * @property accessibilityLabel
+   * @public
    */
   accessibilityLabel = null;
 
@@ -17,6 +18,7 @@ export default class CheckableButton extends Component {
    * @type {String}
    * @default ''
    * @property label
+   * @public
    */
   label = '';
 
@@ -27,6 +29,7 @@ export default class CheckableButton extends Component {
    * @type {Boolean|String}
    * @default null
    * @property selected
+   * @public
    */
   selected = null;
 
@@ -34,6 +37,7 @@ export default class CheckableButton extends Component {
    * @type {Boolean}
    * @default false
    * @property selectMode
+   * @public
    */
   selectMode = false;
 
@@ -41,6 +45,7 @@ export default class CheckableButton extends Component {
    * @type {Boolean}
    * @default false
    * @property plain
+   * @public
    */
   plain = false;
 
@@ -48,6 +53,7 @@ export default class CheckableButton extends Component {
    * @type {Boolean}
    * @default false
    * @property measuring
+   * @public
    */
   measuring = false;
 
@@ -55,6 +61,7 @@ export default class CheckableButton extends Component {
    * @type {Boolean}
    * @default false
    * @property disabled
+   * @public
    */
   disabled = false;
 
@@ -62,6 +69,7 @@ export default class CheckableButton extends Component {
    * @type {Function}
    * @default noop
    * @property onToggleAll
+   * @public
    */
   onToggleAll() {}
 

--- a/addon/components/polaris-resource-list/filter-control.js
+++ b/addon/components/polaris-resource-list/filter-control.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { get, computed } from '@ember/object';
+import { action, get, computed } from '@ember/object';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../templates/components/polaris-resource-list/filter-control';
 import { context } from '@smile-io/ember-polaris/components/polaris-resource-list';
@@ -132,6 +132,7 @@ export default class FilterControl extends Component.extend(
     return `Search ${this.context.resourceName.plural.toLocaleLowerCase()}`;
   }
 
+  @action
   handleAddFilter(newFilter) {
     let { onFiltersChange, appliedFilters } = this;
     appliedFilters = appliedFilters || [];
@@ -153,6 +154,7 @@ export default class FilterControl extends Component.extend(
     onFiltersChange(newAppliedFilters);
   }
 
+  @action
   handleRemoveFilter(filter) {
     let filterId = idFromFilter(filter);
     let { onFiltersChange, appliedFilters } = this;

--- a/addon/components/polaris-resource-list/filter-control.js
+++ b/addon/components/polaris-resource-list/filter-control.js
@@ -1,21 +1,20 @@
 import Component from '@ember/component';
-import { computed, get } from '@ember/object';
+import { get, computed } from '@ember/object';
+import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../templates/components/polaris-resource-list/filter-control';
 import { context } from '@smile-io/ember-polaris/components/polaris-resource-list';
 import { FilterType } from '@smile-io/ember-polaris/components/polaris-resource-list/filter-control/filter-value-selector';
 
-export default Component.extend(context.ConsumerMixin, {
-  tagName: '',
-
-  layout,
-
+@tagName('')
+@templateLayout(layout)
+export default class FilterControl extends Component.extend(context.ConsumerMixin) {
   /**
    * @property searchValue
    * @type {String}
    * @default null
    * @public
    */
-  searchValue: null,
+  searchValue = null;
 
   /**
    * @property appliedFilters
@@ -23,7 +22,7 @@ export default Component.extend(context.ConsumerMixin, {
    * @default null
    * @public
    */
-  appliedFilters: null,
+  appliedFilters = null;
 
   /**
    * @property additionalAction
@@ -31,7 +30,7 @@ export default Component.extend(context.ConsumerMixin, {
    * @default null
    * @public
    */
-  additionalAction: null,
+  additionalAction = null;
 
   /**
    * @property focused
@@ -39,7 +38,7 @@ export default Component.extend(context.ConsumerMixin, {
    * @default false
    * @public
    */
-  focused: false,
+  focused = false;
 
   /**
    * @property filters
@@ -47,7 +46,7 @@ export default Component.extend(context.ConsumerMixin, {
    * @default null
    * @public
    */
-  filters: null,
+  filters = null;
 
   /**
    * @property onSearchBlur
@@ -55,7 +54,7 @@ export default Component.extend(context.ConsumerMixin, {
    * @default noop
    * @public
    */
-  onSearchBlur() {},
+  onSearchBlur() {}
 
   /**
    * @property onSearchChange
@@ -63,7 +62,7 @@ export default Component.extend(context.ConsumerMixin, {
    * @default noop
    * @public
    */
-  onSearchChange() {},
+  onSearchChange() {}
 
   /**
    * @property onFiltersChange
@@ -71,7 +70,7 @@ export default Component.extend(context.ConsumerMixin, {
    * @default noop
    * @public
    */
-  onFiltersChange() {},
+  onFiltersChange() {}
 
   /**
    * Button details for `additionalAction`. This is here
@@ -84,32 +83,32 @@ export default Component.extend(context.ConsumerMixin, {
    * @type {Object}
    * @private
    */
-  additionalActionButton: computed(
+  @(computed(
     'additionalAction.{text,accessibilityLabel,url,external,destructive,icon,loading,onAction}',
-    'context.selectMode',
-    function() {
-      let { additionalAction, context } = this.getProperties(
-        'additionalAction',
-        'context'
-      );
-      if (!additionalAction) {
-        return null;
-      }
-
-      let props = Object.assign({}, additionalAction, {
-        disabled: get(context, 'selectMode'),
-      });
-
-      // Rename onAction to onClick.
-      props.onClick = props.onAction;
-      delete props.onAction;
-
-      return {
-        componentName: 'polaris-button',
-        props,
-      };
+    'context.selectMode'
+  ).readOnly())
+  get additionalActionButton() {
+    let { additionalAction, context } = this.getProperties(
+      'additionalAction',
+      'context'
+    );
+    if (!additionalAction) {
+      return null;
     }
-  ).readOnly(),
+
+    let props = Object.assign({}, additionalAction, {
+      disabled: get(context, 'selectMode'),
+    });
+
+    // Rename onAction to onClick.
+    props.onClick = props.onAction;
+    delete props.onAction;
+
+    return {
+      componentName: 'polaris-button',
+      props,
+    };
+  }
 
   /**
    * List of appliedFilters in a format
@@ -119,20 +118,22 @@ export default Component.extend(context.ConsumerMixin, {
    * @type {Object[]}
    * @private
    */
-  appliedFiltersForRender: computed('appliedFilters.[]', function() {
+  @(computed('appliedFilters.[]').readOnly())
+  get appliedFiltersForRender() {
     let appliedFilters = this.get('appliedFilters') || [];
     return appliedFilters.map((appliedFilter) => {
       let appliedFilterForRender = JSON.parse(JSON.stringify(appliedFilter));
       appliedFilterForRender.label = this.getFilterLabel(appliedFilter);
       return appliedFilterForRender;
     });
-  }).readOnly(),
+  }
 
-  textFieldLabel: computed(function() {
+  @(computed.readOnly())
+  get textFieldLabel() {
     return `Search ${this.get(
       'context.resourceName.plural'
     ).toLocaleLowerCase()}`;
-  }).readOnly(),
+  }
 
   handleAddFilter(newFilter) {
     let { onFiltersChange, appliedFilters } = this.getProperties(
@@ -156,7 +157,7 @@ export default Component.extend(context.ConsumerMixin, {
     let newAppliedFilters = [...appliedFilters, newFilter];
 
     onFiltersChange(newAppliedFilters);
-  },
+  }
 
   handleRemoveFilter(filter) {
     let filterId = idFromFilter(filter);
@@ -183,7 +184,7 @@ export default Component.extend(context.ConsumerMixin, {
         : [...appliedFilters];
 
     onFiltersChange(newAppliedFilters);
-  },
+  }
 
   getFilterLabel(appliedFilter) {
     let key = get(appliedFilter, 'key');
@@ -227,7 +228,7 @@ export default Component.extend(context.ConsumerMixin, {
     }
 
     return `${filter.label} ${filterOperatorLabel} ${filterLabelByType}`;
-  },
+  }
 
   findFilterLabelByType(filter, appliedFilter) {
     let appliedFilterValue = get(appliedFilter, 'value');
@@ -265,8 +266,8 @@ export default Component.extend(context.ConsumerMixin, {
     }
 
     return appliedFilterValue;
-  },
-});
+  }
+}
 
 function idFromFilter(appliedFilter) {
   return `${get(appliedFilter, 'key')}-${get(appliedFilter, 'value')}`;

--- a/addon/components/polaris-resource-list/filter-control.js
+++ b/addon/components/polaris-resource-list/filter-control.js
@@ -7,7 +7,9 @@ import { FilterType } from '@smile-io/ember-polaris/components/polaris-resource-
 
 @tagName('')
 @templateLayout(layout)
-export default class FilterControl extends Component.extend(context.ConsumerMixin) {
+export default class FilterControl extends Component.extend(
+  context.ConsumerMixin
+) {
   /**
    * @property searchValue
    * @type {String}
@@ -88,10 +90,8 @@ export default class FilterControl extends Component.extend(context.ConsumerMixi
     'context.selectMode'
   ).readOnly())
   get additionalActionButton() {
-    let { additionalAction, context } = this.getProperties(
-      'additionalAction',
-      'context'
-    );
+    let { additionalAction, context } = this;
+
     if (!additionalAction) {
       return null;
     }
@@ -120,7 +120,7 @@ export default class FilterControl extends Component.extend(context.ConsumerMixi
    */
   @(computed('appliedFilters.[]').readOnly())
   get appliedFiltersForRender() {
-    let appliedFilters = this.get('appliedFilters') || [];
+    let appliedFilters = this.appliedFilters || [];
     return appliedFilters.map((appliedFilter) => {
       let appliedFilterForRender = JSON.parse(JSON.stringify(appliedFilter));
       appliedFilterForRender.label = this.getFilterLabel(appliedFilter);
@@ -128,18 +128,12 @@ export default class FilterControl extends Component.extend(context.ConsumerMixi
     });
   }
 
-  @(computed.readOnly())
   get textFieldLabel() {
-    return `Search ${this.get(
-      'context.resourceName.plural'
-    ).toLocaleLowerCase()}`;
+    return `Search ${this.context.resourceName.plural.toLocaleLowerCase()}`;
   }
 
   handleAddFilter(newFilter) {
-    let { onFiltersChange, appliedFilters } = this.getProperties(
-      'onFiltersChange',
-      'appliedFilters'
-    );
+    let { onFiltersChange, appliedFilters } = this;
     appliedFilters = appliedFilters || [];
 
     if (!onFiltersChange) {
@@ -161,10 +155,7 @@ export default class FilterControl extends Component.extend(context.ConsumerMixi
 
   handleRemoveFilter(filter) {
     let filterId = idFromFilter(filter);
-    let { onFiltersChange, appliedFilters } = this.getProperties(
-      'onFiltersChange',
-      'appliedFilters'
-    );
+    let { onFiltersChange, appliedFilters } = this;
     appliedFilters = appliedFilters || [];
 
     if (!onFiltersChange) {
@@ -194,7 +185,7 @@ export default class FilterControl extends Component.extend(context.ConsumerMixi
       return label;
     }
 
-    let filters = this.get('filters') || [];
+    let filters = this.filters || [];
 
     let filter = filters.find((filter) => {
       let minKey = get(filter, 'minKey');

--- a/addon/components/polaris-resource-list/filter-control/date-selector.js
+++ b/addon/components/polaris-resource-list/filter-control/date-selector.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { action, computed } from '@ember/object';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../../templates/components/polaris-resource-list/filter-control/date-selector';
 
@@ -253,6 +253,7 @@ export default class DateSelector extends Component {
     return this.get(`dateOptionTypes.${dateOptionType}`);
   }
 
+  @action
   handleDateFilterOptionsChange(newOption) {
     let {
       onFilterValueChange,
@@ -291,6 +292,7 @@ export default class DateSelector extends Component {
     onFilterValueChange(newOption);
   }
 
+  @action
   handleDateFieldChange(value) {
     let { onFilterValueChange, userInputDateError } = this;
 
@@ -306,6 +308,7 @@ export default class DateSelector extends Component {
     this.set('userInputDate', value);
   }
 
+  @action
   handleDateBlur() {
     let { onFilterValueChange, dateTextFieldValue } = this;
 
@@ -350,6 +353,7 @@ export default class DateSelector extends Component {
     );
   }
 
+  @action
   handleDatePickerChange({ end: nextDate }) {
     this.setProperties({
       selectedDate: new Date(nextDate),
@@ -360,6 +364,7 @@ export default class DateSelector extends Component {
     this.handleDateChanged();
   }
 
+  @action
   handleDatePickerMonthChange(month, year) {
     this.setProperties({
       datePickerMonth: month,

--- a/addon/components/polaris-resource-list/filter-control/date-selector.js
+++ b/addon/components/polaris-resource-list/filter-control/date-selector.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
+import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../../templates/components/polaris-resource-list/filter-control/date-selector';
 
 const VALID_DATE_REGEX = /^\d{4}-\d{1,2}-\d{1,2}$/;
@@ -17,11 +18,9 @@ export const DateFilterOption = {
   OnOrAfter: 'on_or_after',
 };
 
-export default Component.extend({
-  tagName: '',
-
-  layout,
-
+@tagName('')
+@templateLayout(layout)
+export default class DateSelector extends Component {
   /**
    * Can be 'past', 'future' or 'full'.
    *
@@ -30,7 +29,7 @@ export default Component.extend({
    * @default 'full'
    * @public
    */
-  dateOptionType: 'full',
+  dateOptionType = 'full';
 
   /**
    * @property filterValue
@@ -38,7 +37,7 @@ export default Component.extend({
    * @default null
    * @public
    */
-  filterValue: null,
+  filterValue = null;
 
   /**
    * @property filterKey
@@ -46,7 +45,7 @@ export default Component.extend({
    * @default null
    * @public
    */
-  filterKey: null,
+  filterKey = null;
 
   /**
    * @property filterMinKey
@@ -54,7 +53,7 @@ export default Component.extend({
    * @default null
    * @public
    */
-  filterMinKey: null,
+  filterMinKey = null;
 
   /**
    * @property filterMaxKey
@@ -62,7 +61,7 @@ export default Component.extend({
    * @default null
    * @public
    */
-  filterMaxKey: null,
+  filterMaxKey = null;
 
   /**
    * @property onFilterValueChange
@@ -70,7 +69,7 @@ export default Component.extend({
    * @default noop
    * @public
    */
-  onFilterValueChange() {},
+  onFilterValueChange() {}
 
   /**
    * @property onFilterKeyChange
@@ -78,7 +77,7 @@ export default Component.extend({
    * @default noop
    * @public
    */
-  onFilterKeyChange() {},
+  onFilterKeyChange() {}
 
   /**
    * @property selectedDate
@@ -86,7 +85,7 @@ export default Component.extend({
    * @default null
    * @private
    */
-  selectedDate: null,
+  selectedDate = null;
 
   /**
    * @property userInputDate
@@ -94,7 +93,7 @@ export default Component.extend({
    * @default null
    * @private
    */
-  userInputDate: null,
+  userInputDate = null;
 
   /**
    * @property userInputDateError
@@ -102,7 +101,7 @@ export default Component.extend({
    * @default null
    * @private
    */
-  userInputDateError: null,
+  userInputDateError = null;
 
   /**
    * Month enum value, either string day of month or integer index (0 = Sunday).
@@ -111,14 +110,14 @@ export default Component.extend({
    * @type {String|Number}
    * @private
    */
-  datePickerMonth: null,
+  datePickerMonth = null;
 
   /**
    * @property datePickerYear
    * @type {Number}
    * @private
    */
-  datePickerYear: null,
+  datePickerYear = null;
 
   /**
    * Will be set on initialisation.
@@ -128,9 +127,10 @@ export default Component.extend({
    * @default null
    * @private
    */
-  initialConsumerFilterKey: null,
+  initialConsumerFilterKey = null;
 
-  dateComparatorOptions: computed(function() {
+  @(computed.readOnly())
+  get dateComparatorOptions() {
     return [
       {
         value: DateFilterOption.OnOrBefore,
@@ -141,9 +141,10 @@ export default Component.extend({
         label: 'on or after',
       },
     ];
-  }).readOnly(),
+  }
 
-  datePastOptions: computed(function() {
+  @(computed.readOnly())
+  get datePastOptions() {
     return [
       {
         value: DateFilterOption.PastWeek,
@@ -162,9 +163,10 @@ export default Component.extend({
         label: 'in the last year',
       },
     ];
-  }).readOnly(),
+  }
 
-  dateFutureOptions: computed(function() {
+  @(computed.readOnly())
+  get dateFutureOptions() {
     return [
       {
         value: DateFilterOption.ComingWeek,
@@ -183,9 +185,10 @@ export default Component.extend({
         label: 'in the next year',
       },
     ];
-  }).readOnly(),
+  }
 
-  dateOptionTypes: computed(function() {
+  @(computed.readOnly())
+  get dateOptionTypes() {
     return {
       past: [
         ...this.get('datePastOptions'),
@@ -201,13 +204,15 @@ export default Component.extend({
         ...this.get('dateComparatorOptions'),
       ],
     };
-  }).readOnly(),
+  }
 
-  now: computed(function() {
+  @(computed.readOnly())
+  get now() {
     return new Date();
-  }).readOnly(),
+  }
 
-  dateTextFieldValue: computed('userInputDate', 'selectedDate', function() {
+  @(computed('userInputDate', 'selectedDate').readOnly())
+  get dateTextFieldValue() {
     const { userInputDate, selectedDate } = this.getProperties(
       'userInputDate',
       'selectedDate'
@@ -226,49 +231,48 @@ export default Component.extend({
     }
 
     return null;
-  }).readOnly(),
+  }
 
-  dateFilterOption: computed(
-    'filterValue',
-    'filterKey',
-    'filterMinKey',
-    'filterMaxKey',
-    function() {
-      let {
-        filterValue,
-        filterKey,
-        filterMinKey,
-        filterMaxKey,
-      } = this.getProperties(
-        'filterValue',
-        'filterKey',
-        'filterMinKey',
-        'filterMaxKey'
-      );
+  @(
+    computed('filterValue', 'filterKey', 'filterMinKey', 'filterMaxKey').readOnly()
+  )
+  get dateFilterOption() {
+    let {
+      filterValue,
+      filterKey,
+      filterMinKey,
+      filterMaxKey,
+    } = this.getProperties(
+      'filterValue',
+      'filterKey',
+      'filterMinKey',
+      'filterMaxKey'
+    );
 
-      return getDateFilterOption(
-        filterValue,
-        filterKey,
-        filterMinKey,
-        filterMaxKey
-      );
-    }
-  ).readOnly(),
+    return getDateFilterOption(
+      filterValue,
+      filterKey,
+      filterMinKey,
+      filterMaxKey
+    );
+  }
 
-  showDatePredicate: computed('dateFilterOption', function() {
+  @(computed('dateFilterOption').readOnly())
+  get showDatePredicate() {
     let dateFilterOption = this.get('dateFilterOption');
 
     return (
       dateFilterOption === DateFilterOption.OnOrBefore ||
       dateFilterOption === DateFilterOption.OnOrAfter
     );
-  }).readOnly(),
+  }
 
-  dateOptions: computed('dateOptionType', function() {
+  @(computed('dateOptionType').readOnly())
+  get dateOptions() {
     let dateOptionType = this.get('dateOptionType') || 'full';
 
     return this.get(`dateOptionTypes.${dateOptionType}`);
-  }).readOnly(),
+  }
 
   handleDateFilterOptionsChange(newOption) {
     let {
@@ -313,7 +317,7 @@ export default Component.extend({
 
     onFilterKeyChange(initialConsumerFilterKey);
     onFilterValueChange(newOption);
-  },
+  }
 
   handleDateFieldChange(value) {
     let { onFilterValueChange, userInputDateError } = this.getProperties(
@@ -331,7 +335,7 @@ export default Component.extend({
     }
 
     this.set('userInputDate', value);
-  },
+  }
 
   handleDateBlur() {
     let { onFilterValueChange, dateTextFieldValue } = this.getProperties(
@@ -366,7 +370,7 @@ export default Component.extend({
       userInputDateError: undefined,
     });
     this.handleDateChanged();
-  },
+  }
 
   handleDateChanged() {
     let { onFilterValueChange, selectedDate } = this.getProperties(
@@ -381,7 +385,7 @@ export default Component.extend({
     onFilterValueChange(
       stripTimeFromISOString(formatDateForLocalTimezone(selectedDate))
     );
-  },
+  }
 
   handleDatePickerChange({ end: nextDate }) {
     this.setProperties({
@@ -391,25 +395,25 @@ export default Component.extend({
     });
 
     this.handleDateChanged();
-  },
+  }
 
   handleDatePickerMonthChange(month, year) {
     this.setProperties({
       datePickerMonth: month,
       datePickerYear: year,
     });
-  },
+  }
 
   init() {
-    this._super(...arguments);
+    super.init(...arguments);
 
     this.setProperties({
       datePickerMonth: this.get('now').getMonth(),
       datePickerYear: this.get('now').getYear(),
       initialConsumerFilterKey: this.get('filterKey'),
     });
-  },
-});
+  }
+}
 
 function isValidDate(date) {
   if (!date) {

--- a/addon/components/polaris-resource-list/filter-control/date-selector.js
+++ b/addon/components/polaris-resource-list/filter-control/date-selector.js
@@ -129,73 +129,66 @@ export default class DateSelector extends Component {
    */
   initialConsumerFilterKey = null;
 
-  get dateComparatorOptions() {
-    return [
-      {
-        value: DateFilterOption.OnOrBefore,
-        label: 'on or before',
-      },
-      {
-        value: DateFilterOption.OnOrAfter,
-        label: 'on or after',
-      },
-    ];
-  }
+  dateComparatorOptions = [
+    {
+      value: DateFilterOption.OnOrBefore,
+      label: 'on or before',
+    },
+    {
+      value: DateFilterOption.OnOrAfter,
+      label: 'on or after',
+    },
+  ];
 
-  get datePastOptions() {
-    return [
-      {
-        value: DateFilterOption.PastWeek,
-        label: 'in the last week',
-      },
-      {
-        value: DateFilterOption.PastMonth,
-        label: 'in the last month',
-      },
-      {
-        value: DateFilterOption.PastQuarter,
-        label: 'in the last 3 months',
-      },
-      {
-        value: DateFilterOption.PastYear,
-        label: 'in the last year',
-      },
-    ];
-  }
+  datePastOptions = [
+    {
+      value: DateFilterOption.PastWeek,
+      label: 'in the last week',
+    },
+    {
+      value: DateFilterOption.PastMonth,
+      label: 'in the last month',
+    },
+    {
+      value: DateFilterOption.PastQuarter,
+      label: 'in the last 3 months',
+    },
+    {
+      value: DateFilterOption.PastYear,
+      label: 'in the last year',
+    },
+  ];
 
-  get dateFutureOptions() {
-    return [
-      {
-        value: DateFilterOption.ComingWeek,
-        label: 'next week',
-      },
-      {
-        value: DateFilterOption.ComingMonth,
-        label: 'next month',
-      },
-      {
-        value: DateFilterOption.ComingQuarter,
-        label: 'in the next 3 months',
-      },
-      {
-        value: DateFilterOption.ComingYear,
-        label: 'in the next year',
-      },
-    ];
-  }
+  dateFutureOptions = [
+    {
+      value: DateFilterOption.ComingWeek,
+      label: 'next week',
+    },
+    {
+      value: DateFilterOption.ComingMonth,
+      label: 'next month',
+    },
+    {
+      value: DateFilterOption.ComingQuarter,
+      label: 'in the next 3 months',
+    },
+    {
+      value: DateFilterOption.ComingYear,
+      label: 'in the next year',
+    },
+  ];
 
-  get dateOptionTypes() {
-    return {
-      past: [...this.datePastOptions, ...this.dateComparatorOptions],
-      future: [...this.dateFutureOptions, ...this.dateComparatorOptions],
-      full: [
-        ...this.datePastOptions,
-        ...this.dateFutureOptions,
-        ...this.dateComparatorOptions,
-      ],
-    };
-  }
+  dateOptionTypes = {
+    past: [...this.datePastOptions, ...this.dateComparatorOptions],
+    future: [...this.dateFutureOptions, ...this.dateComparatorOptions],
+    full: [
+      ...this.datePastOptions,
+      ...this.dateFutureOptions,
+      ...this.dateComparatorOptions,
+    ],
+  };
 
+  @computed()
   get now() {
     return new Date();
   }

--- a/addon/components/polaris-resource-list/filter-control/date-selector.js
+++ b/addon/components/polaris-resource-list/filter-control/date-selector.js
@@ -129,7 +129,6 @@ export default class DateSelector extends Component {
    */
   initialConsumerFilterKey = null;
 
-  @(computed.readOnly())
   get dateComparatorOptions() {
     return [
       {
@@ -143,7 +142,6 @@ export default class DateSelector extends Component {
     ];
   }
 
-  @(computed.readOnly())
   get datePastOptions() {
     return [
       {
@@ -165,7 +163,6 @@ export default class DateSelector extends Component {
     ];
   }
 
-  @(computed.readOnly())
   get dateFutureOptions() {
     return [
       {
@@ -187,36 +184,25 @@ export default class DateSelector extends Component {
     ];
   }
 
-  @(computed.readOnly())
   get dateOptionTypes() {
     return {
-      past: [
-        ...this.get('datePastOptions'),
-        ...this.get('dateComparatorOptions'),
-      ],
-      future: [
-        ...this.get('dateFutureOptions'),
-        ...this.get('dateComparatorOptions'),
-      ],
+      past: [...this.datePastOptions, ...this.dateComparatorOptions],
+      future: [...this.dateFutureOptions, ...this.dateComparatorOptions],
       full: [
-        ...this.get('datePastOptions'),
-        ...this.get('dateFutureOptions'),
-        ...this.get('dateComparatorOptions'),
+        ...this.datePastOptions,
+        ...this.dateFutureOptions,
+        ...this.dateComparatorOptions,
       ],
     };
   }
 
-  @(computed.readOnly())
   get now() {
     return new Date();
   }
 
   @(computed('userInputDate', 'selectedDate').readOnly())
   get dateTextFieldValue() {
-    const { userInputDate, selectedDate } = this.getProperties(
-      'userInputDate',
-      'selectedDate'
-    );
+    const { userInputDate, selectedDate } = this;
 
     if (!userInputDate && !selectedDate) {
       return undefined;
@@ -233,21 +219,14 @@ export default class DateSelector extends Component {
     return null;
   }
 
-  @(
-    computed('filterValue', 'filterKey', 'filterMinKey', 'filterMaxKey').readOnly()
-  )
+  @(computed(
+    'filterValue',
+    'filterKey',
+    'filterMinKey',
+    'filterMaxKey'
+  ).readOnly())
   get dateFilterOption() {
-    let {
-      filterValue,
-      filterKey,
-      filterMinKey,
-      filterMaxKey,
-    } = this.getProperties(
-      'filterValue',
-      'filterKey',
-      'filterMinKey',
-      'filterMaxKey'
-    );
+    let { filterValue, filterKey, filterMinKey, filterMaxKey } = this;
 
     return getDateFilterOption(
       filterValue,
@@ -259,7 +238,7 @@ export default class DateSelector extends Component {
 
   @(computed('dateFilterOption').readOnly())
   get showDatePredicate() {
-    let dateFilterOption = this.get('dateFilterOption');
+    let { dateFilterOption } = this;
 
     return (
       dateFilterOption === DateFilterOption.OnOrBefore ||
@@ -269,7 +248,7 @@ export default class DateSelector extends Component {
 
   @(computed('dateOptionType').readOnly())
   get dateOptions() {
-    let dateOptionType = this.get('dateOptionType') || 'full';
+    let dateOptionType = this.dateOptionType || 'full';
 
     return this.get(`dateOptionTypes.${dateOptionType}`);
   }
@@ -282,14 +261,7 @@ export default class DateSelector extends Component {
       filterMaxKey,
       initialConsumerFilterKey,
       selectedDate,
-    } = this.getProperties(
-      'onFilterValueChange',
-      'onFilterKeyChange',
-      'filterMinKey',
-      'filterMaxKey',
-      'initialConsumerFilterKey',
-      'selectedDate'
-    );
+    } = this;
 
     if (!initialConsumerFilterKey) {
       return;
@@ -320,10 +292,7 @@ export default class DateSelector extends Component {
   }
 
   handleDateFieldChange(value) {
-    let { onFilterValueChange, userInputDateError } = this.getProperties(
-      'onFilterValueChange',
-      'userInputDateError'
-    );
+    let { onFilterValueChange, userInputDateError } = this;
 
     if (value.length === 0) {
       this.set('selectedDate', undefined);
@@ -338,10 +307,7 @@ export default class DateSelector extends Component {
   }
 
   handleDateBlur() {
-    let { onFilterValueChange, dateTextFieldValue } = this.getProperties(
-      'onFilterValueChange',
-      'dateTextFieldValue'
-    );
+    let { onFilterValueChange, dateTextFieldValue } = this;
 
     if (!dateTextFieldValue || !isValidDate(dateTextFieldValue)) {
       this.setProperties({
@@ -353,7 +319,7 @@ export default class DateSelector extends Component {
       return;
     }
 
-    let userInputDate = this.get('userInputDate');
+    let { userInputDate } = this;
     if (!userInputDate) {
       return;
     }
@@ -373,10 +339,7 @@ export default class DateSelector extends Component {
   }
 
   handleDateChanged() {
-    let { onFilterValueChange, selectedDate } = this.getProperties(
-      'onFilterValueChange',
-      'selectedDate'
-    );
+    let { onFilterValueChange, selectedDate } = this;
 
     if (!selectedDate) {
       return;
@@ -408,9 +371,9 @@ export default class DateSelector extends Component {
     super.init(...arguments);
 
     this.setProperties({
-      datePickerMonth: this.get('now').getMonth(),
-      datePickerYear: this.get('now').getYear(),
-      initialConsumerFilterKey: this.get('filterKey'),
+      datePickerMonth: this.now.getMonth(),
+      datePickerYear: this.now.getYear(),
+      initialConsumerFilterKey: this.filterKey,
     });
   }
 }

--- a/addon/components/polaris-resource-list/filter-control/filter-creator.js
+++ b/addon/components/polaris-resource-list/filter-control/filter-creator.js
@@ -65,19 +65,21 @@ export default class FilterCreator extends Component {
    */
   selectedFilterValue = null;
 
-  @(
-    and('selectedFilter', 'selectedFilterKey', 'selectedFilterValue').readOnly()
-  )
+  @(and(
+    'selectedFilter',
+    'selectedFilterKey',
+    'selectedFilterValue'
+  ).readOnly())
   canAddFilter;
 
   @(computed('resourceName.plural').readOnly())
   get selectLabel() {
-    return `Show all ${this.get('resourceName.plural')} where:`;
+    return `Show all ${this.resourceName.plural} where:`;
   }
 
   @(computed('filters.@each.{key,label}').readOnly())
   get filterOptions() {
-    return this.get('filters').map(({ key, label }) => ({
+    return this.filters.map(({ key, label }) => ({
       value: key,
       label,
     }));
@@ -85,13 +87,13 @@ export default class FilterCreator extends Component {
 
   handleButtonFocus(...args) {
     let event = args[0];
-    if (!this.get('node') && event) {
+    if (!this.node && event) {
       this.set('node', event.target);
     }
   }
 
   handleFilterKeyChange(filterKey) {
-    let filters = this.get('filters');
+    let { filters } = this;
 
     let foundFilter = filters.find((filter) => {
       let minKey = get(filter, 'minKey');
@@ -128,18 +130,15 @@ export default class FilterCreator extends Component {
   }
 
   handleAddFilter(popover) {
-    let { onAddFilter, selectedFilterKey } = this.getProperties(
-      'onAddFilter',
-      'selectedFilterKey'
-    );
+    let { onAddFilter, selectedFilterKey } = this;
 
-    if (!onAddFilter || !this.get('canAddFilter') || !selectedFilterKey) {
+    if (!onAddFilter || !this.canAddFilter || !selectedFilterKey) {
       return;
     }
 
     onAddFilter({
       key: selectedFilterKey,
-      value: this.get('selectedFilterValue') || '',
+      value: this.selectedFilterValue || '',
     });
     this.setProperties({
       selectedFilter: undefined,
@@ -148,7 +147,7 @@ export default class FilterCreator extends Component {
 
     popover.close();
 
-    let node = this.get('node');
+    let { node } = this;
     if (node != null) {
       node.focus();
     }

--- a/addon/components/polaris-resource-list/filter-control/filter-creator.js
+++ b/addon/components/polaris-resource-list/filter-control/filter-creator.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import { and } from '@ember/object/computed';
-import { get, computed } from '@ember/object';
+import { action, get, computed } from '@ember/object';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../../templates/components/polaris-resource-list/filter-control/filter-creator';
 
@@ -85,6 +85,7 @@ export default class FilterCreator extends Component {
     }));
   }
 
+  @action
   handleButtonFocus(...args) {
     let event = args[0];
     if (!this.node && event) {
@@ -92,6 +93,7 @@ export default class FilterCreator extends Component {
     }
   }
 
+  @action
   handleFilterKeyChange(filterKey) {
     let { filters } = this;
 
@@ -129,6 +131,7 @@ export default class FilterCreator extends Component {
     });
   }
 
+  @action
   handleAddFilter(popover) {
     let { onAddFilter, selectedFilterKey } = this;
 

--- a/addon/components/polaris-resource-list/filter-control/filter-creator.js
+++ b/addon/components/polaris-resource-list/filter-control/filter-creator.js
@@ -1,20 +1,19 @@
 import Component from '@ember/component';
-import { computed, get } from '@ember/object';
 import { and } from '@ember/object/computed';
+import { get, computed } from '@ember/object';
+import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../../templates/components/polaris-resource-list/filter-control/filter-creator';
 
-export default Component.extend({
-  tagName: '',
-
-  layout,
-
+@tagName('')
+@templateLayout(layout)
+export default class FilterCreator extends Component {
   /**
    * @property filters
    * @type {Object[]}
    * @default null
    * @public
    */
-  filters: null,
+  filters = null;
 
   /**
    * Object with `singular` and `plural` properties.
@@ -24,7 +23,7 @@ export default Component.extend({
    * @default null
    * @public
    */
-  resourceName: null,
+  resourceName = null;
 
   /**
    * @property disabled
@@ -32,7 +31,7 @@ export default Component.extend({
    * @default false
    * @public
    */
-  disabled: false,
+  disabled = false;
 
   /**
    * @property onAddFilter
@@ -40,7 +39,7 @@ export default Component.extend({
    * @default noop
    * @public
    */
-  onAddFilter() {},
+  onAddFilter() {}
 
   /**
    * @property selectedFilter
@@ -48,7 +47,7 @@ export default Component.extend({
    * @default null
    * @private
    */
-  selectedFilter: null,
+  selectedFilter = null;
 
   /**
    * @property selectedFilterKey
@@ -56,7 +55,7 @@ export default Component.extend({
    * @default null
    * @private
    */
-  selectedFilterKey: null,
+  selectedFilterKey = null;
 
   /**
    * @property selectedFilterValue
@@ -64,31 +63,32 @@ export default Component.extend({
    * @default null
    * @private
    */
-  selectedFilterValue: null,
+  selectedFilterValue = null;
 
-  canAddFilter: and(
-    'selectedFilter',
-    'selectedFilterKey',
-    'selectedFilterValue'
-  ).readOnly(),
+  @(
+    and('selectedFilter', 'selectedFilterKey', 'selectedFilterValue').readOnly()
+  )
+  canAddFilter;
 
-  selectLabel: computed('resourceName.plural', function() {
+  @(computed('resourceName.plural').readOnly())
+  get selectLabel() {
     return `Show all ${this.get('resourceName.plural')} where:`;
-  }).readOnly(),
+  }
 
-  filterOptions: computed('filters.@each.{key,label}', function() {
+  @(computed('filters.@each.{key,label}').readOnly())
+  get filterOptions() {
     return this.get('filters').map(({ key, label }) => ({
       value: key,
       label,
     }));
-  }).readOnly(),
+  }
 
   handleButtonFocus(...args) {
     let event = args[0];
     if (!this.get('node') && event) {
       this.set('node', event.target);
     }
-  },
+  }
 
   handleFilterKeyChange(filterKey) {
     let filters = this.get('filters');
@@ -125,7 +125,7 @@ export default Component.extend({
       selectedFilterKey: filterKey,
       selectedFilterValue: undefined,
     });
-  },
+  }
 
   handleAddFilter(popover) {
     let { onAddFilter, selectedFilterKey } = this.getProperties(
@@ -152,5 +152,5 @@ export default Component.extend({
     if (node != null) {
       node.focus();
     }
-  },
-});
+  }
+}

--- a/addon/components/polaris-resource-list/filter-control/filter-value-selector.js
+++ b/addon/components/polaris-resource-list/filter-control/filter-value-selector.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
-import { computed, get } from '@ember/object';
+import { get, computed } from '@ember/object';
+import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../../templates/components/polaris-resource-list/filter-control/filter-value-selector';
 
 export const FilterType = {
@@ -8,18 +9,16 @@ export const FilterType = {
   DateSelector: 'date_selector',
 };
 
-export default Component.extend({
-  tagName: '',
-
-  layout,
-
+@tagName('')
+@templateLayout(layout)
+export default class FilterValueSelector extends Component {
   /**
    * @property filter
    * @type {Object}
    * @default null
    * @public
    */
-  filter: null,
+  filter = null;
 
   /**
    * @property filterKey
@@ -27,7 +26,7 @@ export default Component.extend({
    * @default null
    * @public
    */
-  filterKey: null,
+  filterKey = null;
 
   /**
    * @property value
@@ -35,7 +34,7 @@ export default Component.extend({
    * @default null
    * @public
    */
-  value: null,
+  value = null;
 
   /**
    * @property onChange
@@ -43,7 +42,7 @@ export default Component.extend({
    * @default noop
    * @public
    */
-  onChange() {},
+  onChange() {}
 
   /**
    * @property onFilterKeyChange
@@ -51,11 +50,12 @@ export default Component.extend({
    * @default noop
    * @public
    */
-  onFilterKeyChange() {},
+  onFilterKeyChange() {}
 
-  FilterType,
+  FilterType = FilterType;
 
-  showOperatorOptions: computed('filter.{type,operatorText}', function() {
+  @(computed('filter.{type,operatorText}').readOnly())
+  get showOperatorOptions() {
     let filter = this.get('filter');
     let type = get(filter, 'type');
     let operatorText = get(filter, 'operatorText');
@@ -65,32 +65,30 @@ export default Component.extend({
       operatorText &&
       typeof operatorText !== 'string'
     );
-  }).readOnly(),
+  }
 
-  operatorOptionsMarkup: computed(
-    'filter.{label,operatorText}',
-    'filterKey',
-    function() {
-      let { filter, filterKey } = this.getProperties('filter', 'filterKey');
+  @(computed('filter.{label,operatorText}', 'filterKey').readOnly())
+  get operatorOptionsMarkup() {
+    let { filter, filterKey } = this.getProperties('filter', 'filterKey');
 
-      return {
-        componentName: 'polaris-select',
-        props: {
-          labelHidden: true,
-          dataTestSelect: 'operator',
-          label: get(filter, 'label'),
-          options: buildOperatorOptions(get(filter, 'operatorText')),
-          value: filterKey,
-          onChange: (...args) => this.handleOperatorOptionChange(...args),
-        },
-      };
-    }
-  ).readOnly(),
+    return {
+      componentName: 'polaris-select',
+      props: {
+        labelHidden: true,
+        dataTestSelect: 'operator',
+        label: get(filter, 'label'),
+        options: buildOperatorOptions(get(filter, 'operatorText')),
+        value: filterKey,
+        onChange: (...args) => this.handleOperatorOptionChange(...args),
+      },
+    };
+  }
 
-  selectedFilterLabel: computed('filter.operatorText', function() {
+  @(computed('filter.operatorText').readOnly())
+  get selectedFilterLabel() {
     let operatorText = this.get('filter.operatorText');
     return typeof operatorText === 'string' ? operatorText : '';
-  }).readOnly(),
+  }
 
   handleOperatorOptionChange(operatorKey) {
     let { value, onChange, onFilterKeyChange } = this.getProperties(
@@ -105,10 +103,10 @@ export default Component.extend({
     }
 
     onChange(value);
-  },
+  }
 
   didInsertElement() {
-    this._super(...arguments);
+    super.didInsertElement(...arguments);
 
     let filter = this.get('filter');
     let { operatorText, type } = filter;
@@ -123,8 +121,8 @@ export default Component.extend({
     }
 
     this.handleOperatorOptionChange(operatorText[0].key);
-  },
-});
+  }
+}
 
 function buildOperatorOptions(operatorText) {
   if (!operatorText || typeof operatorText === 'string') {

--- a/addon/components/polaris-resource-list/filter-control/filter-value-selector.js
+++ b/addon/components/polaris-resource-list/filter-control/filter-value-selector.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { get, computed } from '@ember/object';
+import { action, get, computed } from '@ember/object';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../../templates/components/polaris-resource-list/filter-control/filter-value-selector';
 
@@ -56,7 +56,7 @@ export default class FilterValueSelector extends Component {
 
   @(computed('filter.{type,operatorText}').readOnly())
   get showOperatorOptions() {
-    let filter = this.get('filter');
+    let { filter } = this;
     let type = get(filter, 'type');
     let operatorText = get(filter, 'operatorText');
 
@@ -69,7 +69,7 @@ export default class FilterValueSelector extends Component {
 
   @(computed('filter.{label,operatorText}', 'filterKey').readOnly())
   get operatorOptionsMarkup() {
-    let { filter, filterKey } = this.getProperties('filter', 'filterKey');
+    let { filter, filterKey } = this;
 
     return {
       componentName: 'polaris-select',
@@ -86,16 +86,13 @@ export default class FilterValueSelector extends Component {
 
   @(computed('filter.operatorText').readOnly())
   get selectedFilterLabel() {
-    let operatorText = this.get('filter.operatorText');
+    let operatorText = this.filter.operatorText;
     return typeof operatorText === 'string' ? operatorText : '';
   }
 
   handleOperatorOptionChange(operatorKey) {
-    let { value, onChange, onFilterKeyChange } = this.getProperties(
-      'value',
-      'onChange',
-      'onFilterKeyChange'
-    );
+    let { value, onChange, onFilterKeyChange } = this;
+
     onFilterKeyChange(operatorKey);
 
     if (!value) {
@@ -105,10 +102,9 @@ export default class FilterValueSelector extends Component {
     onChange(value);
   }
 
-  didInsertElement() {
-    super.didInsertElement(...arguments);
-
-    let filter = this.get('filter');
+  @action
+  insertFilterValueSelector() {
+    let { filter } = this;
     let { operatorText, type } = filter;
 
     if (

--- a/addon/components/polaris-resource-list/filter-control/filter-value-selector.js
+++ b/addon/components/polaris-resource-list/filter-control/filter-value-selector.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
-import { action, get, computed } from '@ember/object';
+import { get, computed } from '@ember/object';
+import { scheduleOnce } from '@ember/runloop';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../../templates/components/polaris-resource-list/filter-control/filter-value-selector';
 
@@ -102,10 +103,10 @@ export default class FilterValueSelector extends Component {
     onChange(value);
   }
 
-  @action
   insertFilterValueSelector() {
-    let { filter } = this;
-    let { operatorText, type } = filter;
+    let {
+      filter: { type, operatorText },
+    } = this;
 
     if (
       type === FilterType.DateSelector ||
@@ -117,6 +118,15 @@ export default class FilterValueSelector extends Component {
     }
 
     this.handleOperatorOptionChange(operatorText[0].key);
+  }
+
+  init() {
+    super.init(...arguments);
+
+    // Using `afterRender` here instead of `didInsertElement` hook.
+    // This component is tagless and has no container div so we can't
+    // use `{{did-insert}}` modifiers in the template.
+    scheduleOnce('afterRender', this, this.insertFilterValueSelector);
   }
 }
 

--- a/addon/components/polaris-resource-list/filter-control/filter-value-selector.js
+++ b/addon/components/polaris-resource-list/filter-control/filter-value-selector.js
@@ -1,6 +1,5 @@
 import Component from '@ember/component';
-import { get, computed } from '@ember/object';
-import { scheduleOnce } from '@ember/runloop';
+import { action, get, computed } from '@ember/object';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../../templates/components/polaris-resource-list/filter-control/filter-value-selector';
 
@@ -103,6 +102,7 @@ export default class FilterValueSelector extends Component {
     onChange(value);
   }
 
+  @action
   insertFilterValueSelector() {
     let {
       filter: { type, operatorText },
@@ -118,15 +118,6 @@ export default class FilterValueSelector extends Component {
     }
 
     this.handleOperatorOptionChange(operatorText[0].key);
-  }
-
-  init() {
-    super.init(...arguments);
-
-    // Using `afterRender` here instead of `didInsertElement` hook.
-    // This component is tagless and has no container div so we can't
-    // use `{{did-insert}}` modifiers in the template.
-    scheduleOnce('afterRender', this, this.insertFilterValueSelector);
   }
 }
 

--- a/addon/components/polaris-resource-list/item.js
+++ b/addon/components/polaris-resource-list/item.js
@@ -1,25 +1,24 @@
 import Component from '@ember/component';
-import { computed, get } from '@ember/object';
 import { readOnly } from '@ember/object/computed';
+import { get, computed } from '@ember/object';
+import { classNames, attributeBindings, classNameBindings, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../templates/components/polaris-resource-list/item';
 import { context } from '@smile-io/ember-polaris/components/polaris-resource-list';
 import { computedIdVariation } from '@smile-io/ember-polaris/utils/id';
 import { SELECT_ALL_ITEMS } from '../polaris-resource-list';
 
-export default Component.extend(context.ConsumerMixin, {
-  attributeBindings: ['url:data-href'],
-  classNames: ['Polaris-ResourceList-Item'],
-  classNameBindings: [
-    'focused:Polaris-ResourceList-Item--focused',
-    'selectable:Polaris-ResourceList-Item--selectable',
-    'selected:Polaris-ResourceList-Item--selected',
-    'selectMode:Polaris-ResourceList-Item--selectMode',
-    'persistActions:Polaris-ResourceList-Item--persistActions',
-    'focusedInner:Polaris-ResourceList-Item--focusedInner',
-  ],
-
-  layout,
-
+@attributeBindings('url:data-href')
+@classNames('Polaris-ResourceList-Item')
+@classNameBindings(
+  'focused:Polaris-ResourceList-Item--focused',
+  'selectable:Polaris-ResourceList-Item--selectable',
+  'selected:Polaris-ResourceList-Item--selected',
+  'selectMode:Polaris-ResourceList-Item--selectMode',
+  'persistActions:Polaris-ResourceList-Item--persistActions',
+  'focusedInner:Polaris-ResourceList-Item--focusedInner'
+)
+@templateLayout(layout)
+export default class Item extends Component.extend(context.ConsumerMixin) {
   /**
    * Unique identifier for the item
    *
@@ -28,7 +27,7 @@ export default Component.extend(context.ConsumerMixin, {
    * @default null
    * @public
    */
-  itemId: null,
+  itemId = null;
 
   /**
    * Visually hidden text for screen readers
@@ -38,7 +37,7 @@ export default Component.extend(context.ConsumerMixin, {
    * @default null
    * @public
    */
-  accessibilityLabel: null,
+  accessibilityLabel = null;
 
   /**
    * Id of the element the item onClick controls
@@ -48,7 +47,7 @@ export default Component.extend(context.ConsumerMixin, {
    * @default null
    * @public
    */
-  ariaControls: null,
+  ariaControls = null;
 
   /**
    * Tells screen reader the controlled element is expanded
@@ -58,7 +57,7 @@ export default Component.extend(context.ConsumerMixin, {
    * @default false
    * @public
    */
-  ariaExpanded: false,
+  ariaExpanded = false;
 
   /**
    * @property media
@@ -66,7 +65,7 @@ export default Component.extend(context.ConsumerMixin, {
    * @default null
    * @public
    */
-  media: null,
+  media = null;
 
   /**
    * @property persistActions
@@ -74,7 +73,7 @@ export default Component.extend(context.ConsumerMixin, {
    * @default false
    * @public
    */
-  persistActions: false,
+  persistActions = false;
 
   /**
    * @property shortcutActions
@@ -82,7 +81,7 @@ export default Component.extend(context.ConsumerMixin, {
    * @default null
    * @public
    */
-  shortcutActions: null,
+  shortcutActions = null;
 
   /**
    * @property children
@@ -90,7 +89,7 @@ export default Component.extend(context.ConsumerMixin, {
    * @default null
    * @public
    */
-  children: null,
+  children = null;
 
   /**
    * @property url
@@ -98,7 +97,7 @@ export default Component.extend(context.ConsumerMixin, {
    * @default null
    * @public
    */
-  url: null,
+  url = null;
 
   /**
    * @property onClick
@@ -106,7 +105,7 @@ export default Component.extend(context.ConsumerMixin, {
    * @default null
    * @public
    */
-  onClick: null,
+  onClick = null;
 
   /**
    * @property focused
@@ -114,7 +113,7 @@ export default Component.extend(context.ConsumerMixin, {
    * @default false
    * @private
    */
-  focused: false,
+  focused = false;
 
   /**
    * @property focusedInner
@@ -122,22 +121,25 @@ export default Component.extend(context.ConsumerMixin, {
    * @default false
    * @private
    */
-  focusedInner: false,
+  focusedInner = false;
 
-  'data-test-id': 'item-wrapper',
+  'data-test-id' = 'item-wrapper';
+  stopPropagation = stopPropagation;
 
-  stopPropagation,
+  @readOnly('context.selectable')
+  selectable;
 
-  selectable: readOnly('context.selectable'),
-  selectMode: readOnly('context.selectMode'),
-  loading: readOnly('context.loading'),
+  @readOnly('context.selectMode')
+  selectMode;
 
-  checkboxId: computedIdVariation(
-    'itemId',
-    'ResourceListItemCheckbox'
-  ).readOnly(),
+  @readOnly('context.loading')
+  loading;
 
-  isSelected: computed('itemId', 'context.selectedItems', function() {
+  @(computedIdVariation('itemId', 'ResourceListItemCheckbox').readOnly())
+  checkboxId;
+
+  @(computed('itemId', 'context.selectedItems').readOnly())
+  get isSelected() {
     let { itemId, context } = this.getProperties('itemId', 'context');
     let selectedItems = get(context, 'selectedItems');
     return (
@@ -145,41 +147,45 @@ export default Component.extend(context.ConsumerMixin, {
       ((Array.isArray(selectedItems) && selectedItems.includes(itemId)) ||
         selectedItems === SELECT_ALL_ITEMS)
     );
-  }).readOnly(),
+  }
 
   click() {
     this.handleClick(...arguments);
-  },
+  }
+
   focusIn() {
     this.handleFocus(...arguments);
-  },
+  }
+
   focusOut() {
     this.handleBlur(...arguments);
-  },
+  }
+
   mouseDown() {
     this.handleMouseDown(...arguments);
-  },
+  }
+
   keyUp() {
     this.handleKeypress(...arguments);
-  },
+  }
 
   handleAnchorFocus() {
     this.setProperties({
       focused: true,
       focusedInner: false,
     });
-  },
+  }
 
   handleFocusedBlur() {
     this.setProperties({
       focused: true,
       focusedInner: true,
     });
-  },
+  }
 
   handleFocus() {
     this.set('focused', true);
-  },
+  }
 
   handleBlur(event) {
     let isInside = this.compareEventNode(event);
@@ -190,16 +196,16 @@ export default Component.extend(context.ConsumerMixin, {
     } else if (isInside) {
       this.set('focusedInner', true);
     }
-  },
+  }
 
   handleMouseDown() {
     this.set('focusedInner', true);
-  },
+  }
 
   handleLargerSelectionArea(event) {
     stopPropagation(event);
     this.handleSelection(!this.get('isSelected'));
-  },
+  }
 
   handleSelection(value) {
     let { itemId, context } = this.getProperties('itemId', 'context');
@@ -212,7 +218,7 @@ export default Component.extend(context.ConsumerMixin, {
       focusedInner: true,
     });
     onSelectionChange(value, itemId);
-  },
+  }
 
   handleClick(event) {
     let { itemId, onClick, url, selectMode, element } = this.getProperties(
@@ -246,7 +252,7 @@ export default Component.extend(context.ConsumerMixin, {
     if (url && anchor) {
       anchor.click();
     }
-  },
+  }
 
   handleKeypress(event) {
     let { onClick, selectMode } = this.getProperties('onClick', 'selectMode');
@@ -255,14 +261,14 @@ export default Component.extend(context.ConsumerMixin, {
     if (onClick && key === 'Enter' && !selectMode) {
       onClick();
     }
-  },
+  }
 
   compareEventNode(event) {
     return this.get('onClick')
       ? event.target === this.element
       : event.target.tagName.toLowerCase() === 'a';
-  },
-});
+  }
+}
 
 function stopPropagation(event) {
   event.stopPropagation();

--- a/addon/components/polaris-resource-list/item.js
+++ b/addon/components/polaris-resource-list/item.js
@@ -1,22 +1,13 @@
 import Component from '@ember/component';
 import { readOnly } from '@ember/object/computed';
-import { get, computed } from '@ember/object';
-import { classNames, attributeBindings, classNameBindings, layout as templateLayout } from '@ember-decorators/component';
+import { action, get, computed } from '@ember/object';
+import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../templates/components/polaris-resource-list/item';
 import { context } from '@smile-io/ember-polaris/components/polaris-resource-list';
 import { computedIdVariation } from '@smile-io/ember-polaris/utils/id';
 import { SELECT_ALL_ITEMS } from '../polaris-resource-list';
 
-@attributeBindings('url:data-href')
-@classNames('Polaris-ResourceList-Item')
-@classNameBindings(
-  'focused:Polaris-ResourceList-Item--focused',
-  'selectable:Polaris-ResourceList-Item--selectable',
-  'selected:Polaris-ResourceList-Item--selected',
-  'selectMode:Polaris-ResourceList-Item--selectMode',
-  'persistActions:Polaris-ResourceList-Item--persistActions',
-  'focusedInner:Polaris-ResourceList-Item--focusedInner'
-)
+@tagName('')
 @templateLayout(layout)
 export default class Item extends Component.extend(context.ConsumerMixin) {
   /**
@@ -123,7 +114,6 @@ export default class Item extends Component.extend(context.ConsumerMixin) {
    */
   focusedInner = false;
 
-  'data-test-id' = 'item-wrapper';
   stopPropagation = stopPropagation;
 
   @readOnly('context.selectable')
@@ -140,33 +130,13 @@ export default class Item extends Component.extend(context.ConsumerMixin) {
 
   @(computed('itemId', 'context.selectedItems').readOnly())
   get isSelected() {
-    let { itemId, context } = this.getProperties('itemId', 'context');
+    let { itemId, context } = this;
     let selectedItems = get(context, 'selectedItems');
     return (
       selectedItems &&
       ((Array.isArray(selectedItems) && selectedItems.includes(itemId)) ||
         selectedItems === SELECT_ALL_ITEMS)
     );
-  }
-
-  click() {
-    this.handleClick(...arguments);
-  }
-
-  focusIn() {
-    this.handleFocus(...arguments);
-  }
-
-  focusOut() {
-    this.handleBlur(...arguments);
-  }
-
-  mouseDown() {
-    this.handleMouseDown(...arguments);
-  }
-
-  keyUp() {
-    this.handleKeypress(...arguments);
   }
 
   handleAnchorFocus() {
@@ -191,7 +161,10 @@ export default class Item extends Component.extend(context.ConsumerMixin) {
     let isInside = this.compareEventNode(event);
     // TODO: check this works because React implementation
     // casts event.relatedTarget as HTMLElement.
-    if (this.element == null || !this.element.contains(event.relatedTarget)) {
+    if (
+      this.resourceListElement == null ||
+      !this.resourceListElement.contains(event.relatedTarget)
+    ) {
       this.set('focused', false);
     } else if (isInside) {
       this.set('focusedInner', true);
@@ -204,11 +177,11 @@ export default class Item extends Component.extend(context.ConsumerMixin) {
 
   handleLargerSelectionArea(event) {
     stopPropagation(event);
-    this.handleSelection(!this.get('isSelected'));
+    this.handleSelection(!this.isSelected);
   }
 
   handleSelection(value) {
-    let { itemId, context } = this.getProperties('itemId', 'context');
+    let { itemId, context } = this;
     let onSelectionChange = get(context, 'onSelectionChange');
     if (itemId == null || onSelectionChange == null) {
       return;
@@ -221,13 +194,7 @@ export default class Item extends Component.extend(context.ConsumerMixin) {
   }
 
   handleClick(event) {
-    let { itemId, onClick, url, selectMode, element } = this.getProperties(
-      'itemId',
-      'onClick',
-      'url',
-      'selectMode',
-      'element'
-    );
+    let { itemId, onClick, url, selectMode, element } = this;
     let { ctrlKey, metaKey } = event;
     let anchor = element && element.querySelector('a');
 
@@ -255,7 +222,7 @@ export default class Item extends Component.extend(context.ConsumerMixin) {
   }
 
   handleKeypress(event) {
-    let { onClick, selectMode } = this.getProperties('onClick', 'selectMode');
+    let { onClick, selectMode } = this;
     let { key } = event;
 
     if (onClick && key === 'Enter' && !selectMode) {
@@ -264,9 +231,14 @@ export default class Item extends Component.extend(context.ConsumerMixin) {
   }
 
   compareEventNode(event) {
-    return this.get('onClick')
-      ? event.target === this.element
+    return this.onClick
+      ? event.target === this.resourceListElement
       : event.target.tagName.toLowerCase() === 'a';
+  }
+
+  @action
+  insertResourceListItem(element) {
+    this.set('resourceListElement', element);
   }
 }
 

--- a/addon/components/polaris-resource-list/item.js
+++ b/addon/components/polaris-resource-list/item.js
@@ -139,6 +139,7 @@ export default class Item extends Component.extend(context.ConsumerMixin) {
     );
   }
 
+  @action
   handleAnchorFocus() {
     this.setProperties({
       focused: true,
@@ -146,6 +147,7 @@ export default class Item extends Component.extend(context.ConsumerMixin) {
     });
   }
 
+  @action
   handleFocusedBlur() {
     this.setProperties({
       focused: true,
@@ -153,10 +155,12 @@ export default class Item extends Component.extend(context.ConsumerMixin) {
     });
   }
 
+  @action
   handleFocus() {
     this.set('focused', true);
   }
 
+  @action
   handleBlur(event) {
     let isInside = this.compareEventNode(event);
     // TODO: check this works because React implementation
@@ -171,15 +175,18 @@ export default class Item extends Component.extend(context.ConsumerMixin) {
     }
   }
 
+  @action
   handleMouseDown() {
     this.set('focusedInner', true);
   }
 
+  @action
   handleLargerSelectionArea(event) {
     stopPropagation(event);
     this.handleSelection(!this.isSelected);
   }
 
+  @action
   handleSelection(value) {
     let { itemId, context } = this;
     let onSelectionChange = get(context, 'onSelectionChange');
@@ -193,6 +200,7 @@ export default class Item extends Component.extend(context.ConsumerMixin) {
     onSelectionChange(value, itemId);
   }
 
+  @action
   handleClick(event) {
     let { itemId, onClick, url, selectMode, element } = this;
     let { ctrlKey, metaKey } = event;

--- a/addon/components/polaris-resource-list/loading-overlay.js
+++ b/addon/components/polaris-resource-list/loading-overlay.js
@@ -1,15 +1,14 @@
 import Component from '@ember/component';
+import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../templates/components/polaris-resource-list/loading-overlay';
 
 /**
  * Internal component used to DRY up rendering resource list loading state.
  */
-export default Component.extend({
-  tagName: '',
-
-  layout,
-
-  loading: false,
-  spinnerStyle: null,
-  spinnerSize: null,
-});
+@tagName('')
+@templateLayout(layout)
+export default class LoadingOverlay extends Component {
+ loading = false;
+ spinnerStyle = null;
+ spinnerSize = null;
+}

--- a/addon/components/polaris-resource-list/loading-overlay.js
+++ b/addon/components/polaris-resource-list/loading-overlay.js
@@ -8,7 +8,7 @@ import layout from '../../templates/components/polaris-resource-list/loading-ove
 @tagName('')
 @templateLayout(layout)
 export default class LoadingOverlay extends Component {
- loading = false;
- spinnerStyle = null;
- spinnerSize = null;
+  loading = false;
+  spinnerStyle = null;
+  spinnerSize = null;
 }

--- a/addon/templates/components/polaris-resource-list.hbs
+++ b/addon/templates/components/polaris-resource-list.hbs
@@ -1,44 +1,44 @@
-{{#polaris-resource-list/provider value=context}}
+{{#polaris-resource-list/provider value=this.context}}
   {{#with
     (component "polaris-resource-list/loading-overlay"
-      loading=loading
-      spinnerStyle=spinnerStyle
-      spinnerSize=spinnerSize
+      loading=@loading
+      spinnerStyle=this.spinnerStyle
+      spinnerSize=this.spinnerSize
     )
     as |loadingOverlay|
   }}
     <div
       class="Polaris-ResourceList__ResourceListWrapper"
-      id={{wrapperId}}
+      id={{this.wrapperId}}
       {{did-insert this.insertResourceList}}
       {{did-update this.updateResourceList}}
     >
-      {{#if filterControl}}
+      {{#if @filterControl}}
         <div class="Polaris-ResourceList__FiltersWrapper">
-          {{render-content filterControl}}
+          {{render-content @filterControl}}
         </div>
       {{/if}}
 
       {{#if (and
-        (or showHeader needsHeader)
-        listNode
-        itemsExist
+        (or @showHeader this.needsHeader)
+        this.listNode
+        this.itemsExist
       )}}
         <div class="Polaris-ResourceList__HeaderOuterWrapper">
-          <PolarisSticky @boundingElement={{listNode}} as |sticky|>
+          <PolarisSticky @boundingElement={{this.listNode}} as |sticky|>
             <div
               data-test-id="resource-list-header"
               class="
                 Polaris-ResourceList__HeaderWrapper
-                {{if (and sortOptions.length (not alternateTool)) "Polaris-ResourceList__HeaderWrapper--hasSort"}}
-                {{if selectable "Polaris-ResourceList__HeaderWrapper--hasSelect"}}
-                {{if alternateTool "Polaris-ResourceList__HeaderWrapper--hasAlternateTool"}}
-                {{if loading "Polaris-ResourceList__HeaderWrapper--disabled"}}
-                {{if (and selectable selectMode) "Polaris-ResourceList__HeaderWrapper--inSelectMode"}}
+                {{if (and @sortOptions.length (not @alternateTool)) "Polaris-ResourceList__HeaderWrapper--hasSort"}}
+                {{if this.selectable "Polaris-ResourceList__HeaderWrapper--hasSelect"}}
+                {{if @alternateTool "Polaris-ResourceList__HeaderWrapper--hasAlternateTool"}}
+                {{if @loading "Polaris-ResourceList__HeaderWrapper--disabled"}}
+                {{if (and this.selectable this.selectMode) "Polaris-ResourceList__HeaderWrapper--inSelectMode"}}
                 {{if sticky.isSticky "Polaris-ResourceList__HeaderWrapper--isSticky"}}
               "
             >
-              {{#if loading}}
+              {{#if @loading}}
                 <div class="Polaris-ResourceList__HeaderWrapper--overlay"></div>
               {{/if}}
 
@@ -47,40 +47,70 @@
                   class="Polaris-ResourceList__HeaderTitleWrapper"
                   data-test-id="header-title-wrapper"
                 >
-                  {{headerTitle}}
+                  {{this.headerTitle}}
                 </div>
 
-                {{#if selectable}}
+                {{#if this.selectable}}
                   <div class="Polaris-ResourceList__CheckableButtonWrapper">
-                    <PolarisResourceList::CheckableButton @plain={{true}} @disabled={{loading}} @accessibilityLabel={{bulkActionsAccessibilityLabel}} @label={{headerTitle}} @onToggleAll={{action handleToggleAll}} />
+                    <PolarisResourceList::CheckableButton
+                      @plain={{true}}
+                      @disabled={{@loading}}
+                      @accessibilityLabel={{this.bulkActionsAccessibilityLabel}}
+                      @label={{this.headerTitle}}
+                      @onToggleAll={{fn this.handleToggleAll}}
+                    />
                   </div>
                 {{/if}}
 
-                {{#if (and sortOptions (not alternateTool))}}
+                {{#if (and @sortOptions (not @alternateTool))}}
                   <div class="Polaris-ResourceList__SortWrapper">
-                    <label class="Polaris-ResourceList__SortLabel" htmlFor={{selectId}}>
+                    <label class="Polaris-ResourceList__SortLabel" htmlFor={{this.selectId}}>
                       Sort by
                     </label>
 
-                    <PolarisSelect @label="Sort by" @labelHidden={{true}} @options={{sortOptions}} @value={{or sortValue ""}} @disabled={{selectMode}} @onChange={{action onSortChange}} />
+                    <PolarisSelect
+                      @label="Sort by"
+                      @labelHidden={{true}}
+                      @options={{@sortOptions}}
+                      @value={{or @sortValue ""}}
+                      @disabled={{this.selectMode}}
+                      @onChange={{fn (or @onSortChange this.onSortChange)}}
+                    />
                   </div>
-                {{else if alternateTool}}
+                {{else if @alternateTool}}
                   <div class="Polaris-ResourceList__AlternateToolWrapper">
-                    {{render-content alternateTool}}
+                    {{render-content @alternateTool}}
                   </div>
                 {{/if}}
 
-                {{#if selectable}}
+                {{#if this.selectable}}
                   <div class="Polaris-ResourceList__SelectButtonWrapper">
                     {{!-- TODO: include enable-selection icon --}}
-                    <PolarisButton @text="Select" @disabled={{selectMode}} @icon="enable-selection" @onClick={{action handleSelectMode true}} />
+                    <PolarisButton
+                      @text="Select"
+                      @disabled={{this.selectMode}}
+                      @icon="enable-selection"
+                      @onClick={{fn this.handleSelectMode true}}
+                    />
                   </div>
                 {{/if}}
               </div>
 
-              {{#if selectable}}
+              {{#if this.selectable}}
                 <div class="Polaris-ResourceList__BulkActionsWrapper">
-                  <PolarisResourceList::BulkActions @label={{bulkActionsLabel}} @accessibilityLabel={{bulkActionsAccessibilityLabel}} @selected={{bulkSelectState}} @onToggleAll={{action handleToggleAll}} @selectMode={{selectMode}} @onSelectModeToggle={{action handleSelectMode}} @promotedActions={{promotedBulkActions}} @paginatedSelectAllAction={{paginatedSelectAllAction}} @paginatedSelectAllText={{paginatedSelectAllText}} @actionsCollection={{bulkActions}} @disabled={{loading}} />
+                  <PolarisResourceList::BulkActions
+                    @label={{this.bulkActionsLabel}}
+                    @accessibilityLabel={{this.bulkActionsAccessibilityLabel}}
+                    @selected={{this.bulkSelectState}}
+                    @onToggleAll={{fn this.handleToggleAll}}
+                    @selectMode={{this.selectMode}}
+                    @onSelectModeToggle={{fn this.handleSelectMode}}
+                    @promotedActions={{@promotedBulkActions}}
+                    @paginatedSelectAllAction={{this.paginatedSelectAllAction}}
+                    @paginatedSelectAllText={{this.paginatedSelectAllText}}
+                    @actionsCollection={{@bulkActions}}
+                    @disabled={{@loading}}
+                  />
                 </div>
               {{/if}}
             </div>
@@ -88,7 +118,7 @@
         </div>
       {{/if}}
 
-      {{#if itemsExist}}
+      {{#if this.itemsExist}}
         {{!--
           NOTE: Polaris-ResourceList--disabledPointerEvents doesn't exist at this point,
           but Polaris-ResourceList__DisabledPointerEvents does. The former is probably
@@ -96,32 +126,36 @@
           doesn't seem to be necessary for the list's `loading` behaviour to work.
         --}}
         <ul
-          class="Polaris-ResourceList {{if loading "Polaris-ResourceList--disabledPointerEvents"}}"
+          class="Polaris-ResourceList {{if @loading "Polaris-ResourceList--disabledPointerEvents"}}"
           aria-live="polite"
-          aria-busy={{loading}}
+          aria-busy={{@loading}}
         >
           {{component loadingOverlay}}
 
-          {{#each itemsWithId as |itemWithId|}}
+          {{#each this.itemsWithId as |itemWithId|}}
             <li
               class="Polaris-ResourceList__ItemWrapper"
               data-test-item-id={{itemWithId.id}}
             >
-              {{component itemComponent item=itemWithId.item itemId=itemWithId.id}}
+              {{component @itemComponent item=itemWithId.item itemId=itemWithId.id}}
             </li>
           {{/each}}
         </ul>
-      {{else if showEmptyState}}
+      {{else if this.showEmptyState}}
         <div class="Polaris-ResourceList__EmptySearchResultWrapper">
-          <PolarisEmptySearchResult @withIllustration={{true}} @description="Try changing the filters or search term" @title={{emptySearchResultTitle}} />
+          <PolarisEmptySearchResult
+            @withIllustration={{true}}
+            @description="Try changing the filters or search term"
+            @title={{this.emptySearchResultTitle}}
+          />
         </div>
       {{/if}}
 
-      {{#if (and loading (not itemsExist))}}
+      {{#if (and @loading (not this.itemsExist))}}
         <div
           class="
             Polaris-ResourceList__ItemWrapper
-            {{if loading "Polaris-ResourceList__ItemWrapper--isLoading"}}
+            {{if @loading "Polaris-ResourceList__ItemWrapper--isLoading"}}
           "
           tabIndex="-1"
         >

--- a/addon/templates/components/polaris-resource-list.hbs
+++ b/addon/templates/components/polaris-resource-list.hbs
@@ -7,7 +7,12 @@
     )
     as |loadingOverlay|
   }}
-    <div class="Polaris-ResourceList__ResourceListWrapper" id={{wrapperId}}>
+    <div
+      class="Polaris-ResourceList__ResourceListWrapper"
+      id={{wrapperId}}
+      {{did-insert this.insertResourceList}}
+      {{did-update this.updateResourceList}}
+    >
       {{#if filterControl}}
         <div class="Polaris-ResourceList__FiltersWrapper">
           {{render-content filterControl}}

--- a/addon/templates/components/polaris-resource-list.hbs
+++ b/addon/templates/components/polaris-resource-list.hbs
@@ -20,7 +20,7 @@
         itemsExist
       )}}
         <div class="Polaris-ResourceList__HeaderOuterWrapper">
-          {{#polaris-sticky boundingElement=listNode as |sticky|}}
+          <PolarisSticky @boundingElement={{listNode}} as |sticky|>
             <div
               data-test-id="resource-list-header"
               class="
@@ -47,13 +47,7 @@
 
                 {{#if selectable}}
                   <div class="Polaris-ResourceList__CheckableButtonWrapper">
-                    {{polaris-resource-list/checkable-button
-                      plain=true
-                      disabled=loading
-                      accessibilityLabel=bulkActionsAccessibilityLabel
-                      label=headerTitle
-                      onToggleAll=(action handleToggleAll)
-                    }}
+                    <PolarisResourceList::CheckableButton @plain={{true}} @disabled={{loading}} @accessibilityLabel={{bulkActionsAccessibilityLabel}} @label={{headerTitle}} @onToggleAll={{action handleToggleAll}} />
                   </div>
                 {{/if}}
 
@@ -63,14 +57,7 @@
                       Sort by
                     </label>
 
-                    {{polaris-select
-                      label="Sort by"
-                      labelHidden=true
-                      options=sortOptions
-                      value=(or sortValue "")
-                      disabled=selectMode
-                      onChange=(action onSortChange)
-                    }}
+                    <PolarisSelect @label="Sort by" @labelHidden={{true}} @options={{sortOptions}} @value={{or sortValue ""}} @disabled={{selectMode}} @onChange={{action onSortChange}} />
                   </div>
                 {{else if alternateTool}}
                   <div class="Polaris-ResourceList__AlternateToolWrapper">
@@ -81,35 +68,18 @@
                 {{#if selectable}}
                   <div class="Polaris-ResourceList__SelectButtonWrapper">
                     {{!-- TODO: include enable-selection icon --}}
-                    {{polaris-button
-                      text="Select"
-                      disabled=selectMode
-                      icon="enable-selection"
-                      onClick=(action handleSelectMode true)
-                    }}
+                    <PolarisButton @text="Select" @disabled={{selectMode}} @icon="enable-selection" @onClick={{action handleSelectMode true}} />
                   </div>
                 {{/if}}
               </div>
 
               {{#if selectable}}
                 <div class="Polaris-ResourceList__BulkActionsWrapper">
-                  {{polaris-resource-list/bulk-actions
-                    label=bulkActionsLabel
-                    accessibilityLabel=bulkActionsAccessibilityLabel
-                    selected=bulkSelectState
-                    onToggleAll=(action handleToggleAll)
-                    selectMode=selectMode
-                    onSelectModeToggle=(action handleSelectMode)
-                    promotedActions=promotedBulkActions
-                    paginatedSelectAllAction=paginatedSelectAllAction
-                    paginatedSelectAllText=paginatedSelectAllText
-                    actionsCollection=bulkActions
-                    disabled=loading
-                  }}
+                  <PolarisResourceList::BulkActions @label={{bulkActionsLabel}} @accessibilityLabel={{bulkActionsAccessibilityLabel}} @selected={{bulkSelectState}} @onToggleAll={{action handleToggleAll}} @selectMode={{selectMode}} @onSelectModeToggle={{action handleSelectMode}} @promotedActions={{promotedBulkActions}} @paginatedSelectAllAction={{paginatedSelectAllAction}} @paginatedSelectAllText={{paginatedSelectAllText}} @actionsCollection={{bulkActions}} @disabled={{loading}} />
                 </div>
               {{/if}}
             </div>
-          {{/polaris-sticky}}
+          </PolarisSticky>
         </div>
       {{/if}}
 
@@ -138,11 +108,7 @@
         </ul>
       {{else if showEmptyState}}
         <div class="Polaris-ResourceList__EmptySearchResultWrapper">
-          {{polaris-empty-search-result
-            withIllustration=true
-            description="Try changing the filters or search term"
-            title=emptySearchResultTitle
-          }}
+          <PolarisEmptySearchResult @withIllustration={{true}} @description="Try changing the filters or search term" @title={{emptySearchResultTitle}} />
         </div>
       {{/if}}
 

--- a/addon/templates/components/polaris-resource-list.hbs
+++ b/addon/templates/components/polaris-resource-list.hbs
@@ -11,6 +11,7 @@
       class="Polaris-ResourceList__ResourceListWrapper"
       {{did-insert this.insertResourceList}}
       {{did-update this.updateResourceList}}
+      ...attributes
     >
       {{#if @filterControl}}
         <div class="Polaris-ResourceList__FiltersWrapper">

--- a/addon/templates/components/polaris-resource-list.hbs
+++ b/addon/templates/components/polaris-resource-list.hbs
@@ -9,7 +9,6 @@
   }}
     <div
       class="Polaris-ResourceList__ResourceListWrapper"
-      id={{this.wrapperId}}
       {{did-insert this.insertResourceList}}
       {{did-update this.updateResourceList}}
     >
@@ -129,6 +128,7 @@
           class="Polaris-ResourceList {{if @loading "Polaris-ResourceList--disabledPointerEvents"}}"
           aria-live="polite"
           aria-busy={{@loading}}
+          {{did-insert this.insertListNode}}
         >
           {{component loadingOverlay}}
 

--- a/addon/templates/components/polaris-resource-list/bulk-actions.hbs
+++ b/addon/templates/components/polaris-resource-list/bulk-actions.hbs
@@ -8,33 +8,19 @@
   "
 >
   <div class="Polaris-ResourceList-BulkActions__ButtonGroup">
-    {{polaris-resource-list/checkable-button
-      accessibilityLabel=accessibilityLabel
-      label=label
-      selected=selected
-      selectMode=selectMode
-      measuring=measuring
-      disabled=disabled
-      onToggleAll=(action onToggleAll)
-    }}
+    <PolarisResourceList::CheckableButton @accessibilityLabel={{accessibilityLabel}} @label={{label}} @selected={{selected}} @selectMode={{selectMode}} @measuring={{measuring}} @disabled={{disabled}} @onToggleAll={{action onToggleAll}} />
 
     {{#if hasActions}}
       <div class="Polaris-ResourceList-BulkActions__Popover">
-        {{#polaris-popover as |popover|}}
-          {{#popover.activator}}
-            {{polaris-resource-list/bulk-actions/bulk-action-button
-              content="Actions"
-            }}
-          {{/popover.activator}}
+        <PolarisPopover as |popover|>
+          <popover.activator>
+            <PolarisResourceList::BulkActions::BulkActionButton @content="Actions" />
+          </popover.activator>
 
-          {{#popover.content}}
-            {{polaris-action-list
-              items=promotedActions
-              sections=actionSections
-              onActionAnyItem=(action popover.close)
-            }}
-          {{/popover.content}}
-        {{/polaris-popover}}
+          <popover.content>
+            <PolarisActionList @items={{promotedActions}} @sections={{actionSections}} @onActionAnyItem={{action popover.close}} />
+          </popover.content>
+        </PolarisPopover>
       </div>
     {{/if}}
 
@@ -55,12 +41,7 @@
       {{/if}}
 
       {{#if paginatedSelectAllAction}}
-        {{polaris-button
-          plain=true
-          disabled=disabled
-          text=paginatedSelectAllAction.content
-          onClick=(action paginatedSelectAllAction.onAction)
-        }}
+        <PolarisButton @plain={{true}} @disabled={{disabled}} @text={{paginatedSelectAllAction.content}} @onClick={{action paginatedSelectAllAction.onAction}} />
       {{/if}}
     </div>
   {{/if}}
@@ -77,44 +58,26 @@
   "
 >
   <div class="Polaris-ResourceList-BulkActions__ButtonGroup">
-    {{polaris-resource-list/checkable-button
-      accessibilityLabel=accessibilityLabel
-      label=label
-      selected=selected
-      selectMode=selectMode
-      measuring=measuring
-      disabled=disabled
-      onToggleAll=(action onToggleAll)
-    }}
+    <PolarisResourceList::CheckableButton @accessibilityLabel={{accessibilityLabel}} @label={{label}} @selected={{selected}} @selectMode={{selectMode}} @measuring={{measuring}} @disabled={{disabled}} @onToggleAll={{action onToggleAll}} />
 
     {{#each promotedActionsToRender as |promotedAction|}}
-      {{polaris-resource-list/bulk-actions/bulk-action-button
-        content=promotedAction.content
-        onAction=(action promotedAction.onAction)
-        handleMeasurement=(action "handleMeasurement")
-      }}
+      <PolarisResourceList::BulkActions::BulkActionButton @content={{promotedAction.content}} @onAction={{action promotedAction.onAction}} @handleMeasurement={{action "handleMeasurement"}} />
     {{/each}}
 
     {{#if shouldRenderActionsPopover}}
       <div class="Polaris-ResourceList-BulkActions__Popover">
-        {{#polaris-popover as |popover|}}
+        <PolarisPopover as |popover|>
           {{#component (if disabled
             (component "wrapper-element" tagName="")
             popover.activator
           )}}
-            {{polaris-resource-list/bulk-actions/bulk-action-button
-              content=activatorLabel
-              disabled=disabled
-            }}
+            <PolarisResourceList::BulkActions::BulkActionButton @content={{activatorLabel}} @disabled={{disabled}} />
           {{/component}}
 
-          {{#popover.content}}
-            {{polaris-action-list
-              sections=combinedActions
-              onActionAnyItem=(action popover.close)
-            }}
-          {{/popover.content}}
-        {{/polaris-popover}}
+          <popover.content>
+            <PolarisActionList @sections={{combinedActions}} @onActionAnyItem={{action popover.close}} />
+          </popover.content>
+        </PolarisPopover>
       </div>
     {{/if}}
   </div>
@@ -131,12 +94,7 @@
       {{/if}}
 
       {{#if paginatedSelectAllAction}}
-        {{polaris-button
-          plain=true
-          disabled=disabled
-          text=paginatedSelectAllAction.content
-          onClick=(action paginatedSelectAllAction.onAction)
-        }}
+        <PolarisButton @plain={{true}} @disabled={{disabled}} @text={{paginatedSelectAllAction.content}} @onClick={{action paginatedSelectAllAction.onAction}} />
       {{/if}}
     </div>
   {{/if}}

--- a/addon/templates/components/polaris-resource-list/bulk-actions.hbs
+++ b/addon/templates/components/polaris-resource-list/bulk-actions.hbs
@@ -1,4 +1,5 @@
 <div
+  data-test-bulk-actions="true"
   class="Polaris-ResourceList-BulkActions__Group
     Polaris-ResourceList-BulkActions__Group--smallScreen
     {{if selectMode
@@ -6,6 +7,7 @@
       "Polaris-ResourceList-BulkActions__Group--exited"
     }}
   "
+  {{did-insert this.insertBulkActions}}
 >
   <div class="Polaris-ResourceList-BulkActions__ButtonGroup">
     <PolarisResourceList::CheckableButton @accessibilityLabel={{accessibilityLabel}} @label={{label}} @selected={{selected}} @selectMode={{selectMode}} @measuring={{measuring}} @disabled={{disabled}} @onToggleAll={{action onToggleAll}} />

--- a/addon/templates/components/polaris-resource-list/bulk-actions.hbs
+++ b/addon/templates/components/polaris-resource-list/bulk-actions.hbs
@@ -40,7 +40,7 @@
 
     <button
       class="Polaris-ResourceList-BulkActions__Button Polaris-ResourceList-BulkActions__Button--cancel"
-      onclick={{fn this.setSelectMode false}}
+      {{on "click" (fn this.setSelectMode false)}}
     >
       Cancel
     </button>

--- a/addon/templates/components/polaris-resource-list/bulk-actions.hbs
+++ b/addon/templates/components/polaris-resource-list/bulk-actions.hbs
@@ -2,7 +2,7 @@
   data-test-bulk-actions="true"
   class="Polaris-ResourceList-BulkActions__Group
     Polaris-ResourceList-BulkActions__Group--smallScreen
-    {{if selectMode
+    {{if @selectMode
       "Polaris-ResourceList-BulkActions__Group--entered"
       "Polaris-ResourceList-BulkActions__Group--exited"
     }}
@@ -10,9 +10,17 @@
   {{did-insert this.insertBulkActions}}
 >
   <div class="Polaris-ResourceList-BulkActions__ButtonGroup">
-    <PolarisResourceList::CheckableButton @accessibilityLabel={{accessibilityLabel}} @label={{label}} @selected={{selected}} @selectMode={{selectMode}} @measuring={{measuring}} @disabled={{disabled}} @onToggleAll={{action onToggleAll}} />
+    <PolarisResourceList::CheckableButton
+      @accessibilityLabel={{@accessibilityLabel}}
+      @label={{@label}}
+      @selected={{@selected}}
+      @selectMode={{@selectMode}}
+      @measuring={{this.measuring}}
+      @disabled={{@disabled}}
+      @onToggleAll={{fn (or @onToggleAll this.onToggleAll)}}
+    />
 
-    {{#if hasActions}}
+    {{#if this.hasActions}}
       <div class="Polaris-ResourceList-BulkActions__Popover">
         <PolarisPopover as |popover|>
           <popover.activator>
@@ -20,7 +28,11 @@
           </popover.activator>
 
           <popover.content>
-            <PolarisActionList @items={{promotedActions}} @sections={{actionSections}} @onActionAnyItem={{action popover.close}} />
+            <PolarisActionList
+              @items={{@promotedActions}}
+              @sections={{this.actionSections}}
+              @onActionAnyItem={{action popover.close}}
+            />
           </popover.content>
         </PolarisPopover>
       </div>
@@ -28,22 +40,27 @@
 
     <button
       class="Polaris-ResourceList-BulkActions__Button Polaris-ResourceList-BulkActions__Button--cancel"
-      onclick={{action "setSelectMode" false}}
+      onclick={{fn this.setSelectMode false}}
     >
       Cancel
     </button>
   </div>
 
-  {{#if (or paginatedSelectAllAction (and paginatedSelectAllText paginatedSelectAllAction))}}
+  {{#if (or @paginatedSelectAllAction (and @paginatedSelectAllText @paginatedSelectAllAction))}}
     <div class="Polaris-ResourceList-BulkActions__PaginatedSelectAll">
-      {{#if (and paginatedSelectAllText paginatedSelectAllAction)}}
-        <span aria-live="polite">{{paginatedSelectAllText}}</span>
+      {{#if (and @paginatedSelectAllText @paginatedSelectAllAction)}}
+        <span aria-live="polite">{{@paginatedSelectAllText}}</span>
       {{else}}
-        {{paginatedSelectAllText}}
+        {{@paginatedSelectAllText}}
       {{/if}}
 
-      {{#if paginatedSelectAllAction}}
-        <PolarisButton @plain={{true}} @disabled={{disabled}} @text={{paginatedSelectAllAction.content}} @onClick={{action paginatedSelectAllAction.onAction}} />
+      {{#if @paginatedSelectAllAction}}
+        <PolarisButton
+          @plain={{true}}
+          @disabled={{@disabled}}
+          @text={{@paginatedSelectAllAction.content}}
+          @onClick={{action @paginatedSelectAllAction.onAction}}
+        />
       {{/if}}
     </div>
   {{/if}}
@@ -52,32 +69,50 @@
 <div
   class="Polaris-ResourceList-BulkActions__Group
     Polaris-ResourceList-BulkActions__Group--largeScreen
-    {{if measuring "Polaris-ResourceList-BulkActions__Group--measuring"}}
-    {{if selectMode
+    {{if this.measuring "Polaris-ResourceList-BulkActions__Group--measuring"}}
+    {{if @selectMode
       "Polaris-ResourceList-BulkActions__Group--entered"
       "Polaris-ResourceList-BulkActions__Group--exited"
     }}
   "
 >
   <div class="Polaris-ResourceList-BulkActions__ButtonGroup">
-    <PolarisResourceList::CheckableButton @accessibilityLabel={{accessibilityLabel}} @label={{label}} @selected={{selected}} @selectMode={{selectMode}} @measuring={{measuring}} @disabled={{disabled}} @onToggleAll={{action onToggleAll}} />
+    <PolarisResourceList::CheckableButton
+      @accessibilityLabel={{@accessibilityLabel}}
+      @label={{@label}}
+      @selected={{@selected}}
+      @selectMode={{@selectMode}}
+      @measuring={{this.measuring}}
+      @disabled={{@disabled}}
+      @onToggleAll={{fn (or @onToggleAll this.onToggleAll)}}
+    />
 
-    {{#each promotedActionsToRender as |promotedAction|}}
-      <PolarisResourceList::BulkActions::BulkActionButton @content={{promotedAction.content}} @onAction={{action promotedAction.onAction}} @handleMeasurement={{action "handleMeasurement"}} />
+    {{#each this.promotedActionsToRender as |promotedAction|}}
+      <PolarisResourceList::BulkActions::BulkActionButton
+        @content={{promotedAction.content}}
+        @onAction={{action promotedAction.onAction}}
+        @handleMeasurement={{fn this.handleMeasurement}}
+      />
     {{/each}}
 
-    {{#if shouldRenderActionsPopover}}
+    {{#if this.shouldRenderActionsPopover}}
       <div class="Polaris-ResourceList-BulkActions__Popover">
         <PolarisPopover as |popover|>
-          {{#component (if disabled
+          {{#component (if @disabled
             (component "wrapper-element" tagName="")
             popover.activator
           )}}
-            <PolarisResourceList::BulkActions::BulkActionButton @content={{activatorLabel}} @disabled={{disabled}} />
+            <PolarisResourceList::BulkActions::BulkActionButton
+              @content={{this.activatorLabel}}
+              @disabled={{@disabled}}
+            />
           {{/component}}
 
           <popover.content>
-            <PolarisActionList @sections={{combinedActions}} @onActionAnyItem={{action popover.close}} />
+            <PolarisActionList
+              @sections={{this.combinedActions}}
+              @onActionAnyItem={{action popover.close}}
+            />
           </popover.content>
         </PolarisPopover>
       </div>
@@ -85,18 +120,23 @@
   </div>
 
   {{#if (or
-    paginatedSelectAllAction
-    (and paginatedSelectAllText paginatedSelectAllAction)
+    @paginatedSelectAllAction
+    (and @paginatedSelectAllText @paginatedSelectAllAction)
   )}}
     <div class="Polaris-ResourceList-BulkActions__PaginatedSelectAll">
-      {{#if (and paginatedSelectAllText paginatedSelectAllAction)}}
-        <span aria-live="polite">{{paginatedSelectAllText}}</span>
+      {{#if (and @paginatedSelectAllText @paginatedSelectAllAction)}}
+        <span aria-live="polite">{{@paginatedSelectAllText}}</span>
       {{else}}
-        {{paginatedSelectAllText}}
+        {{@paginatedSelectAllText}}
       {{/if}}
 
-      {{#if paginatedSelectAllAction}}
-        <PolarisButton @plain={{true}} @disabled={{disabled}} @text={{paginatedSelectAllAction.content}} @onClick={{action paginatedSelectAllAction.onAction}} />
+      {{#if @paginatedSelectAllAction}}
+        <PolarisButton
+          @plain={{true}}
+          @disabled={{@disabled}}
+          @text={{@paginatedSelectAllAction.content}}
+          @onClick={{action @paginatedSelectAllAction.onAction}}
+        />
       {{/if}}
     </div>
   {{/if}}

--- a/addon/templates/components/polaris-resource-list/bulk-actions/bulk-action-button.hbs
+++ b/addon/templates/components/polaris-resource-list/bulk-actions/bulk-action-button.hbs
@@ -19,29 +19,19 @@
   ariaLabel=@accessibilityLabel
   onMouseUp=this.handleMouseUpByBlurring
 }}
-  {{#component
-    (if @disclosure
-      (component "wrapper-element"
-        tagName="span"
-        class="Polaris-ResourceList-BulkActions__ActionContent"
-      )
-      (component "wrapper-element"
-        tagName=""
-      )
-    )
-  }}
-    <WrapperElement @tagName={{if @disclosure "span" ""}}>
-      {{#if hasBlock}}
-        {{yield}}
-      {{else}}
-        {{render-content @content}}
-      {{/if}}
-    </WrapperElement>
-
-    {{#if @disclosure}}
-      <span class="Polaris-ResourceList-BulkActions__ActionIcon">
-        <PolarisIcon @source="caret-down" />
-      </span>
-    {{/if}}
-  {{/component}}
+  {{#let (element (if @disclosure "span" "")) as |OuterWrapper|}}
+    <OuterWrapper
+      class="Polaris-ResourceList-BulkActions__ActionContent"
+    >
+      {{#let (element (if @disclosure "span" "")) as |InnerWrapper|}}
+        <InnerWrapper>
+          {{#if hasBlock}}
+            {{yield}}
+          {{else}}
+            {{render-content @content}}
+          {{/if}}
+        </InnerWrapper>
+      {{/let}}
+    </OuterWrapper>
+  {{/let}}
 {{/component}}

--- a/addon/templates/components/polaris-resource-list/bulk-actions/bulk-action-button.hbs
+++ b/addon/templates/components/polaris-resource-list/bulk-actions/bulk-action-button.hbs
@@ -30,19 +30,17 @@
       )
     )
   }}
-    {{#wrapper-element
-      tagName=(if disclosure "span" "")
-    }}
+    <WrapperElement @tagName={{if disclosure "span" ""}}>
       {{#if hasBlock}}
         {{yield}}
       {{else}}
         {{render-content content}}
       {{/if}}
-    {{/wrapper-element}}
+    </WrapperElement>
 
     {{#if disclosure}}
       <span class="Polaris-ResourceList-BulkActions__ActionIcon">
-        {{polaris-icon source="caret-down"}}
+        <PolarisIcon @source="caret-down" />
       </span>
     {{/if}}
   {{/component}}

--- a/addon/templates/components/polaris-resource-list/bulk-actions/bulk-action-button.hbs
+++ b/addon/templates/components/polaris-resource-list/bulk-actions/bulk-action-button.hbs
@@ -32,6 +32,12 @@
           {{/if}}
         </InnerWrapper>
       {{/let}}
+
+      {{#if @disclosure}}
+        <span class="Polaris-ResourceList-BulkActions__ActionIcon">
+          <PolarisIcon @source="caret-down" />
+        </span>
+      {{/if}}
     </OuterWrapper>
   {{/let}}
 {{/component}}

--- a/addon/templates/components/polaris-resource-list/bulk-actions/bulk-action-button.hbs
+++ b/addon/templates/components/polaris-resource-list/bulk-actions/bulk-action-button.hbs
@@ -1,26 +1,26 @@
 {{#component
-  (if url
+  (if @url
     (component "polaris-unstyled-link"
       class="Polaris-ResourceList-BulkActions__Button"
-      external=external
-      url=url
+      external=@external
+      url=@url
     )
     (component "wrapper-element"
       tagName="button"
       type="button"
-      disabled=disabled
+      disabled=@disabled
       class=(concat
         "Polaris-ResourceList-BulkActions__Button"
-        (if disabled " Polaris-ResourceList-BulkActions--disabled")
+        (if @disabled " Polaris-ResourceList-BulkActions--disabled")
       )
-      click=(action onAction)
+      click=(fn (or @onAction this.onAction))
     )
   )
-  ariaLabel=accessibilityLabel
-  onMouseUp=handleMouseUpByBlurring
+  ariaLabel=@accessibilityLabel
+  onMouseUp=this.handleMouseUpByBlurring
 }}
   {{#component
-    (if disclosure
+    (if @disclosure
       (component "wrapper-element"
         tagName="span"
         class="Polaris-ResourceList-BulkActions__ActionContent"
@@ -30,15 +30,15 @@
       )
     )
   }}
-    <WrapperElement @tagName={{if disclosure "span" ""}}>
+    <WrapperElement @tagName={{if @disclosure "span" ""}}>
       {{#if hasBlock}}
         {{yield}}
       {{else}}
-        {{render-content content}}
+        {{render-content @content}}
       {{/if}}
     </WrapperElement>
 
-    {{#if disclosure}}
+    {{#if @disclosure}}
       <span class="Polaris-ResourceList-BulkActions__ActionIcon">
         <PolarisIcon @source="caret-down" />
       </span>

--- a/addon/templates/components/polaris-resource-list/checkable-button.hbs
+++ b/addon/templates/components/polaris-resource-list/checkable-button.hbs
@@ -1,7 +1,9 @@
-<div class="Polaris-ResourceList-CheckableButton {{if this.plain "Polaris-ResourceList-CheckableButton__CheckableButton--plain"}} {{if this.shouldApplySelectModeClass "Polaris-ResourceList-CheckableButton__CheckableButton--selectMode"}} {{if this.shouldApplySelectedClass "Polaris-ResourceList-CheckableButton__CheckableButton--selected"}} {{if this.shouldApplyMeasuringClass "Polaris-ResourceList-CheckableButton__CheckableButton--measuring"}}" ...attributes>
+<div
+  {{on "click" this.onToggleAll}}
+  class="Polaris-ResourceList-CheckableButton {{if this.plain "Polaris-ResourceList-CheckableButton__CheckableButton--plain"}} {{if this.shouldApplySelectModeClass "Polaris-ResourceList-CheckableButton__CheckableButton--selectMode"}} {{if this.shouldApplySelectedClass "Polaris-ResourceList-CheckableButton__CheckableButton--selected"}} {{if this.shouldApplyMeasuringClass "Polaris-ResourceList-CheckableButton__CheckableButton--measuring"}}" ...attributes>
   <div class="Polaris-ResourceList-CheckableButton__Checkbox">
     <PolarisCheckbox @labelHidden={{true}} @label={{accessibilityLabel}} @checked={{selected}} @disabled={{disabled}} />
   </div>
   <span class="Polaris-ResourceList-CheckableButton__Label">{{label}}</span>
-  
+
 </div>

--- a/addon/templates/components/polaris-resource-list/checkable-button.hbs
+++ b/addon/templates/components/polaris-resource-list/checkable-button.hbs
@@ -1,6 +1,6 @@
 {{!-- template-lint-disable no-invalid-interactive --}}
 <div
-  {{on "click" this.onToggleAll}}
+  {{on "click" (fn (or @onToggleAll this.onToggleAll))}}
   class="Polaris-ResourceList-CheckableButton
     {{if this.plain "Polaris-ResourceList-CheckableButton__CheckableButton--plain"}}
     {{if this.shouldApplySelectModeClass "Polaris-ResourceList-CheckableButton__CheckableButton--selectMode"}}

--- a/addon/templates/components/polaris-resource-list/checkable-button.hbs
+++ b/addon/templates/components/polaris-resource-list/checkable-button.hbs
@@ -1,3 +1,4 @@
+{{!-- template-lint-disable no-invalid-interactive --}}
 <div
   {{on "click" this.onToggleAll}}
   class="Polaris-ResourceList-CheckableButton

--- a/addon/templates/components/polaris-resource-list/checkable-button.hbs
+++ b/addon/templates/components/polaris-resource-list/checkable-button.hbs
@@ -1,9 +1,20 @@
 <div
   {{on "click" this.onToggleAll}}
-  class="Polaris-ResourceList-CheckableButton {{if this.plain "Polaris-ResourceList-CheckableButton__CheckableButton--plain"}} {{if this.shouldApplySelectModeClass "Polaris-ResourceList-CheckableButton__CheckableButton--selectMode"}} {{if this.shouldApplySelectedClass "Polaris-ResourceList-CheckableButton__CheckableButton--selected"}} {{if this.shouldApplyMeasuringClass "Polaris-ResourceList-CheckableButton__CheckableButton--measuring"}}" ...attributes>
+  class="Polaris-ResourceList-CheckableButton
+    {{if this.plain "Polaris-ResourceList-CheckableButton__CheckableButton--plain"}}
+    {{if this.shouldApplySelectModeClass "Polaris-ResourceList-CheckableButton__CheckableButton--selectMode"}}
+    {{if this.shouldApplySelectedClass "Polaris-ResourceList-CheckableButton__CheckableButton--selected"}}
+    {{if this.shouldApplyMeasuringClass "Polaris-ResourceList-CheckableButton__CheckableButton--measuring"}}
+  "
+  ...attributes
+>
   <div class="Polaris-ResourceList-CheckableButton__Checkbox">
-    <PolarisCheckbox @labelHidden={{true}} @label={{accessibilityLabel}} @checked={{selected}} @disabled={{disabled}} />
+    <PolarisCheckbox
+      @labelHidden={{true}}
+      @label={{@accessibilityLabel}}
+      @checked={{@selected}}
+      @disabled={{@disabled}}
+    />
   </div>
-  <span class="Polaris-ResourceList-CheckableButton__Label">{{label}}</span>
-
+  <span class="Polaris-ResourceList-CheckableButton__Label">{{@label}}</span>
 </div>

--- a/addon/templates/components/polaris-resource-list/checkable-button.hbs
+++ b/addon/templates/components/polaris-resource-list/checkable-button.hbs
@@ -1,9 +1,7 @@
-<div class="Polaris-ResourceList-CheckableButton__Checkbox">
-  {{polaris-checkbox
-    labelHidden=true
-    label=accessibilityLabel
-    checked=selected
-    disabled=disabled
-  }}
+<div class="Polaris-ResourceList-CheckableButton {{if this.plain "Polaris-ResourceList-CheckableButton__CheckableButton--plain"}} {{if this.shouldApplySelectModeClass "Polaris-ResourceList-CheckableButton__CheckableButton--selectMode"}} {{if this.shouldApplySelectedClass "Polaris-ResourceList-CheckableButton__CheckableButton--selected"}} {{if this.shouldApplyMeasuringClass "Polaris-ResourceList-CheckableButton__CheckableButton--measuring"}}" ...attributes>
+  <div class="Polaris-ResourceList-CheckableButton__Checkbox">
+    <PolarisCheckbox @labelHidden={{true}} @label={{accessibilityLabel}} @checked={{selected}} @disabled={{disabled}} />
+  </div>
+  <span class="Polaris-ResourceList-CheckableButton__Label">{{label}}</span>
+  
 </div>
-<span class="Polaris-ResourceList-CheckableButton__Label">{{label}}</span>

--- a/addon/templates/components/polaris-resource-list/filter-control.hbs
+++ b/addon/templates/components/polaris-resource-list/filter-control.hbs
@@ -3,9 +3,9 @@
     @labelHidden={{true}}
     @connectedLeft={{if @filters
       (component "polaris-resource-list/filter-control/filter-creator"
-        resourceName=context.resourceName
+        resourceName=this.context.resourceName
         filters=@filters
-        disabled=context.selectMode
+        disabled=this.context.selectMode
         onAddFilter=(fn this.handleAddFilter)
       )
     }}
@@ -15,7 +15,7 @@
     @prefix={{component "polaris-icon" source="search" color="skyDark"}}
     @value={{@searchValue}}
     @focused={{@focused}}
-    @disabled={{context.selectMode}}
+    @disabled={{this.context.selectMode}}
     @onChange={{fn (or @onSearchChange this.onSearchChange)}}
     @onBlur={{fn (or @onSearchBlur this.onSearchBlur)}}
   />
@@ -26,7 +26,7 @@
         <li class="Polaris-ResourceList-FilterControl__AppliedFilter">
           <PolarisTag
             @text={{appliedFilterForRender.label}}
-            @disabled={{context.selectMode}}
+            @disabled={{this.context.selectMode}}
             @onRemove={{fn this.handleRemoveFilter appliedFilterForRender}}
           />
         </li>

--- a/addon/templates/components/polaris-resource-list/filter-control.hbs
+++ b/addon/templates/components/polaris-resource-list/filter-control.hbs
@@ -1,36 +1,12 @@
-{{#polaris-form-layout}}
-  {{polaris-text-field
-    labelHidden=true
-    connectedLeft=(if filters
-      (component
-        "polaris-resource-list/filter-control/filter-creator"
-        resourceName=context.resourceName
-        filters=filters
-        disabled=context.selectMode
-        onAddFilter=(action handleAddFilter)
-      )
-    )
-    connectedRight=additionalActionButton
-    label=textFieldLabel
-    placeholder=textFieldLabel
-    prefix=(component "polaris-icon" source="search" color="skyDark")
-    value=searchValue
-    focused=focused
-    disabled=context.selectMode
-    onChange=(action onSearchChange)
-    onBlur=(action onSearchBlur)
-  }}
+<PolarisFormLayout>
+  <PolarisTextField @labelHidden={{true}} @connectedLeft={{if filters (component "polaris-resource-list/filter-control/filter-creator" resourceName=context.resourceName filters=filters disabled=context.selectMode onAddFilter=(action handleAddFilter))}} @connectedRight={{additionalActionButton}} @label={{textFieldLabel}} @placeholder={{textFieldLabel}} @prefix={{component "polaris-icon" source="search" color="skyDark"}} @value={{searchValue}} @focused={{focused}} @disabled={{context.selectMode}} @onChange={{action onSearchChange}} @onBlur={{action onSearchBlur}} />
   {{#if appliedFilters}}
     <ul class="Polaris-ResourceList-FilterControl__AppliedFilters">
       {{#each appliedFiltersForRender as |appliedFilterForRender|}}
         <li class="Polaris-ResourceList-FilterControl__AppliedFilter">
-          {{polaris-tag
-            text=appliedFilterForRender.label
-            disabled=context.selectMode
-            onRemove=(action handleRemoveFilter appliedFilterForRender)
-          }}
+          <PolarisTag @text={{appliedFilterForRender.label}} @disabled={{context.selectMode}} @onRemove={{action handleRemoveFilter appliedFilterForRender}} />
         </li>
       {{/each}}
     </ul>
   {{/if}}
-{{/polaris-form-layout}}
+</PolarisFormLayout>

--- a/addon/templates/components/polaris-resource-list/filter-control.hbs
+++ b/addon/templates/components/polaris-resource-list/filter-control.hbs
@@ -1,10 +1,34 @@
 <PolarisFormLayout>
-  <PolarisTextField @labelHidden={{true}} @connectedLeft={{if filters (component "polaris-resource-list/filter-control/filter-creator" resourceName=context.resourceName filters=filters disabled=context.selectMode onAddFilter=(action handleAddFilter))}} @connectedRight={{additionalActionButton}} @label={{textFieldLabel}} @placeholder={{textFieldLabel}} @prefix={{component "polaris-icon" source="search" color="skyDark"}} @value={{searchValue}} @focused={{focused}} @disabled={{context.selectMode}} @onChange={{action onSearchChange}} @onBlur={{action onSearchBlur}} />
-  {{#if appliedFilters}}
+  <PolarisTextField
+    @labelHidden={{true}}
+    @connectedLeft={{if @filters
+      (component "polaris-resource-list/filter-control/filter-creator"
+        resourceName=context.resourceName
+        filters=@filters
+        disabled=context.selectMode
+        onAddFilter=(fn this.handleAddFilter)
+      )
+    }}
+    @connectedRight={{this.additionalActionButton}}
+    @label={{this.textFieldLabel}}
+    @placeholder={{this.textFieldLabel}}
+    @prefix={{component "polaris-icon" source="search" color="skyDark"}}
+    @value={{@searchValue}}
+    @focused={{@focused}}
+    @disabled={{context.selectMode}}
+    @onChange={{fn (or @onSearchChange this.onSearchChange)}}
+    @onBlur={{fn (or @onSearchBlur this.onSearchBlur)}}
+  />
+
+  {{#if @appliedFilters}}
     <ul class="Polaris-ResourceList-FilterControl__AppliedFilters">
-      {{#each appliedFiltersForRender as |appliedFilterForRender|}}
+      {{#each this.appliedFiltersForRender as |appliedFilterForRender|}}
         <li class="Polaris-ResourceList-FilterControl__AppliedFilter">
-          <PolarisTag @text={{appliedFilterForRender.label}} @disabled={{context.selectMode}} @onRemove={{action handleRemoveFilter appliedFilterForRender}} />
+          <PolarisTag
+            @text={{appliedFilterForRender.label}}
+            @disabled={{context.selectMode}}
+            @onRemove={{fn this.handleRemoveFilter appliedFilterForRender}}
+          />
         </li>
       {{/each}}
     </ul>

--- a/addon/templates/components/polaris-resource-list/filter-control/date-selector.hbs
+++ b/addon/templates/components/polaris-resource-list/filter-control/date-selector.hbs
@@ -1,33 +1,10 @@
-{{polaris-select
-  dataTestSelect="date-selector"
-  label="Select a value"
-  labelHidden=true
-  placeholder="Select a filter..."
-  options=dateOptions
-  value=(or dateFilterOption "")
-  onChange=(action handleDateFilterOptionsChange)
-}}
+<PolarisSelect @dataTestSelect="date-selector" @label="Select a value" @labelHidden={{true}} @placeholder="Select a filter..." @options={{dateOptions}} @value={{or dateFilterOption ""}} @onChange={{action handleDateFilterOptionsChange}} />
 
 {{#if showDatePredicate}}
   <div class="Polaris-FilterControl-DateSelector__DateTextField">
-    {{polaris-text-field
-      label="Date"
-      placeholder="YYYY-MM-DD"
-      autoComplete=false
-      prefix=(component "polaris-icon" source="calendar" color="skyDark")
-      value=dateTextFieldValue
-      error=userInputDateError
-      onChange=(action handleDateFieldChange)
-      onBlur=(action handleDateBlur)
-    }}
+    <PolarisTextField @label="Date" @placeholder="YYYY-MM-DD" @autoComplete={{false}} @prefix={{component "polaris-icon" source="calendar" color="skyDark"}} @value={{dateTextFieldValue}} @error={{userInputDateError}} @onChange={{action handleDateFieldChange}} @onBlur={{action handleDateBlur}} />
   </div>
   <div class="Polaris-FilterControl-DateSelector__DatePicker">
-    {{polaris-date-picker
-      selected=selectedDate
-      month=datePickerMonth
-      year=datePickerYear
-      onChange=(action handleDatePickerChange)
-      onMonthChange=(action handleDatePickerMonthChange)
-    }}
+    <PolarisDatePicker @selected={{selectedDate}} @month={{datePickerMonth}} @year={{datePickerYear}} @onChange={{action handleDatePickerChange}} @onMonthChange={{action handleDatePickerMonthChange}} />
   </div>
 {{/if}}

--- a/addon/templates/components/polaris-resource-list/filter-control/date-selector.hbs
+++ b/addon/templates/components/polaris-resource-list/filter-control/date-selector.hbs
@@ -1,10 +1,32 @@
-<PolarisSelect @dataTestSelect="date-selector" @label="Select a value" @labelHidden={{true}} @placeholder="Select a filter..." @options={{dateOptions}} @value={{or dateFilterOption ""}} @onChange={{action handleDateFilterOptionsChange}} />
+<PolarisSelect dataTestSelect="date-selector"
+  @label="Select a value"
+  @labelHidden={{true}}
+  @placeholder="Select a filter..."
+  @options={{this.dateOptions}}
+  @value={{or this.dateFilterOption ""}}
+  @onChange={{fn this.handleDateFilterOptionsChange}}
+/>
 
 {{#if showDatePredicate}}
   <div class="Polaris-FilterControl-DateSelector__DateTextField">
-    <PolarisTextField @label="Date" @placeholder="YYYY-MM-DD" @autoComplete={{false}} @prefix={{component "polaris-icon" source="calendar" color="skyDark"}} @value={{dateTextFieldValue}} @error={{userInputDateError}} @onChange={{action handleDateFieldChange}} @onBlur={{action handleDateBlur}} />
+    <PolarisTextField
+      @label="Date"
+      @placeholder="YYYY-MM-DD"
+      @autoComplete={{false}}
+      @prefix={{component "polaris-icon" source="calendar" color="skyDark"}}
+      @value={{this.dateTextFieldValue}}
+      @error={{this.userInputDateError}}
+      @onChange={{fn this.handleDateFieldChange}}
+      @onBlur={{fn this.handleDateBlur}}
+    />
   </div>
   <div class="Polaris-FilterControl-DateSelector__DatePicker">
-    <PolarisDatePicker @selected={{selectedDate}} @month={{datePickerMonth}} @year={{datePickerYear}} @onChange={{action handleDatePickerChange}} @onMonthChange={{action handleDatePickerMonthChange}} />
+    <PolarisDatePicker
+      @selected={{this.selectedDate}}
+      @month={{this.datePickerMonth}}
+      @year={{this.datePickerYear}}
+      @onChange={{fn this.handleDatePickerChange}}
+      @onMonthChange={{fn this.handleDatePickerMonthChange}}
+    />
   </div>
 {{/if}}

--- a/addon/templates/components/polaris-resource-list/filter-control/date-selector.hbs
+++ b/addon/templates/components/polaris-resource-list/filter-control/date-selector.hbs
@@ -1,4 +1,5 @@
-<PolarisSelect dataTestSelect="date-selector"
+<PolarisSelect
+  @dataTestSelect="date-selector"
   @label="Select a value"
   @labelHidden={{true}}
   @placeholder="Select a filter..."

--- a/addon/templates/components/polaris-resource-list/filter-control/filter-creator.hbs
+++ b/addon/templates/components/polaris-resource-list/filter-control/filter-creator.hbs
@@ -8,7 +8,7 @@
     popover.activator
   )}}
     <PolarisButton
-      dataTestId="filter-activator"
+      @dataTestId="filter-activator"
       @text="Filter"
       @disclosure={{true}}
       @disabled={{@disabled}}
@@ -40,7 +40,7 @@
 
           <formLayout.item>
             <PolarisButton
-              dataTestId="add-filter"
+              @dataTestId="add-filter"
               @text="Add filter"
               @disabled={{not this.canAddFilter}}
               @onClick={{fn this.handleAddFilter popover}}

--- a/addon/templates/components/polaris-resource-list/filter-control/filter-creator.hbs
+++ b/addon/templates/components/polaris-resource-list/filter-control/filter-creator.hbs
@@ -1,23 +1,50 @@
-<PolarisPopover @sectioned={{true}} @fullHeight={{true}} as |popover|>
-  {{#component (if disabled
+<PolarisPopover
+  @sectioned={{true}}
+  @fullHeight={{true}}
+  as |popover|
+>
+  {{#component (if @disabled
     (component "wrapper-element" tagName="")
     popover.activator
   )}}
-    <PolarisButton @dataTestId="filter-activator" @text="Filter" @disclosure={{true}} @disabled={{disabled}} @onFocus={{action handleButtonFocus}} />
+    <PolarisButton
+      dataTestId="filter-activator"
+      @text="Filter"
+      @disclosure={{true}}
+      @disabled={{@disabled}}
+      @onFocus={{fn this.handleButtonFocus}}
+    />
   {{/component}}
 
   <popover.content>
-    <PolarisForm @onSubmit={{action handleAddFilter popover}}>
+    <PolarisForm @onSubmit={{fn this.handleAddFilter popover}}>
       <PolarisFormLayout as |formLayout|>
-        <PolarisSelect @placeholder="Select a filter..." @label={{selectLabel}} @options={{filterOptions}} @value={{or selectedFilter.key ""}} @onChange={{action handleFilterKeyChange}} />
+        <PolarisSelect
+          @placeholder="Select a filter..."
+          @label={{this.selectLabel}}
+          @options={{this.filterOptions}}
+          @value={{or this.selectedFilter.key ""}}
+          @onChange={{fn this.handleFilterKeyChange}}
+        />
 
-        {{#if selectedFilter}}
+        {{#if this.selectedFilter}}
           <formLayout.item>
-            <PolarisResourceList::FilterControl::FilterValueSelector @filter={{selectedFilter}} @filterKey={{selectedFilterKey}} @value={{selectedFilterValue}} @onFilterKeyChange={{action handleFilterKeyChange}} @onChange={{action (mut selectedFilterValue)}} />
+            <PolarisResourceList::FilterControl::FilterValueSelector
+              @filter={{this.selectedFilter}}
+              @filterKey={{this.selectedFilterKey}}
+              @value={{this.selectedFilterValue}}
+              @onFilterKeyChange={{fn this.handleFilterKeyChange}}
+              @onChange={{action (mut this.selectedFilterValue)}}
+            />
           </formLayout.item>
 
           <formLayout.item>
-            <PolarisButton @dataTestId="add-filter" @text="Add filter" @disabled={{not canAddFilter}} @onClick={{action handleAddFilter popover}} />
+            <PolarisButton
+              dataTestId="add-filter"
+              @text="Add filter"
+              @disabled={{not this.canAddFilter}}
+              @onClick={{fn this.handleAddFilter popover}}
+            />
           </formLayout.item>
         {{/if}}
       </PolarisFormLayout>

--- a/addon/templates/components/polaris-resource-list/filter-control/filter-creator.hbs
+++ b/addon/templates/components/polaris-resource-list/filter-control/filter-creator.hbs
@@ -1,53 +1,26 @@
-{{#polaris-popover
-  sectioned=true
-  fullHeight=true
-  as |popover|
-}}
+<PolarisPopover @sectioned={{true}} @fullHeight={{true}} as |popover|>
   {{#component (if disabled
     (component "wrapper-element" tagName="")
     popover.activator
   )}}
-    {{polaris-button
-      dataTestId="filter-activator"
-      text="Filter"
-      disclosure=true
-      disabled=disabled
-      onFocus=(action handleButtonFocus)
-    }}
+    <PolarisButton @dataTestId="filter-activator" @text="Filter" @disclosure={{true}} @disabled={{disabled}} @onFocus={{action handleButtonFocus}} />
   {{/component}}
 
-  {{#popover.content}}
-    {{#polaris-form onSubmit=(action handleAddFilter popover)}}
-      {{#polaris-form-layout as |formLayout|}}
-        {{polaris-select
-          placeholder="Select a filter..."
-          label=selectLabel
-          options=filterOptions
-          value=(or selectedFilter.key "")
-          onChange=(action handleFilterKeyChange)
-        }}
+  <popover.content>
+    <PolarisForm @onSubmit={{action handleAddFilter popover}}>
+      <PolarisFormLayout as |formLayout|>
+        <PolarisSelect @placeholder="Select a filter..." @label={{selectLabel}} @options={{filterOptions}} @value={{or selectedFilter.key ""}} @onChange={{action handleFilterKeyChange}} />
 
         {{#if selectedFilter}}
-          {{#formLayout.item}}
-            {{polaris-resource-list/filter-control/filter-value-selector
-              filter=selectedFilter
-              filterKey=selectedFilterKey
-              value=selectedFilterValue
-              onFilterKeyChange=(action handleFilterKeyChange)
-              onChange=(action (mut selectedFilterValue))
-            }}
-          {{/formLayout.item}}
+          <formLayout.item>
+            <PolarisResourceList::FilterControl::FilterValueSelector @filter={{selectedFilter}} @filterKey={{selectedFilterKey}} @value={{selectedFilterValue}} @onFilterKeyChange={{action handleFilterKeyChange}} @onChange={{action (mut selectedFilterValue)}} />
+          </formLayout.item>
 
-          {{#formLayout.item}}
-            {{polaris-button
-              dataTestId="add-filter"
-              text="Add filter"
-              disabled=(not canAddFilter)
-              onClick=(action handleAddFilter popover)
-            }}
-          {{/formLayout.item}}
+          <formLayout.item>
+            <PolarisButton @dataTestId="add-filter" @text="Add filter" @disabled={{not canAddFilter}} @onClick={{action handleAddFilter popover}} />
+          </formLayout.item>
         {{/if}}
-      {{/polaris-form-layout}}
-    {{/polaris-form}}
-  {{/popover.content}}
-{{/polaris-popover}}
+      </PolarisFormLayout>
+    </PolarisForm>
+  </popover.content>
+</PolarisPopover>

--- a/addon/templates/components/polaris-resource-list/filter-control/filter-value-selector.hbs
+++ b/addon/templates/components/polaris-resource-list/filter-control/filter-value-selector.hbs
@@ -1,5 +1,9 @@
 {{#if (eq filter.type FilterType.Select)}}
-  <PolarisStack @vertical={{true}} as |stack|>
+  <PolarisStack
+    {{did-insert this.insertFilterValueSelector}}
+    @vertical={{true}}
+    as |stack|
+  >
     {{#if showOperatorOptions}}
       <stack.item>
         {{render-content operatorOptionsMarkup}}
@@ -8,7 +12,11 @@
     <PolarisSelect @dataTestSelect="filter" @label={{selectedFilterLabel}} @options={{filter.options}} @placeholder="Select a filter..." @value={{or value ""}} @onChange={{action onChange}} />
   </PolarisStack>
 {{else if (eq filter.type FilterType.TextField)}}
-  <PolarisStack @vertical={{true}} as |stack|>
+  <PolarisStack
+    {{did-insert this.insertFilterValueSelector}}
+    @vertical={{true}}
+    as |stack|
+  >
     {{#if showOperatorOptions}}
       <stack.item>
         {{render-content operatorOptionsMarkup}}

--- a/addon/templates/components/polaris-resource-list/filter-control/filter-value-selector.hbs
+++ b/addon/templates/components/polaris-resource-list/filter-control/filter-value-selector.hbs
@@ -1,29 +1,49 @@
-{{#if (eq filter.type FilterType.Select)}}
+{{#if (eq @filter.type FilterType.Select)}}
   <PolarisStack
     {{did-insert this.insertFilterValueSelector}}
     @vertical={{true}}
     as |stack|
   >
-    {{#if showOperatorOptions}}
+    {{#if this.showOperatorOptions}}
       <stack.item>
-        {{render-content operatorOptionsMarkup}}
+        {{render-content this.operatorOptionsMarkup}}
       </stack.item>
     {{/if}}
-    <PolarisSelect @dataTestSelect="filter" @label={{selectedFilterLabel}} @options={{filter.options}} @placeholder="Select a filter..." @value={{or value ""}} @onChange={{action onChange}} />
+    <PolarisSelect
+      dataTestSelect="filter"
+      @label={{this.selectedFilterLabel}}
+      @options={{@filter.options}}
+      @placeholder="Select a filter..."
+      @value={{or @value ""}}
+      @onChange={{fn (or @onChange this.onChange)}}
+    />
   </PolarisStack>
-{{else if (eq filter.type FilterType.TextField)}}
+{{else if (eq @filter.type FilterType.TextField)}}
   <PolarisStack
     {{did-insert this.insertFilterValueSelector}}
     @vertical={{true}}
     as |stack|
   >
-    {{#if showOperatorOptions}}
+    {{#if this.showOperatorOptions}}
       <stack.item>
-        {{render-content operatorOptionsMarkup}}
+        {{render-content this.operatorOptionsMarkup}}
       </stack.item>
     {{/if}}
-    <PolarisTextField @label={{selectedFilterLabel}} @value={{value}} @type={{filter.textFieldType}} @onChange={{action onChange}} />
+    <PolarisTextField
+      @label={{this.selectedFilterLabel}}
+      @value={{@value}}
+      @type={{@filter.textFieldType}}
+      @onChange={{fn (or @onChange this.onChange)}}
+    />
   </PolarisStack>
-{{else if (eq filter.type FilterType.DateSelector)}}
-  <PolarisResourceList::FilterControl::DateSelector @dateOptionType={{filter.dateOptionType}} @filterValue={{value}} @filterKey={{filterKey}} @filterMinKey={{filter.minKey}} @filterMaxKey={{filter.maxKey}} @onFilterValueChange={{action onChange}} @onFilterKeyChange={{action onFilterKeyChange}} />
+{{else if (eq @filter.type FilterType.DateSelector)}}
+  <PolarisResourceList::FilterControl::DateSelector
+    @dateOptionType={{@filter.dateOptionType}}
+    @filterValue={{@value}}
+    @filterKey={{@filterKey}}
+    @filterMinKey={{@filter.minKey}}
+    @filterMaxKey={{@filter.maxKey}}
+    @onFilterValueChange={{fn (or @onChange this.onChange)}}
+    @onFilterKeyChange={{fn (or @onFilterKeyChange this.onFilterKeyChange)}}
+  />
 {{/if}}

--- a/addon/templates/components/polaris-resource-list/filter-control/filter-value-selector.hbs
+++ b/addon/templates/components/polaris-resource-list/filter-control/filter-value-selector.hbs
@@ -1,47 +1,49 @@
-{{#if (eq @filter.type FilterType.Select)}}
-  <PolarisStack
-    @vertical={{true}}
-    as |stack|
-  >
-    {{#if this.showOperatorOptions}}
-      <stack.item>
-        {{render-content this.operatorOptionsMarkup}}
-      </stack.item>
-    {{/if}}
-    <PolarisSelect
-      @dataTestSelect="filter"
-      @label={{this.selectedFilterLabel}}
-      @options={{@filter.options}}
-      @placeholder="Select a filter..."
-      @value={{or @value ""}}
-      @onChange={{fn (or @onChange this.onChange)}}
+<span {{did-insert (fn this.insertFilterValueSelector)}}>
+  {{#if (eq @filter.type FilterType.Select)}}
+    <PolarisStack
+      @vertical={{true}}
+      as |stack|
+    >
+      {{#if this.showOperatorOptions}}
+        <stack.item>
+          {{render-content this.operatorOptionsMarkup}}
+        </stack.item>
+      {{/if}}
+      <PolarisSelect
+        @dataTestSelect="filter"
+        @label={{this.selectedFilterLabel}}
+        @options={{@filter.options}}
+        @placeholder="Select a filter..."
+        @value={{or @value ""}}
+        @onChange={{fn (or @onChange this.onChange)}}
+      />
+    </PolarisStack>
+  {{else if (eq @filter.type FilterType.TextField)}}
+    <PolarisStack
+      @vertical={{true}}
+      as |stack|
+    >
+      {{#if this.showOperatorOptions}}
+        <stack.item>
+          {{render-content this.operatorOptionsMarkup}}
+        </stack.item>
+      {{/if}}
+      <PolarisTextField
+        @label={{this.selectedFilterLabel}}
+        @value={{@value}}
+        @type={{@filter.textFieldType}}
+        @onChange={{fn (or @onChange this.onChange)}}
+      />
+    </PolarisStack>
+  {{else if (eq @filter.type FilterType.DateSelector)}}
+    <PolarisResourceList::FilterControl::DateSelector
+      @dateOptionType={{@filter.dateOptionType}}
+      @filterValue={{@value}}
+      @filterKey={{@filterKey}}
+      @filterMinKey={{@filter.minKey}}
+      @filterMaxKey={{@filter.maxKey}}
+      @onFilterValueChange={{fn (or @onChange this.onChange)}}
+      @onFilterKeyChange={{fn (or @onFilterKeyChange this.onFilterKeyChange)}}
     />
-  </PolarisStack>
-{{else if (eq @filter.type FilterType.TextField)}}
-  <PolarisStack
-    @vertical={{true}}
-    as |stack|
-  >
-    {{#if this.showOperatorOptions}}
-      <stack.item>
-        {{render-content this.operatorOptionsMarkup}}
-      </stack.item>
-    {{/if}}
-    <PolarisTextField
-      @label={{this.selectedFilterLabel}}
-      @value={{@value}}
-      @type={{@filter.textFieldType}}
-      @onChange={{fn (or @onChange this.onChange)}}
-    />
-  </PolarisStack>
-{{else if (eq @filter.type FilterType.DateSelector)}}
-  <PolarisResourceList::FilterControl::DateSelector
-    @dateOptionType={{@filter.dateOptionType}}
-    @filterValue={{@value}}
-    @filterKey={{@filterKey}}
-    @filterMinKey={{@filter.minKey}}
-    @filterMaxKey={{@filter.maxKey}}
-    @onFilterValueChange={{fn (or @onChange this.onChange)}}
-    @onFilterKeyChange={{fn (or @onFilterKeyChange this.onFilterKeyChange)}}
-  />
-{{/if}}
+  {{/if}}
+</span>

--- a/addon/templates/components/polaris-resource-list/filter-control/filter-value-selector.hbs
+++ b/addon/templates/components/polaris-resource-list/filter-control/filter-value-selector.hbs
@@ -1,6 +1,5 @@
 {{#if (eq @filter.type FilterType.Select)}}
   <PolarisStack
-    {{did-insert this.insertFilterValueSelector}}
     @vertical={{true}}
     as |stack|
   >
@@ -20,7 +19,6 @@
   </PolarisStack>
 {{else if (eq @filter.type FilterType.TextField)}}
   <PolarisStack
-    {{did-insert this.insertFilterValueSelector}}
     @vertical={{true}}
     as |stack|
   >

--- a/addon/templates/components/polaris-resource-list/filter-control/filter-value-selector.hbs
+++ b/addon/templates/components/polaris-resource-list/filter-control/filter-value-selector.hbs
@@ -1,4 +1,4 @@
-<span {{did-insert (fn this.insertFilterValueSelector)}}>
+<span {{did-insert this.insertFilterValueSelector}}>
   {{#if (eq @filter.type FilterType.Select)}}
     <PolarisStack
       @vertical={{true}}

--- a/addon/templates/components/polaris-resource-list/filter-control/filter-value-selector.hbs
+++ b/addon/templates/components/polaris-resource-list/filter-control/filter-value-selector.hbs
@@ -10,7 +10,7 @@
       </stack.item>
     {{/if}}
     <PolarisSelect
-      dataTestSelect="filter"
+      @dataTestSelect="filter"
       @label={{this.selectedFilterLabel}}
       @options={{@filter.options}}
       @placeholder="Select a filter..."

--- a/addon/templates/components/polaris-resource-list/filter-control/filter-value-selector.hbs
+++ b/addon/templates/components/polaris-resource-list/filter-control/filter-value-selector.hbs
@@ -1,41 +1,21 @@
 {{#if (eq filter.type FilterType.Select)}}
-  {{#polaris-stack vertical=true as |stack|}}
+  <PolarisStack @vertical={{true}} as |stack|>
     {{#if showOperatorOptions}}
-      {{#stack.item}}
+      <stack.item>
         {{render-content operatorOptionsMarkup}}
-      {{/stack.item}}
+      </stack.item>
     {{/if}}
-    {{polaris-select
-      dataTestSelect="filter"
-      label=selectedFilterLabel
-      options=filter.options
-      placeholder="Select a filter..."
-      value=(or value "")
-      onChange=(action onChange)
-    }}
-  {{/polaris-stack}}
+    <PolarisSelect @dataTestSelect="filter" @label={{selectedFilterLabel}} @options={{filter.options}} @placeholder="Select a filter..." @value={{or value ""}} @onChange={{action onChange}} />
+  </PolarisStack>
 {{else if (eq filter.type FilterType.TextField)}}
-  {{#polaris-stack vertical=true as |stack|}}
+  <PolarisStack @vertical={{true}} as |stack|>
     {{#if showOperatorOptions}}
-      {{#stack.item}}
+      <stack.item>
         {{render-content operatorOptionsMarkup}}
-      {{/stack.item}}
+      </stack.item>
     {{/if}}
-    {{polaris-text-field
-      label=selectedFilterLabel
-      value=value
-      type=filter.textFieldType
-      onChange=(action onChange)
-    }}
-  {{/polaris-stack}}
+    <PolarisTextField @label={{selectedFilterLabel}} @value={{value}} @type={{filter.textFieldType}} @onChange={{action onChange}} />
+  </PolarisStack>
 {{else if (eq filter.type FilterType.DateSelector)}}
-  {{polaris-resource-list/filter-control/date-selector
-    dateOptionType=filter.dateOptionType
-    filterValue=value
-    filterKey=filterKey
-    filterMinKey=filter.minKey
-    filterMaxKey=filter.maxKey
-    onFilterValueChange=(action onChange)
-    onFilterKeyChange=(action onFilterKeyChange)
-  }}
+  <PolarisResourceList::FilterControl::DateSelector @dateOptionType={{filter.dateOptionType}} @filterValue={{value}} @filterKey={{filterKey}} @filterMinKey={{filter.minKey}} @filterMaxKey={{filter.maxKey}} @onFilterValueChange={{action onChange}} @onFilterKeyChange={{action onFilterKeyChange}} />
 {{/if}}

--- a/addon/templates/components/polaris-resource-list/item.hbs
+++ b/addon/templates/components/polaris-resource-list/item.hbs
@@ -29,17 +29,18 @@
         @onBlur={{fn this.handleFocusedBlur}}
       />
     {{else}}
-      <WrapperElement
-        class="Polaris-ResourceList-Item__Button"
-        @tagName="button"
-        @aria-label={{@accessibilityLabel}}
-        @aria-controls={{@ariaControls}}
-        @aria-expanded={{@ariaExpanded}}
-        @click={{fn this.handleClick}}
-        @focusIn={{fn this.handleAnchorFocus}}
-        @focusOut={{fn this.handleFocusedBlur}}
-        @tabIndex={{tabIndex}}
-      />
+      {{#let (element "button") as |ItemButton|}}
+        <ItemButton
+          class="Polaris-ResourceList-Item__Button"
+          aria-label={{@accessibilityLabel}}
+          aria-controls={{@ariaControls}}
+          aria-expanded={{@ariaExpanded}}
+          tab-index={{tabIndex}}
+          onclick={{fn this.handleClick}}
+          onfocusin={{fn this.handleAnchorFocus}}
+          onfocusout={{fn this.handleFocusedBlur}}
+        />
+      {{/let}}
     {{/if}}
   {{/with}}
 
@@ -51,27 +52,29 @@
     {{#if (or @media this.selectable)}}
       <div class="Polaris-ResourceList-Item__Owned">
         {{#if this.selectable}}
-          <WrapperElement
-            class="Polaris-ResourceList-Item__Handle"
-            @tagName="div"
-            @data-test-id="larger-selection-area"
-            @click={{fn this.handleLargerSelectionArea}}
-          >
-            <WrapperElement
-              class="Polaris-ResourceList-Item__CheckboxWrapper"
-              @tagName="div"
-              @click={{fn this.stopPropagation}}
+          {{#let (element "div") as |ItemHandle|}}
+            <ItemHandle
+              data-test-id="larger-selection-area"
+              class="Polaris-ResourceList-Item__Handle"
+              onclick={{fn this.handleLargerSelectionArea}}
             >
-              <PolarisCheckbox
-                @id={{this.checkboxId}}
-                @label={{label}}
-                @labelHidden={{true}}
-                @checked={{this.isSelected}}
-                @disabled={{@loading}}
-                @onChange={{fn this.handleSelection}}
-              />
-            </WrapperElement>
-          </WrapperElement>
+              {{#let (element "div") as |CheckboxWrapper|}}
+                <CheckboxWrapper
+                  class="Polaris-ResourceList-Item__CheckboxWrapper"
+                  onclick={{fn this.stopPropagation}}
+                >
+                  <PolarisCheckbox
+                    @id={{this.checkboxId}}
+                    @label={{label}}
+                    @labelHidden={{true}}
+                    @checked={{this.isSelected}}
+                    @disabled={{@loading}}
+                    @onChange={{fn this.handleSelection}}
+                  />
+                </CheckboxWrapper>
+              {{/let}}
+            </ItemHandle>
+          {{/let}}
         {{/if}}
 
         {{#if @media}}
@@ -93,63 +96,65 @@
     {{/if}}
 
     {{#if (and @shortcutActions (not @loading))}}
-      <WrapperElement
-        class="Polaris-ResourceList-Item__Actions"
-        @tagName="div"
-        @click={{fn this.stopPropagation}}
-      >
-        <PolarisButtonGroup
-          data-test-id={{unless @persistActions "shortcut-actions"}}
-          @segmented={{not @persistActions}}
-          as |buttonGroup|
+      {{#let (element "div") as |ItemActions|}}
+        <ItemActions
+          class="Polaris-ResourceList-Item__Actions"
+          onclick={{fn this.stopPropagation}}
         >
-          {{#each @shortcutActions as |shortcutAction|}}
-            <buttonGroup.item>
-              <PolarisButton
-                @size="slim"
-                @plain={{@persistActions}}
-                @text={{shortcutAction.text}}
-                @accessibilityLabel={{shortcutAction.accessibilityLabel}}
-                @url={{shortcutAction.url}}
-                @external={{shortcutAction.external}}
-                @destructive={{shortcutAction.destructive}}
-                @icon={{shortcutAction.icon}}
-                @loading={{shortcutAction.loading}}
-                @disabled={{shortcutAction.disabled}}
-                @onClick={{fn (or shortcutAction.onAction (action (mut dummy)))}}
-              />
-            </buttonGroup.item>
-          {{/each}}
-        </PolarisButtonGroup>
-      </WrapperElement>
+          <PolarisButtonGroup
+            data-test-id={{unless @persistActions "shortcut-actions"}}
+            @segmented={{not @persistActions}}
+            as |buttonGroup|
+          >
+            {{#each @shortcutActions as |shortcutAction|}}
+              <buttonGroup.item>
+                <PolarisButton
+                  @size="slim"
+                  @plain={{@persistActions}}
+                  @text={{shortcutAction.text}}
+                  @accessibilityLabel={{shortcutAction.accessibilityLabel}}
+                  @url={{shortcutAction.url}}
+                  @external={{shortcutAction.external}}
+                  @destructive={{shortcutAction.destructive}}
+                  @icon={{shortcutAction.icon}}
+                  @loading={{shortcutAction.loading}}
+                  @disabled={{shortcutAction.disabled}}
+                  @onClick={{fn (or shortcutAction.onAction (action (mut dummy)))}}
+                />
+              </buttonGroup.item>
+            {{/each}}
+          </PolarisButtonGroup>
+        </ItemActions>
+      {{/let}}
 
       {{#if @persistActions}}
-        <WrapperElement
-          class="Polaris-ResourceList-Item__Disclosure"
-          @tagName="div"
-          @click={{fn this.stopPropagation}}
-        >
-          <PolarisPopover as |popover|>
-            <popover.activator>
-              {{!--
-                Possible mistake in the Polaris source here as
-                `Button` doesn't seem to support `aria-label`.
-                Matching what they do for now, and if they fix
-                it we can update ;)
-              --}}
-              <PolarisButton
-                aria-label="Actions dropdown"
-                @plain={{true}}
-                @icon="horizontal-dots"
-                @onClick={{fn popover.toggle}}
-              />
-            </popover.activator>
+        {{#let (element "div") as |ItemDisclosure|}}
+          <ItemDisclosure
+            class="Polaris-ResourceList-Item__Disclosure"
+            onclick={{fn this.stopPropagation}}
+          >
+            <PolarisPopover as |popover|>
+              <popover.activator>
+                {{!--
+                  Possible mistake in the Polaris source here as
+                  `Button` doesn't seem to support `aria-label`.
+                  Matching what they do for now, and if they fix
+                  it we can update ;)
+                --}}
+                <PolarisButton
+                  aria-label="Actions dropdown"
+                  @plain={{true}}
+                  @icon="horizontal-dots"
+                  @onClick={{fn popover.toggle}}
+                />
+              </popover.activator>
 
-            <popover.content>
-              <PolarisActionList @items={{@shortcutActions}} />
-            </popover.content>
-          </PolarisPopover>
-        </WrapperElement>
+              <popover.content>
+                <PolarisActionList @items={{@shortcutActions}} />
+              </popover.content>
+            </PolarisPopover>
+          </ItemDisclosure>
+        {{/let}}
       {{/if}}
     {{/if}}
   </div>

--- a/addon/templates/components/polaris-resource-list/item.hbs
+++ b/addon/templates/components/polaris-resource-list/item.hbs
@@ -10,17 +10,7 @@
       @onBlur={{action handleFocusedBlur}}
     />
   {{else}}
-    {{wrapper-element
-      tagName="button"
-      class="Polaris-ResourceList-Item__Button"
-      aria-label=accessibilityLabel
-      aria-controls=ariaControls
-      aria-expanded=ariaExpanded
-      click=(action handleClick)
-      focusIn=(action handleAnchorFocus)
-      focusOut=(action handleFocusedBlur)
-      tabIndex=tabIndex
-    }}
+    <WrapperElement @tagName="button" @class="Polaris-ResourceList-Item__Button" @aria-label={{accessibilityLabel}} @aria-controls={{ariaControls}} @aria-expanded={{ariaExpanded}} @click={{action handleClick}} @focusIn={{action handleAnchorFocus}} @focusOut={{action handleFocusedBlur}} @tabIndex={{tabIndex}} />
   {{/if}}
 {{/with}}
 
@@ -32,27 +22,11 @@
   {{#if (or media selectable)}}
     <div class="Polaris-ResourceList-Item__Owned">
       {{#if selectable}}
-        {{#wrapper-element
-          tagName="div"
-          class="Polaris-ResourceList-Item__Handle"
-          data-test-id="larger-selection-area"
-          click=(action handleLargerSelectionArea)
-        }}
-          {{#wrapper-element
-            tagName="div"
-            class="Polaris-ResourceList-Item__CheckboxWrapper"
-            click=(action stopPropagation)
-          }}
-            {{polaris-checkbox
-              id=checkboxId
-              label=label
-              labelHidden=true
-              checked=isSelected
-              disabled=loading
-              onChange=(action handleSelection)
-            }}
-          {{/wrapper-element}}
-        {{/wrapper-element}}
+        <WrapperElement @tagName="div" @class="Polaris-ResourceList-Item__Handle" @data-test-id="larger-selection-area" @click={{action handleLargerSelectionArea}}>
+          <WrapperElement @tagName="div" @class="Polaris-ResourceList-Item__CheckboxWrapper" @click={{action stopPropagation}}>
+            <PolarisCheckbox @id={{checkboxId}} @label={{label}} @labelHidden={{true}} @checked={{isSelected}} @disabled={{loading}} @onChange={{action handleSelection}} />
+          </WrapperElement>
+        </WrapperElement>
       {{/if}}
 
       {{#if media}}
@@ -74,67 +48,38 @@
   {{/if}}
 
   {{#if (and shortcutActions (not loading))}}
-    {{#wrapper-element
-      tagName="div"
-      class="Polaris-ResourceList-Item__Actions"
-      click=(action stopPropagation)
-    }}
+    <WrapperElement @tagName="div" @class="Polaris-ResourceList-Item__Actions" @click={{action stopPropagation}}>
       <PolarisButtonGroup
         data-test-id={{unless persistActions "shortcut-actions"}}
         @segmented={{not persistActions}}
         as |buttonGroup|
       >
         {{#each shortcutActions as |shortcutAction|}}
-          {{#buttonGroup.item}}
-            {{polaris-button
-              size="slim"
-              plain=persistActions
-              text=shortcutAction.text
-              accessibilityLabel=shortcutAction.accessibilityLabel
-              url=shortcutAction.url
-              external=shortcutAction.external
-              destructive=shortcutAction.destructive
-              icon=shortcutAction.icon
-              loading=shortcutAction.loading
-              disabled=shortcutAction.disabled
-              onClick=(action
-                (or shortcutAction.onAction (action (mut dummy)))
-              )
-            }}
-          {{/buttonGroup.item}}
+          <buttonGroup.item>
+            <PolarisButton @size="slim" @plain={{persistActions}} @text={{shortcutAction.text}} @accessibilityLabel={{shortcutAction.accessibilityLabel}} @url={{shortcutAction.url}} @external={{shortcutAction.external}} @destructive={{shortcutAction.destructive}} @icon={{shortcutAction.icon}} @loading={{shortcutAction.loading}} @disabled={{shortcutAction.disabled}} @onClick={{action (or shortcutAction.onAction (action (mut dummy)))}} />
+          </buttonGroup.item>
         {{/each}}
       </PolarisButtonGroup>
-    {{/wrapper-element}}
+    </WrapperElement>
 
     {{#if persistActions}}
-      {{#wrapper-element
-        tagName="div"
-        class="Polaris-ResourceList-Item__Disclosure"
-        click=(action stopPropagation)
-      }}
-        {{#polaris-popover
-          as |popover|
-        }}
-          {{#popover.activator}}
+      <WrapperElement @tagName="div" @class="Polaris-ResourceList-Item__Disclosure" @click={{action stopPropagation}}>
+        <PolarisPopover as |popover|>
+          <popover.activator>
             {{!--
               Possible mistake in the Polaris source here as
               `Button` doesn't seem to support `aria-label`.
               Matching what they do for now, and if they fix
               it we can update ;)
             --}}
-            {{polaris-button
-              aria-label="Actions dropdown"
-              plain=true
-              icon="horizontal-dots"
-              onClick=(action popover.toggle)
-            }}
-          {{/popover.activator}}
+            <PolarisButton @aria-label="Actions dropdown" @plain={{true}} @icon="horizontal-dots" @onClick={{action popover.toggle}} />
+          </popover.activator>
 
-          {{#popover.content}}
-            {{polaris-action-list items=shortcutActions}}
-          {{/popover.content}}
-        {{/polaris-popover}}
-      {{/wrapper-element}}
+          <popover.content>
+            <PolarisActionList @items={{shortcutActions}} />
+          </popover.content>
+        </PolarisPopover>
+      </WrapperElement>
     {{/if}}
   {{/if}}
 </div>

--- a/addon/templates/components/polaris-resource-list/item.hbs
+++ b/addon/templates/components/polaris-resource-list/item.hbs
@@ -1,3 +1,4 @@
+{{!-- template-lint-disable no-invalid-interactive --}}
 <div
   data-test-id="item-wrapper"
   data-href={{@url}}

--- a/addon/templates/components/polaris-resource-list/item.hbs
+++ b/addon/templates/components/polaris-resource-list/item.hbs
@@ -18,7 +18,7 @@
   {{did-insert this.insertResourceListItem}}
   ...attributes
 >
-  {{#with (if @loading "-1" "0") as |tabIndex|}}
+  {{#with (if this.loading "-1" "0") as |tabIndex|}}
     {{#if @url}}
       <PolarisUnstyledLink
         class="Polaris-ResourceList-Item__Link"
@@ -69,7 +69,7 @@
                     @label={{label}}
                     @labelHidden={{true}}
                     @checked={{this.isSelected}}
-                    @disabled={{@loading}}
+                    @disabled={{this.loading}}
                     @onChange={{fn this.handleSelection}}
                   />
                 </CheckboxWrapper>
@@ -96,7 +96,7 @@
       </div>
     {{/if}}
 
-    {{#if (and @shortcutActions (not @loading))}}
+    {{#if (and @shortcutActions (not this.loading))}}
       {{#let (element "div") as |ItemActions|}}
         <ItemActions
           class="Polaris-ResourceList-Item__Actions"
@@ -118,7 +118,7 @@
                   @external={{shortcutAction.external}}
                   @destructive={{shortcutAction.destructive}}
                   @icon={{shortcutAction.icon}}
-                  @loading={{shortcutAction.loading}}
+                  this.loading={{shortcutAction.loading}}
                   @disabled={{shortcutAction.disabled}}
                   @onClick={{fn (or shortcutAction.onAction (action (mut dummy)))}}
                 />

--- a/addon/templates/components/polaris-resource-list/item.hbs
+++ b/addon/templates/components/polaris-resource-list/item.hbs
@@ -18,7 +18,7 @@
   {{did-insert this.insertResourceListItem}}
   ...attributes
 >
-  {{#with (if this.loading "-1" "0") as |tabIndex|}}
+  {{#let (if this.loading "-1" "0") as |tabIndex|}}
     {{#if @url}}
       <PolarisUnstyledLink
         class="Polaris-ResourceList-Item__Link"
@@ -37,13 +37,13 @@
           aria-controls={{@ariaControls}}
           aria-expanded={{@ariaExpanded}}
           tab-index={{tabIndex}}
-          onclick={{fn this.handleClick}}
-          onfocusin={{fn this.handleAnchorFocus}}
-          onfocusout={{fn this.handleFocusedBlur}}
+          {{on "click" this.handleClick}}
+          {{on "focusin" this.handleAnchorFocus}}
+          {{on "focusout" this.handleFocusedBlur}}
         />
       {{/let}}
     {{/if}}
-  {{/with}}
+  {{/let}}
 
   <div
     data-test-id="item-content"

--- a/addon/templates/components/polaris-resource-list/item.hbs
+++ b/addon/templates/components/polaris-resource-list/item.hbs
@@ -30,18 +30,16 @@
         @onBlur={{fn this.handleFocusedBlur}}
       />
     {{else}}
-      {{#let (element "button") as |ItemButton|}}
-        <ItemButton
-          class="Polaris-ResourceList-Item__Button"
-          aria-label={{@accessibilityLabel}}
-          aria-controls={{@ariaControls}}
-          aria-expanded={{@ariaExpanded}}
-          tab-index={{tabIndex}}
-          {{on "click" this.handleClick}}
-          {{on "focusin" this.handleAnchorFocus}}
-          {{on "focusout" this.handleFocusedBlur}}
-        />
-      {{/let}}
+      <button
+        class="Polaris-ResourceList-Item__Button"
+        aria-label={{@accessibilityLabel}}
+        aria-controls={{@ariaControls}}
+        aria-expanded={{@ariaExpanded}}
+        tab-index={{tabIndex}}
+        {{on "click" this.handleClick}}
+        {{on "focusin" this.handleAnchorFocus}}
+        {{on "focusout" this.handleFocusedBlur}}
+      />
     {{/if}}
   {{/let}}
 
@@ -53,29 +51,25 @@
     {{#if (or @media this.selectable)}}
       <div class="Polaris-ResourceList-Item__Owned">
         {{#if this.selectable}}
-          {{#let (element "div") as |ItemHandle|}}
-            <ItemHandle
-              data-test-id="larger-selection-area"
-              class="Polaris-ResourceList-Item__Handle"
-              onclick={{fn this.handleLargerSelectionArea}}
+          <div
+            data-test-id="larger-selection-area"
+            class="Polaris-ResourceList-Item__Handle"
+            {{on "click" this.handleLargerSelectionArea}}
+          >
+            <div
+              class="Polaris-ResourceList-Item__CheckboxWrapper"
+              {{on "click" this.stopPropagation}}
             >
-              {{#let (element "div") as |CheckboxWrapper|}}
-                <CheckboxWrapper
-                  class="Polaris-ResourceList-Item__CheckboxWrapper"
-                  onclick={{fn this.stopPropagation}}
-                >
-                  <PolarisCheckbox
-                    @id={{this.checkboxId}}
-                    @label={{label}}
-                    @labelHidden={{true}}
-                    @checked={{this.isSelected}}
-                    @disabled={{this.loading}}
-                    @onChange={{fn this.handleSelection}}
-                  />
-                </CheckboxWrapper>
-              {{/let}}
-            </ItemHandle>
-          {{/let}}
+              <PolarisCheckbox
+                @id={{this.checkboxId}}
+                @label={{label}}
+                @labelHidden={{true}}
+                @checked={{this.isSelected}}
+                @disabled={{this.loading}}
+                @onChange={{fn this.handleSelection}}
+              />
+            </div>
+          </div>
         {{/if}}
 
         {{#if @media}}
@@ -97,65 +91,61 @@
     {{/if}}
 
     {{#if (and @shortcutActions (not this.loading))}}
-      {{#let (element "div") as |ItemActions|}}
-        <ItemActions
-          class="Polaris-ResourceList-Item__Actions"
-          onclick={{fn this.stopPropagation}}
+      <div
+        class="Polaris-ResourceList-Item__Actions"
+        {{on "click" this.stopPropagation}}
+      >
+        <PolarisButtonGroup
+          data-test-id={{unless @persistActions "shortcut-actions"}}
+          @segmented={{not @persistActions}}
+          as |buttonGroup|
         >
-          <PolarisButtonGroup
-            data-test-id={{unless @persistActions "shortcut-actions"}}
-            @segmented={{not @persistActions}}
-            as |buttonGroup|
-          >
-            {{#each @shortcutActions as |shortcutAction|}}
-              <buttonGroup.item>
-                <PolarisButton
-                  @size="slim"
-                  @plain={{@persistActions}}
-                  @text={{shortcutAction.text}}
-                  @accessibilityLabel={{shortcutAction.accessibilityLabel}}
-                  @url={{shortcutAction.url}}
-                  @external={{shortcutAction.external}}
-                  @destructive={{shortcutAction.destructive}}
-                  @icon={{shortcutAction.icon}}
-                  this.loading={{shortcutAction.loading}}
-                  @disabled={{shortcutAction.disabled}}
-                  @onClick={{fn (or shortcutAction.onAction (action (mut dummy)))}}
-                />
-              </buttonGroup.item>
-            {{/each}}
-          </PolarisButtonGroup>
-        </ItemActions>
-      {{/let}}
+          {{#each @shortcutActions as |shortcutAction|}}
+            <buttonGroup.item>
+              <PolarisButton
+                @size="slim"
+                @plain={{@persistActions}}
+                @text={{shortcutAction.text}}
+                @accessibilityLabel={{shortcutAction.accessibilityLabel}}
+                @url={{shortcutAction.url}}
+                @external={{shortcutAction.external}}
+                @destructive={{shortcutAction.destructive}}
+                @icon={{shortcutAction.icon}}
+                this.loading={{shortcutAction.loading}}
+                @disabled={{shortcutAction.disabled}}
+                @onClick={{fn (or shortcutAction.onAction (action (mut dummy)))}}
+              />
+            </buttonGroup.item>
+          {{/each}}
+        </PolarisButtonGroup>
+      </div>
 
       {{#if @persistActions}}
-        {{#let (element "div") as |ItemDisclosure|}}
-          <ItemDisclosure
-            class="Polaris-ResourceList-Item__Disclosure"
-            onclick={{fn this.stopPropagation}}
-          >
-            <PolarisPopover as |popover|>
-              <popover.activator>
-                {{!--
-                  Possible mistake in the Polaris source here as
-                  `Button` doesn't seem to support `aria-label`.
-                  Matching what they do for now, and if they fix
-                  it we can update ;)
-                --}}
-                <PolarisButton
-                  aria-label="Actions dropdown"
-                  @plain={{true}}
-                  @icon="horizontal-dots"
-                  @onClick={{fn popover.toggle}}
-                />
-              </popover.activator>
+        <div
+          class="Polaris-ResourceList-Item__Disclosure"
+          {{on "click" this.stopPropagation}}
+        >
+          <PolarisPopover as |popover|>
+            <popover.activator>
+              {{!--
+                Possible mistake in the Polaris source here as
+                `Button` doesn't seem to support `aria-label`.
+                Matching what they do for now, and if they fix
+                it we can update ;)
+              --}}
+              <PolarisButton
+                aria-label="Actions dropdown"
+                @plain={{true}}
+                @icon="horizontal-dots"
+                @onClick={{fn popover.toggle}}
+              />
+            </popover.activator>
 
-              <popover.content>
-                <PolarisActionList @items={{@shortcutActions}} />
-              </popover.content>
-            </PolarisPopover>
-          </ItemDisclosure>
-        {{/let}}
+            <popover.content>
+              <PolarisActionList @items={{@shortcutActions}} />
+            </popover.content>
+          </PolarisPopover>
+        </div>
       {{/if}}
     {{/if}}
   </div>

--- a/addon/templates/components/polaris-resource-list/item.hbs
+++ b/addon/templates/components/polaris-resource-list/item.hbs
@@ -1,85 +1,104 @@
-{{#with (if loading "-1" "0") as |tabIndex|}}
-  {{#if url}}
-    <PolarisUnstyledLink
-      class="Polaris-ResourceList-Item__Link"
-      @ariaDescribedBy={{itemId}}
-      @ariaLabel={{accessibilityLabel}}
-      @url={{url}}
-      @tabIndex={{tabIndex}}
-      @onFocus={{action handleAnchorFocus}}
-      @onBlur={{action handleFocusedBlur}}
-    />
-  {{else}}
-    <WrapperElement @tagName="button" @class="Polaris-ResourceList-Item__Button" @aria-label={{accessibilityLabel}} @aria-controls={{ariaControls}} @aria-expanded={{ariaExpanded}} @click={{action handleClick}} @focusIn={{action handleAnchorFocus}} @focusOut={{action handleFocusedBlur}} @tabIndex={{tabIndex}} />
-  {{/if}}
-{{/with}}
-
 <div
-  data-test-id="item-content"
-  class="Polaris-ResourceList-Item__Container"
-  id={{itemId}}
+  data-test-id="item-wrapper"
+  data-href={{url}}
+  class="Polaris-ResourceList-Item
+  {{if focused "Polaris-ResourceList-Item--focused"}}
+  {{if selectable "Polaris-ResourceList-Item--selectable"}}
+  {{if selected "Polaris-ResourceList-Item--selected"}}
+  {{if selectMode "Polaris-ResourceList-Item--selectMode"}}
+  {{if persistActions "Polaris-ResourceList-Item--persistActions"}}
+  {{if focusedInner "Polaris-ResourceList-Item--focusedInner"}}"
+  {{on "click" this.handleClick}}
+  {{on "focusin" this.handleFocus}}
+  {{on "focusout" this.handleBlur}}
+  {{on "mousedown" this.handleMouseDown}}
+  {{on "keyup" this.handleKeypress}}
+  {{did-insert this.insertResourceListItem}}
+  ...attributes
 >
-  {{#if (or media selectable)}}
-    <div class="Polaris-ResourceList-Item__Owned">
-      {{#if selectable}}
-        <WrapperElement @tagName="div" @class="Polaris-ResourceList-Item__Handle" @data-test-id="larger-selection-area" @click={{action handleLargerSelectionArea}}>
-          <WrapperElement @tagName="div" @class="Polaris-ResourceList-Item__CheckboxWrapper" @click={{action stopPropagation}}>
-            <PolarisCheckbox @id={{checkboxId}} @label={{label}} @labelHidden={{true}} @checked={{isSelected}} @disabled={{loading}} @onChange={{action handleSelection}} />
+  {{#with (if loading "-1" "0") as |tabIndex|}}
+    {{#if url}}
+      <PolarisUnstyledLink
+        class="Polaris-ResourceList-Item__Link"
+        @ariaDescribedBy={{itemId}}
+        @ariaLabel={{accessibilityLabel}}
+        @url={{url}}
+        @tabIndex={{tabIndex}}
+        @onFocus={{action handleAnchorFocus}}
+        @onBlur={{action handleFocusedBlur}}
+      />
+    {{else}}
+      <WrapperElement @tagName="button" @class="Polaris-ResourceList-Item__Button" @aria-label={{accessibilityLabel}} @aria-controls={{ariaControls}} @aria-expanded={{ariaExpanded}} @click={{action handleClick}} @focusIn={{action handleAnchorFocus}} @focusOut={{action handleFocusedBlur}} @tabIndex={{tabIndex}} />
+    {{/if}}
+  {{/with}}
+
+  <div
+    data-test-id="item-content"
+    class="Polaris-ResourceList-Item__Container"
+    id={{itemId}}
+  >
+    {{#if (or media selectable)}}
+      <div class="Polaris-ResourceList-Item__Owned">
+        {{#if selectable}}
+          <WrapperElement @tagName="div" @class="Polaris-ResourceList-Item__Handle" @data-test-id="larger-selection-area" @click={{action handleLargerSelectionArea}}>
+            <WrapperElement @tagName="div" @class="Polaris-ResourceList-Item__CheckboxWrapper" @click={{action stopPropagation}}>
+              <PolarisCheckbox @id={{checkboxId}} @label={{label}} @labelHidden={{true}} @checked={{isSelected}} @disabled={{loading}} @onChange={{action handleSelection}} />
+            </WrapperElement>
           </WrapperElement>
+        {{/if}}
+
+        {{#if media}}
+          <div class="Polaris-ResourceList-Item__Media" data-test-id="media">
+            {{render-content media}}
+          </div>
+        {{/if}}
+      </div>
+    {{/if}}
+
+    {{#if (or hasBlock children)}}
+      <div class="Polaris-ResourceList-Item__Content">
+        {{#if hasBlock}}
+          {{yield}}
+        {{else}}
+          {{render-content children}}
+        {{/if}}
+      </div>
+    {{/if}}
+
+    {{#if (and shortcutActions (not loading))}}
+      <WrapperElement @tagName="div" @class="Polaris-ResourceList-Item__Actions" @click={{action stopPropagation}}>
+        <PolarisButtonGroup
+          data-test-id={{unless persistActions "shortcut-actions"}}
+          @segmented={{not persistActions}}
+          as |buttonGroup|
+        >
+          {{#each shortcutActions as |shortcutAction|}}
+            <buttonGroup.item>
+              <PolarisButton @size="slim" @plain={{persistActions}} @text={{shortcutAction.text}} @accessibilityLabel={{shortcutAction.accessibilityLabel}} @url={{shortcutAction.url}} @external={{shortcutAction.external}} @destructive={{shortcutAction.destructive}} @icon={{shortcutAction.icon}} @loading={{shortcutAction.loading}} @disabled={{shortcutAction.disabled}} @onClick={{action (or shortcutAction.onAction (action (mut dummy)))}} />
+            </buttonGroup.item>
+          {{/each}}
+        </PolarisButtonGroup>
+      </WrapperElement>
+
+      {{#if persistActions}}
+        <WrapperElement @tagName="div" @class="Polaris-ResourceList-Item__Disclosure" @click={{action stopPropagation}}>
+          <PolarisPopover as |popover|>
+            <popover.activator>
+              {{!--
+                Possible mistake in the Polaris source here as
+                `Button` doesn't seem to support `aria-label`.
+                Matching what they do for now, and if they fix
+                it we can update ;)
+              --}}
+              <PolarisButton @aria-label="Actions dropdown" @plain={{true}} @icon="horizontal-dots" @onClick={{action popover.toggle}} />
+            </popover.activator>
+
+            <popover.content>
+              <PolarisActionList @items={{shortcutActions}} />
+            </popover.content>
+          </PolarisPopover>
         </WrapperElement>
       {{/if}}
-
-      {{#if media}}
-        <div class="Polaris-ResourceList-Item__Media" data-test-id="media">
-          {{render-content media}}
-        </div>
-      {{/if}}
-    </div>
-  {{/if}}
-
-  {{#if (or hasBlock children)}}
-    <div class="Polaris-ResourceList-Item__Content">
-      {{#if hasBlock}}
-        {{yield}}
-      {{else}}
-        {{render-content children}}
-      {{/if}}
-    </div>
-  {{/if}}
-
-  {{#if (and shortcutActions (not loading))}}
-    <WrapperElement @tagName="div" @class="Polaris-ResourceList-Item__Actions" @click={{action stopPropagation}}>
-      <PolarisButtonGroup
-        data-test-id={{unless persistActions "shortcut-actions"}}
-        @segmented={{not persistActions}}
-        as |buttonGroup|
-      >
-        {{#each shortcutActions as |shortcutAction|}}
-          <buttonGroup.item>
-            <PolarisButton @size="slim" @plain={{persistActions}} @text={{shortcutAction.text}} @accessibilityLabel={{shortcutAction.accessibilityLabel}} @url={{shortcutAction.url}} @external={{shortcutAction.external}} @destructive={{shortcutAction.destructive}} @icon={{shortcutAction.icon}} @loading={{shortcutAction.loading}} @disabled={{shortcutAction.disabled}} @onClick={{action (or shortcutAction.onAction (action (mut dummy)))}} />
-          </buttonGroup.item>
-        {{/each}}
-      </PolarisButtonGroup>
-    </WrapperElement>
-
-    {{#if persistActions}}
-      <WrapperElement @tagName="div" @class="Polaris-ResourceList-Item__Disclosure" @click={{action stopPropagation}}>
-        <PolarisPopover as |popover|>
-          <popover.activator>
-            {{!--
-              Possible mistake in the Polaris source here as
-              `Button` doesn't seem to support `aria-label`.
-              Matching what they do for now, and if they fix
-              it we can update ;)
-            --}}
-            <PolarisButton @aria-label="Actions dropdown" @plain={{true}} @icon="horizontal-dots" @onClick={{action popover.toggle}} />
-          </popover.activator>
-
-          <popover.content>
-            <PolarisActionList @items={{shortcutActions}} />
-          </popover.content>
-        </PolarisPopover>
-      </WrapperElement>
     {{/if}}
-  {{/if}}
+  </div>
 </div>

--- a/addon/templates/components/polaris-resource-list/item.hbs
+++ b/addon/templates/components/polaris-resource-list/item.hbs
@@ -1,13 +1,14 @@
 <div
   data-test-id="item-wrapper"
-  data-href={{url}}
+  data-href={{@url}}
   class="Polaris-ResourceList-Item
-  {{if focused "Polaris-ResourceList-Item--focused"}}
-  {{if selectable "Polaris-ResourceList-Item--selectable"}}
-  {{if selected "Polaris-ResourceList-Item--selected"}}
-  {{if selectMode "Polaris-ResourceList-Item--selectMode"}}
-  {{if persistActions "Polaris-ResourceList-Item--persistActions"}}
-  {{if focusedInner "Polaris-ResourceList-Item--focusedInner"}}"
+    {{if this.focused "Polaris-ResourceList-Item--focused"}}
+    {{if this.selectable "Polaris-ResourceList-Item--selectable"}}
+    {{if this.selected "Polaris-ResourceList-Item--selected"}}
+    {{if this.selectMode "Polaris-ResourceList-Item--selectMode"}}
+    {{if @persistActions "Polaris-ResourceList-Item--persistActions"}}
+    {{if this.focusedInner "Polaris-ResourceList-Item--focusedInner"}}
+  "
   {{on "click" this.handleClick}}
   {{on "focusin" this.handleFocus}}
   {{on "focusout" this.handleBlur}}
@@ -16,72 +17,118 @@
   {{did-insert this.insertResourceListItem}}
   ...attributes
 >
-  {{#with (if loading "-1" "0") as |tabIndex|}}
-    {{#if url}}
+  {{#with (if @loading "-1" "0") as |tabIndex|}}
+    {{#if @url}}
       <PolarisUnstyledLink
         class="Polaris-ResourceList-Item__Link"
-        @ariaDescribedBy={{itemId}}
-        @ariaLabel={{accessibilityLabel}}
-        @url={{url}}
+        @ariaDescribedBy={{@itemId}}
+        @ariaLabel={{@accessibilityLabel}}
+        @url={{@url}}
         @tabIndex={{tabIndex}}
-        @onFocus={{action handleAnchorFocus}}
-        @onBlur={{action handleFocusedBlur}}
+        @onFocus={{fn this.handleAnchorFocus}}
+        @onBlur={{fn this.handleFocusedBlur}}
       />
     {{else}}
-      <WrapperElement @tagName="button" @class="Polaris-ResourceList-Item__Button" @aria-label={{accessibilityLabel}} @aria-controls={{ariaControls}} @aria-expanded={{ariaExpanded}} @click={{action handleClick}} @focusIn={{action handleAnchorFocus}} @focusOut={{action handleFocusedBlur}} @tabIndex={{tabIndex}} />
+      <WrapperElement
+        class="Polaris-ResourceList-Item__Button"
+        @tagName="button"
+        @aria-label={{@accessibilityLabel}}
+        @aria-controls={{@ariaControls}}
+        @aria-expanded={{@ariaExpanded}}
+        @click={{fn this.handleClick}}
+        @focusIn={{fn this.handleAnchorFocus}}
+        @focusOut={{fn this.handleFocusedBlur}}
+        @tabIndex={{tabIndex}}
+      />
     {{/if}}
   {{/with}}
 
   <div
     data-test-id="item-content"
     class="Polaris-ResourceList-Item__Container"
-    id={{itemId}}
+    id={{@itemId}}
   >
-    {{#if (or media selectable)}}
+    {{#if (or @media this.selectable)}}
       <div class="Polaris-ResourceList-Item__Owned">
-        {{#if selectable}}
-          <WrapperElement @tagName="div" @class="Polaris-ResourceList-Item__Handle" @data-test-id="larger-selection-area" @click={{action handleLargerSelectionArea}}>
-            <WrapperElement @tagName="div" @class="Polaris-ResourceList-Item__CheckboxWrapper" @click={{action stopPropagation}}>
-              <PolarisCheckbox @id={{checkboxId}} @label={{label}} @labelHidden={{true}} @checked={{isSelected}} @disabled={{loading}} @onChange={{action handleSelection}} />
+        {{#if this.selectable}}
+          <WrapperElement
+            class="Polaris-ResourceList-Item__Handle"
+            @tagName="div"
+            @data-test-id="larger-selection-area"
+            @click={{fn this.handleLargerSelectionArea}}
+          >
+            <WrapperElement
+              class="Polaris-ResourceList-Item__CheckboxWrapper"
+              @tagName="div"
+              @click={{fn this.stopPropagation}}
+            >
+              <PolarisCheckbox
+                @id={{this.checkboxId}}
+                @label={{label}}
+                @labelHidden={{true}}
+                @checked={{this.isSelected}}
+                @disabled={{@loading}}
+                @onChange={{fn this.handleSelection}}
+              />
             </WrapperElement>
           </WrapperElement>
         {{/if}}
 
-        {{#if media}}
+        {{#if @media}}
           <div class="Polaris-ResourceList-Item__Media" data-test-id="media">
-            {{render-content media}}
+            {{render-content @media}}
           </div>
         {{/if}}
       </div>
     {{/if}}
 
-    {{#if (or hasBlock children)}}
+    {{#if (or hasBlock @children)}}
       <div class="Polaris-ResourceList-Item__Content">
         {{#if hasBlock}}
           {{yield}}
         {{else}}
-          {{render-content children}}
+          {{render-content @children}}
         {{/if}}
       </div>
     {{/if}}
 
-    {{#if (and shortcutActions (not loading))}}
-      <WrapperElement @tagName="div" @class="Polaris-ResourceList-Item__Actions" @click={{action stopPropagation}}>
+    {{#if (and @shortcutActions (not @loading))}}
+      <WrapperElement
+        class="Polaris-ResourceList-Item__Actions"
+        @tagName="div"
+        @click={{fn this.stopPropagation}}
+      >
         <PolarisButtonGroup
-          data-test-id={{unless persistActions "shortcut-actions"}}
-          @segmented={{not persistActions}}
+          data-test-id={{unless @persistActions "shortcut-actions"}}
+          @segmented={{not @persistActions}}
           as |buttonGroup|
         >
-          {{#each shortcutActions as |shortcutAction|}}
+          {{#each @shortcutActions as |shortcutAction|}}
             <buttonGroup.item>
-              <PolarisButton @size="slim" @plain={{persistActions}} @text={{shortcutAction.text}} @accessibilityLabel={{shortcutAction.accessibilityLabel}} @url={{shortcutAction.url}} @external={{shortcutAction.external}} @destructive={{shortcutAction.destructive}} @icon={{shortcutAction.icon}} @loading={{shortcutAction.loading}} @disabled={{shortcutAction.disabled}} @onClick={{action (or shortcutAction.onAction (action (mut dummy)))}} />
+              <PolarisButton
+                @size="slim"
+                @plain={{@persistActions}}
+                @text={{shortcutAction.text}}
+                @accessibilityLabel={{shortcutAction.accessibilityLabel}}
+                @url={{shortcutAction.url}}
+                @external={{shortcutAction.external}}
+                @destructive={{shortcutAction.destructive}}
+                @icon={{shortcutAction.icon}}
+                @loading={{shortcutAction.loading}}
+                @disabled={{shortcutAction.disabled}}
+                @onClick={{fn (or shortcutAction.onAction (action (mut dummy)))}}
+              />
             </buttonGroup.item>
           {{/each}}
         </PolarisButtonGroup>
       </WrapperElement>
 
-      {{#if persistActions}}
-        <WrapperElement @tagName="div" @class="Polaris-ResourceList-Item__Disclosure" @click={{action stopPropagation}}>
+      {{#if @persistActions}}
+        <WrapperElement
+          class="Polaris-ResourceList-Item__Disclosure"
+          @tagName="div"
+          @click={{fn this.stopPropagation}}
+        >
           <PolarisPopover as |popover|>
             <popover.activator>
               {{!--
@@ -90,11 +137,16 @@
                 Matching what they do for now, and if they fix
                 it we can update ;)
               --}}
-              <PolarisButton @aria-label="Actions dropdown" @plain={{true}} @icon="horizontal-dots" @onClick={{action popover.toggle}} />
+              <PolarisButton
+                aria-label="Actions dropdown"
+                @plain={{true}}
+                @icon="horizontal-dots"
+                @onClick={{fn popover.toggle}}
+              />
             </popover.activator>
 
             <popover.content>
-              <PolarisActionList @items={{shortcutActions}} />
+              <PolarisActionList @items={{@shortcutActions}} />
             </popover.content>
           </PolarisPopover>
         </WrapperElement>

--- a/addon/templates/components/polaris-resource-list/loading-overlay.hbs
+++ b/addon/templates/components/polaris-resource-list/loading-overlay.hbs
@@ -1,6 +1,6 @@
-{{#if loading}}
-  <div class="Polaris-ResourceList__SpinnerContainer" style={{spinnerStyle}}>
-    <PolarisSpinner @accessibilityLabel="Items are loading" @size={{spinnerSize}} />
+{{#if @loading}}
+  <div class="Polaris-ResourceList__SpinnerContainer" style={{@spinnerStyle}}>
+    <PolarisSpinner @accessibilityLabel="Items are loading" @size={{@spinnerSize}} />
   </div>
   <div class="Polaris-ResourceList__LoadingOverlay"></div>
 {{/if}}

--- a/addon/templates/components/polaris-resource-list/loading-overlay.hbs
+++ b/addon/templates/components/polaris-resource-list/loading-overlay.hbs
@@ -1,9 +1,6 @@
 {{#if loading}}
   <div class="Polaris-ResourceList__SpinnerContainer" style={{spinnerStyle}}>
-    {{polaris-spinner
-      accessibilityLabel="Items are loading"
-      size=spinnerSize
-    }}
+    <PolarisSpinner @accessibilityLabel="Items are loading" @size={{spinnerSize}} />
   </div>
   <div class="Polaris-ResourceList__LoadingOverlay"></div>
 {{/if}}


### PR DESCRIPTION
[DEV-78](https://smileio.atlassian.net/secure/RapidBoard.jspa?rapidView=6&modal=detail&selectedIssue=DEV-78)

Updates `PolarisResourceList` and all sub-components to tagless component, ES6 classes, and angle bracket syntax.

Notable changes:
- Removed `wrapperId` from the main `polaris-resource-list` component. It was only used as a selector in order to set the `listNode` attribute (`ul.Polaris-ResourceList`). This was breaking in tests because the `ul` wasn't rendered yet when setting the node in the component file, so instead I added a `{{did-insert this.insertListNode}}` on the `ul` itself and set the reference directly in there.
- Used the `(element)` template helper in favor of our `WrapperElement` component wherever I could.

Dummy app:

![list](https://user-images.githubusercontent.com/2292367/74380776-d7998700-4daf-11ea-8c85-15ba7d35b317.gif)
