### PR TITLE
Modernize polaris-popover components

### DIFF
--- a/addon/components/polaris-popover.js
+++ b/addon/components/polaris-popover.js
@@ -121,8 +121,22 @@ export default class PolarisPopover extends Component {
   /**
    * @private
    */
+  triggerStyle = htmlSafe(`
+    display: inline-block;
+    overflow: inherit;
+    border: none;
+  `);
+
+  /**
+   * @private
+   */
   @computed('preferredPosition')
   get verticalPosition() {
+    // If `preferredPosition` is set to `mostSpace`, the value
+    // will be calculated and set when the user opens the popover.
+    // The only allowed values are 'above' and 'below', so we
+    // return null for anything other than those values and let
+    // ember-basic-dropdown use its default value.
     let { preferredPosition } = this;
 
     if (preferredPosition === ABOVE || preferredPosition === BELOW) {
@@ -138,18 +152,6 @@ export default class PolarisPopover extends Component {
     }
 
     return null;
-  }
-
-  /**
-   * @private
-   */
-  @computed
-  get triggerStyle() {
-    return htmlSafe(`
-      display: inline-block;
-      overflow: inherit;
-      border: none;
-    `);
   }
 
   /**

--- a/addon/components/polaris-popover.js
+++ b/addon/components/polaris-popover.js
@@ -1,8 +1,9 @@
-import Ember from 'ember';
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { action, computed } from '@ember/object';
+import Ember from 'ember';
 import { htmlSafe } from '@ember/string';
 import { warn } from '@ember/debug';
+import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import { getRectForNode } from '@shopify/javascript-utilities/geometry';
 import layout from '../templates/components/polaris-popover';
 
@@ -14,11 +15,9 @@ const BELOW = 'below';
  * Polaris popover component.
  * See https://polaris.shopify.com/components/overlays/popover
  */
-export default Component.extend({
-  tagName: '',
-
-  layout,
-
+@tagName('')
+@templateLayout(layout)
+export default class PolarisPopover extends Component {
   /**
    * The content to display inside the popover
    *
@@ -31,7 +30,7 @@ export default Component.extend({
    * @default null
    * @public
    */
-  text: null,
+  text = null;
 
   /**
    * The preferred direction to open the popover
@@ -41,7 +40,7 @@ export default Component.extend({
    * @default 'below'
    * @public
    */
-  preferredPosition: BELOW,
+  preferredPosition = BELOW;
 
   /**
    * Show or hide the Popover
@@ -53,7 +52,7 @@ export default Component.extend({
    * @default false
    * @public
    */
-  active: false,
+  active = false;
 
   /**
    * The element type to wrap the activator with
@@ -65,7 +64,7 @@ export default Component.extend({
    * @default null
    * @public
    */
-  activatorWrapper: null,
+  activatorWrapper = null;
 
   /**
    * Prevent automatic focus of the first field on activation
@@ -77,7 +76,7 @@ export default Component.extend({
    * @default false
    * @public
    */
-  preventAutofocus: false,
+  preventAutofocus = false;
 
   /**
    * Automatically add wrap content in a section
@@ -87,7 +86,7 @@ export default Component.extend({
    * @default false
    * @public
    */
-  sectioned: false,
+  sectioned = false;
 
   /**
    * Allow popover to stretch to the full width of its activator
@@ -97,7 +96,7 @@ export default Component.extend({
    * @default false
    * @public
    */
-  fullWidth: false,
+  fullWidth = false;
 
   /**
    * Allow popover to stretch to fit content vertically
@@ -107,7 +106,7 @@ export default Component.extend({
    * @default false
    * @public
    */
-  fullHeight: false,
+  fullHeight = false;
 
   /**
    * Callback when popover is closed
@@ -117,46 +116,41 @@ export default Component.extend({
    * @default noop
    * @public
    */
-  onClose() {},
+  onClose() {}
 
   /**
    * @private
    */
-  verticalPosition: computed('preferredPosition', {
-    // If `preferredPosition` is set to `mostSpace`, the value
-    // will be calculated and set when the user opens the popover.
-    // The only allowed values are 'above' and 'below', so we
-    // return null for anything other than those values and let
-    // ember-basic-dropdown use its default value.
-    get() {
-      let preferredPosition = this.get('preferredPosition');
+  @computed('preferredPosition')
+  get verticalPosition() {
+    let preferredPosition = this.get('preferredPosition');
 
-      if (preferredPosition === ABOVE || preferredPosition === BELOW) {
-        return preferredPosition;
-      }
+    if (preferredPosition === ABOVE || preferredPosition === BELOW) {
+      return preferredPosition;
+    }
 
-      return null;
-    },
+    return null;
+  }
 
-    set(key, value) {
-      if (value === ABOVE || value === BELOW) {
-        return value;
-      }
+  set verticalPosition(value) {
+    if (value === ABOVE || value === BELOW) {
+      return value;
+    }
 
-      return null;
-    },
-  }),
+    return null;
+  }
 
   /**
    * @private
    */
-  triggerStyle: computed(function() {
+  @(computed.readOnly())
+  get triggerStyle() {
     return htmlSafe(`
       display: inline-block;
       overflow: inherit;
       border: none;
     `);
-  }).readOnly(),
+  }
 
   /**
    * Checks the dropdown activator's location on
@@ -198,18 +192,17 @@ export default Component.extend({
 
     // Use `below` if distance is equal
     return bottomSpace >= top ? BELOW : ABOVE;
-  },
+  }
 
-  actions: {
-    onOpen() {
-      // Check to see if `preferredPosition` is set to `mostSpace`
-      // onOpen, since user could have scrolled vertically since
-      // the time the component originally rendered.
-      let preferredPosition = this.get('preferredPosition');
+  @action
+  onOpen() {
+    // Check to see if `preferredPosition` is set to `mostSpace`
+    // onOpen, since user could have scrolled vertically since
+    // the time the component originally rendered.
+    let preferredPosition = this.get('preferredPosition');
 
-      if (preferredPosition === 'mostSpace') {
-        this.set('verticalPosition', this.getMostVerticalSpace());
-      }
-    },
-  },
-});
+    if (preferredPosition === 'mostSpace') {
+      this.set('verticalPosition', this.getMostVerticalSpace());
+    }
+  }
+}

--- a/addon/components/polaris-popover.js
+++ b/addon/components/polaris-popover.js
@@ -123,7 +123,7 @@ export default class PolarisPopover extends Component {
    */
   @computed('preferredPosition')
   get verticalPosition() {
-    let preferredPosition = this.get('preferredPosition');
+    let { preferredPosition } = this;
 
     if (preferredPosition === ABOVE || preferredPosition === BELOW) {
       return preferredPosition;
@@ -143,7 +143,7 @@ export default class PolarisPopover extends Component {
   /**
    * @private
    */
-  @(computed.readOnly())
+  @computed
   get triggerStyle() {
     return htmlSafe(`
       display: inline-block;
@@ -199,9 +199,7 @@ export default class PolarisPopover extends Component {
     // Check to see if `preferredPosition` is set to `mostSpace`
     // onOpen, since user could have scrolled vertically since
     // the time the component originally rendered.
-    let preferredPosition = this.get('preferredPosition');
-
-    if (preferredPosition === 'mostSpace') {
+    if (this.preferredPosition === 'mostSpace') {
       this.set('verticalPosition', this.getMostVerticalSpace());
     }
   }

--- a/addon/components/polaris-popover/content.js
+++ b/addon/components/polaris-popover/content.js
@@ -1,72 +1,71 @@
 import Component from '@ember/component';
+import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../templates/components/polaris-popover/content';
 
-export default Component.extend({
-  tagName: '',
+@tagName('')
+@templateLayout(layout)
+export default class Content extends Component {
+ /**
+  * Automatically add wrap content in a section
+  *
+  * @property sectioned
+  * @type {Boolean}
+  * @default false
+  * @public
+  */
+ sectioned = false;
 
-  layout,
+ /**
+  * Allow popover to stretch to the full width of its activator
+  *
+  * @property fullWidth
+  * @type {Boolean}
+  * @default false
+  * @public
+  */
+ fullWidth = false;
 
-  /**
-   * Automatically add wrap content in a section
-   *
-   * @property sectioned
-   * @type {Boolean}
-   * @default false
-   * @public
-   */
-  sectioned: false,
+ /**
+  * Allow popover to stretch to fit content vertically
+  *
+  * @property fullHeight
+  * @type {Boolean}
+  * @default false
+  * @public
+  */
+ fullHeight = false;
 
-  /**
-   * Allow popover to stretch to the full width of its activator
-   *
-   * @property fullWidth
-   * @type {Boolean}
-   * @default false
-   * @public
-   */
-  fullWidth: false,
+ /**
+  * Content wrapper component.
+  *
+  * @property contentComponent
+  * @type {Component}
+  * @default: null
+  * @public
+  */
+ contentComponent = null;
 
-  /**
-   * Allow popover to stretch to fit content vertically
-   *
-   * @property fullHeight
-   * @type {Boolean}
-   * @default false
-   * @public
-   */
-  fullHeight: false,
+ /**
+  * Simple text for quick popovers.
+  *
+  * This component can be used in block form,
+  * in which case the block content will be used
+  * instead of `text`
+  *
+  * @property text
+  * @type {String}
+  * @default null
+  * @public
+  */
+ text = null;
 
-  /**
-   * Content wrapper component.
-   *
-   * @property contentComponent
-   * @type {Component}
-   * @default: null
-   * @public
-   */
-  contentComponent: null,
-
-  /**
-   * Simple text for quick popovers.
-   *
-   * This component can be used in block form,
-   * in which case the block content will be used
-   * instead of `text`
-   *
-   * @property text
-   * @type {String}
-   * @default null
-   * @public
-   */
-  text: null,
-
-  /**
-   * `ember-basic-dropdown`'s generated ID, used to look up
-   *
-   * @property uniqueId
-   * @type {String}
-   * @default: null
-   * @public
-   */
-  uniqueId: null,
-});
+ /**
+  * `ember-basic-dropdown`'s generated ID, used to look up
+  *
+  * @property uniqueId
+  * @type {String}
+  * @default: null
+  * @public
+  */
+ uniqueId = null;
+}

--- a/addon/components/polaris-popover/content.js
+++ b/addon/components/polaris-popover/content.js
@@ -5,67 +5,67 @@ import layout from '../../templates/components/polaris-popover/content';
 @tagName('')
 @templateLayout(layout)
 export default class Content extends Component {
- /**
-  * Automatically add wrap content in a section
-  *
-  * @property sectioned
-  * @type {Boolean}
-  * @default false
-  * @public
-  */
- sectioned = false;
+  /**
+   * Automatically add wrap content in a section
+   *
+   * @property sectioned
+   * @type {Boolean}
+   * @default false
+   * @public
+   */
+  sectioned = false;
 
- /**
-  * Allow popover to stretch to the full width of its activator
-  *
-  * @property fullWidth
-  * @type {Boolean}
-  * @default false
-  * @public
-  */
- fullWidth = false;
+  /**
+   * Allow popover to stretch to the full width of its activator
+   *
+   * @property fullWidth
+   * @type {Boolean}
+   * @default false
+   * @public
+   */
+  fullWidth = false;
 
- /**
-  * Allow popover to stretch to fit content vertically
-  *
-  * @property fullHeight
-  * @type {Boolean}
-  * @default false
-  * @public
-  */
- fullHeight = false;
+  /**
+   * Allow popover to stretch to fit content vertically
+   *
+   * @property fullHeight
+   * @type {Boolean}
+   * @default false
+   * @public
+   */
+  fullHeight = false;
 
- /**
-  * Content wrapper component.
-  *
-  * @property contentComponent
-  * @type {Component}
-  * @default: null
-  * @public
-  */
- contentComponent = null;
+  /**
+   * Content wrapper component.
+   *
+   * @property contentComponent
+   * @type {Component}
+   * @default: null
+   * @public
+   */
+  contentComponent = null;
 
- /**
-  * Simple text for quick popovers.
-  *
-  * This component can be used in block form,
-  * in which case the block content will be used
-  * instead of `text`
-  *
-  * @property text
-  * @type {String}
-  * @default null
-  * @public
-  */
- text = null;
+  /**
+   * Simple text for quick popovers.
+   *
+   * This component can be used in block form,
+   * in which case the block content will be used
+   * instead of `text`
+   *
+   * @property text
+   * @type {String}
+   * @default null
+   * @public
+   */
+  text = null;
 
- /**
-  * `ember-basic-dropdown`'s generated ID, used to look up
-  *
-  * @property uniqueId
-  * @type {String}
-  * @default: null
-  * @public
-  */
- uniqueId = null;
+  /**
+   * `ember-basic-dropdown`'s generated ID, used to look up
+   *
+   * @property uniqueId
+   * @type {String}
+   * @default: null
+   * @public
+   */
+  uniqueId = null;
 }

--- a/addon/templates/components/polaris-popover.hbs
+++ b/addon/templates/components/polaris-popover.hbs
@@ -1,9 +1,4 @@
-{{#basic-dropdown
-  verticalPosition=verticalPosition
-  onOpen=(action "onOpen")
-  onClose=(action onClose)
-  as |dd|
-}}
+<BasicDropdown @verticalPosition={{verticalPosition}} @onOpen={{action "onOpen"}} @onClose={{action onClose}} as |dd|>
   {{yield
     (hash
       activator=(component dd.trigger style=triggerStyle)
@@ -19,4 +14,4 @@
       toggle=(action dd.actions.toggle)
     )
   }}
-{{/basic-dropdown}}
+</BasicDropdown>

--- a/addon/templates/components/polaris-popover.hbs
+++ b/addon/templates/components/polaris-popover.hbs
@@ -1,17 +1,22 @@
-<BasicDropdown @verticalPosition={{verticalPosition}} @onOpen={{action "onOpen"}} @onClose={{action onClose}} as |dd|>
+<BasicDropdown
+  @verticalPosition={{this.verticalPosition}}
+  @onOpen={{fn this.onOpen}}
+  @onClose={{fn (or @onClose this.onClose)}}
+  as |dd|
+>
   {{yield
     (hash
-      activator=(component dd.trigger style=triggerStyle)
+      activator=(component dd.trigger style=this.triggerStyle)
       content=(component "polaris-popover/content"
         contentComponent=dd.content
         uniqueId=dd.uniqueId
-        sectioned=sectioned
-        fullWidth=fullWidth
-        fullHeight=fullHeight
+        sectioned=@sectioned
+        fullWidth=@fullWidth
+        fullHeight=@fullHeight
       )
-      open=(action dd.actions.open)
-      close=(action dd.actions.close)
-      toggle=(action dd.actions.toggle)
+      open=(fn dd.actions.open)
+      close=(fn dd.actions.close)
+      toggle=(fn dd.actions.toggle)
     )
   }}
 </BasicDropdown>

--- a/addon/templates/components/polaris-popover/content.hbs
+++ b/addon/templates/components/polaris-popover/content.hbs
@@ -1,10 +1,10 @@
-{{#if contentComponent}}
-  {{#component contentComponent class="Polaris-PositionedOverlay"}}
+{{#if @contentComponent}}
+  {{#component @contentComponent class="Polaris-PositionedOverlay"}}
     <div
       data-polaris-overlay="true"
       class="
         Polaris-Popover
-        {{if fullWidth "Polaris-Popover--fullWidth"}}
+        {{if @fullWidth "Polaris-Popover--fullWidth"}}
       "
     >
       <div class="Polaris-Popover__Tip"></div>
@@ -12,25 +12,25 @@
       <div class="Polaris-Popover__Wrapper">
         <div
           tabindex="-1"
-          class="Polaris-Popover__Content {{if fullHeight "Polaris-Popover__Content--fullHeight"}}"
+          class="Polaris-Popover__Content {{if @fullHeight "Polaris-Popover__Content--fullHeight"}}"
         >
           <div
             class="Polaris-Popover__Pane Polaris-Scrollable Polaris-Scrollable--vertical"
             data-polaris-scrollable="true"
           >
-            {{#if sectioned}}
+            {{#if @sectioned}}
               <div class="Polaris-Popover__Section">
                 {{#if hasBlock}}
                   {{yield}}
                 {{else}}
-                  {{text}}
+                  {{@text}}
                 {{/if}}
               </div>
             {{else}}
               {{#if hasBlock}}
                 {{yield}}
               {{else}}
-                {{text}}
+                {{@text}}
               {{/if}}
             {{/if}}
           </div>


### PR DESCRIPTION
[DEV-74](https://smileio.atlassian.net/secure/RapidBoard.jspa?rapidView=6&modal=detail&selectedIssue=DEV-74)

Updates `PolarisPopover` and subcomponent to tagless components, ES6 classes, and angle bracket syntax.

Dummy app:

![popover](https://user-images.githubusercontent.com/2292367/74762626-d7800800-5243-11ea-939b-723e8e59bd7e.gif)
