### PR TITLE
Modernize polaris-link component

### DIFF
--- a/addon/components/polaris-link.js
+++ b/addon/components/polaris-link.js
@@ -1,17 +1,15 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
+import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../templates/components/polaris-link';
 
 /**
  * Polaris link component.
  * See https://polaris.shopify.com/components/navigation/link
  */
-export default Component.extend({
-  // No tag since we dynamically render either an anchor or a button element.
-  tagName: '',
-
-  layout,
-
+@tagName('')
+@templateLayout(layout)
+export default class PolarisLink extends Component {
   /**
    * The url to link to
    *
@@ -20,7 +18,7 @@ export default Component.extend({
    * @default null
    * @public
    */
-  url: null,
+  url = null;
 
   /**
    * The content to display inside link
@@ -30,7 +28,7 @@ export default Component.extend({
    * @default null
    * @public
    */
-  text: null,
+  text = null;
 
   /**
    * Use for a links that open a different site
@@ -40,7 +38,7 @@ export default Component.extend({
    * @default false
    * @public
    */
-  external: false,
+  external = false;
 
   /**
    * Makes the link color the same as the current text color and adds an underline
@@ -50,7 +48,7 @@ export default Component.extend({
    * @default false
    * @public
    */
-  monochrome: false,
+  monochrome = false;
 
   /**
    * Callback when a link is clicked
@@ -60,23 +58,24 @@ export default Component.extend({
    * @default noop
    * @public
    */
-  onClick() {},
+  onClick() {}
 
   /**
    * @private
    */
-  linkClass: computed('class', function() {
+  @(computed('class').readOnly())
+  get linkClass() {
     let linkClasses = ['Polaris-Link'];
 
     if (this.get('monochrome')) {
       linkClasses.push('Polaris-Link--monochrome');
     }
 
-    const externalClasses = this.get('class');
+    const externalClasses = this.class;
     if (externalClasses) {
       linkClasses.push(externalClasses);
     }
 
     return linkClasses.join(' ');
-  }).readOnly(),
-});
+  }
+}

--- a/addon/templates/components/polaris-link.hbs
+++ b/addon/templates/components/polaris-link.hbs
@@ -1,26 +1,26 @@
-{{#if url}}
+{{#if @url}}
   <PolarisUnstyledLink
-    class={{linkClass}}
-    @url={{url}}
-    @external={{external}}
-    @onClick={{action onClick}}
+    class={{this.linkClass}}
+    @url={{@url}}
+    @external={{@external}}
+    @onClick={{fn (or @onClick this.onClick)}}
   >
     {{#if hasBlock}}
       {{yield}}
     {{else}}
-      {{text}}
+      {{@text}}
     {{/if}}
   </PolarisUnstyledLink>
 {{else}}
   <button
     type="button"
-    class={{linkClass}}
-    {{action (action onClick) bubbles=false}}
+    class={{this.linkClass}}
+    {{on "click" (stop-propagation (or @onClick this.onClick))}}
   >
     {{#if hasBlock}}
       {{yield}}
     {{else}}
-      {{text}}
+      {{@text}}
     {{/if}}
   </button>
 {{/if}}

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "ember-cli-uglify": "^3.0.0",
     "ember-decorators": "^6.0.0",
     "ember-disable-prototype-extensions": "^1.1.3",
+    "ember-event-helpers": "^0.1.0",
     "ember-fn-helper-polyfill": "^1.0.2",
     "ember-load-initializers": "^2.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5066,6 +5066,13 @@ ember-element-helper@^0.1.1:
   dependencies:
     ember-cli-babel "^6.16.0"
 
+ember-event-helpers@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ember-event-helpers/-/ember-event-helpers-0.1.0.tgz#4b7f49f136b660df21731a9e0329507c0816438e"
+  integrity sha512-JdsYPmW0g0LLKmdRGxS9lRIdtB1Swc7Asr0XmUwhkjbFY40bfB0wlQ8P2yA3YLqbP/ToShBitN62t9Cy4PTazQ==
+  dependencies:
+    ember-cli-babel "^7.7.3"
+
 ember-fn-helper-polyfill@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ember-fn-helper-polyfill/-/ember-fn-helper-polyfill-1.0.2.tgz#deb035fced77f98b9256ba4eb17694b7a2e2a526"


### PR DESCRIPTION
[DEV-69](https://smileio.atlassian.net/secure/RapidBoard.jspa?rapidView=6&modal=detail&selectedIssue=DEV-69)

Updates `PolarisLink` to tagless component, ES6 classes, and angle bracket syntax.

Notable change:
- Added `ember-event-helpers` to use with the `on` modifier so we can stop propagation via template helper.

