### PR TITLE
Modernize display-text component

### DIFF
--- a/addon/components/polaris-display-text.js
+++ b/addon/components/polaris-display-text.js
@@ -12,15 +12,25 @@ import layout from '../templates/components/polaris-display-text';
  *
  *   {{polaris-display-text text="This is some text"}}
  *
- * Customised block usage (note the use of tagName instead of element - this is an ember thing):
+ * Customised block usage (note the use of htmlTag instead of element - this is an ember thing):
  *
- *   {{#polaris-display-text tagName="h1" size="extraLarge"}}
+ *   {{#polaris-display-text htmlTag="h1" size="extraLarge"}}
  *     This is some BIG text
  *   {{/polaris-display-text}}
  */
 @tagName('')
 @templateLayout(layout)
 export default class PolarisDisplayText extends Component {
+  /**
+   * Name of element to use for text
+   * NOTE: Matches polaris-react's `element`
+   *
+   * @type {String}
+   * @default p
+   * @public
+   */
+  htmlTag = 'p';
+
   /**
    * Size of the text
    *

--- a/addon/components/polaris-display-text.js
+++ b/addon/components/polaris-display-text.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { classify } from '@ember/string';
+import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../templates/components/polaris-display-text';
 
 /**
@@ -17,22 +18,17 @@ import layout from '../templates/components/polaris-display-text';
  *     This is some BIG text
  *   {{/polaris-display-text}}
  */
-export default Component.extend({
-  tagName: 'p',
-  classNames: ['Polaris-DisplayText'],
-  classNameBindings: ['sizeClassName'],
-
-  layout,
-
+@tagName('')
+@templateLayout(layout)
+export default class PolarisDisplayText extends Component {
   /**
    * Size of the text
    *
-   * @property size
    * @type {String}
    * @default medium
    * @public
    */
-  size: 'medium',
+  size = 'medium';
 
   /**
    * Content to display
@@ -41,20 +37,14 @@ export default Component.extend({
    * in which case the block content will be used
    * instead of `text`
    *
-   * @property text
    * @type {String}
    * @default null
    * @public
    */
-  text: null,
+  text = null;
 
-  'data-test-display-text': true,
-
-  /**
-   * @private
-   */
-  sizeClassName: computed('size', function() {
-    const size = this.get('size');
-    return `Polaris-DisplayText--size${classify(size)}`;
-  }).readOnly(),
-});
+  @computed('size')
+  get sizeClassName() {
+    return `Polaris-DisplayText--size${classify(this.size)}`;
+  }
+}

--- a/addon/templates/components/polaris-display-text.hbs
+++ b/addon/templates/components/polaris-display-text.hbs
@@ -1,4 +1,4 @@
-{{#let (element (or @tagName "p")) as |DisplayText|}}
+{{#let (element (or @htmlTag "p")) as |DisplayText|}}
   <DisplayText
     class="Polaris-DisplayText {{this.sizeClassName}}"
     data-test-display-text

--- a/addon/templates/components/polaris-display-text.hbs
+++ b/addon/templates/components/polaris-display-text.hbs
@@ -1,5 +1,13 @@
-{{#if hasBlock}}
-  {{yield}}
-{{else}}
-  {{text}}
-{{/if}}
+{{#let (element (or @tagName "p")) as |DisplayText|}}
+  <DisplayText
+    class="Polaris-DisplayText {{this.sizeClassName}}"
+    data-test-display-text
+    ...attributes
+  >
+    {{#if hasBlock}}
+      {{yield}}
+    {{else}}
+      {{@text}}
+    {{/if}}
+  </DisplayText>
+{{/let}}

--- a/addon/templates/components/polaris-drop-zone.hbs
+++ b/addon/templates/components/polaris-drop-zone.hbs
@@ -29,7 +29,7 @@
             {{#if (eq this.state.size "extraLarge")}}
               <PolarisDisplayText
                 @size="small"
-                @tagName="p"
+                @htmlTag="p"
                 @text={{this.state.overlayText}}
               />
             {{else if (or (eq this.state.size "medium") (eq this.state.size "large"))}}
@@ -47,7 +47,7 @@
             {{#if (eq this.state.size "extraLarge")}}
               <PolarisDisplayText
                 @size="small"
-                @tagName="p"
+                @htmlTag="p"
                 @text={{this.state.errorOverlayText}}
               />
             {{else if (or (eq this.state.size "medium") (eq this.state.size "large"))}}

--- a/addon/templates/components/polaris-empty-state/details.hbs
+++ b/addon/templates/components/polaris-empty-state/details.hbs
@@ -3,7 +3,7 @@
   data-test-empty-state-details
 >
   <PolarisTextContainer>
-    <PolarisDisplayText @data-test-empty-state-heading={{true}} @size="medium" @text={{@heading}} />
+    <PolarisDisplayText data-test-empty-state-heading @size="medium" @text={{@heading}} />
     <div data-test-empty-state-content class="Polaris-EmptyState__Content">
       {{#if hasBlock}}
         {{yield}}

--- a/addon/templates/components/polaris-page/header.hbs
+++ b/addon/templates/components/polaris-page/header.hbs
@@ -38,7 +38,7 @@
           <div class="Polaris-Page-Header__Title">
             <div>
               <PolarisDisplayText
-                @tagName="h1"
+                @htmlTag="h1"
                 @size="large"
                 @text={{@title}}
               />

--- a/addon/templates/components/polaris-skeleton-page.hbs
+++ b/addon/templates/components/polaris-skeleton-page.hbs
@@ -2,7 +2,7 @@
   class={{this.classes}}
   aria-label={{this.ariaLabel}}
   role={{this.role}}
-  data-test-skeleton-page={{true}}
+  data-test-skeleton-page
   ...attributes
 >
   <div
@@ -22,7 +22,7 @@
       >
         <PolarisSkeletonBodyText
           @lines={{1}}
-          data-test-skeleton-page-breadcrumb={{true}}
+          data-test-skeleton-page-breadcrumb
         />
       </div>
     {{/if}}
@@ -35,14 +35,14 @@
         {{#if this.hasTitle}}
           {{#if this.hasTitleText}}
             <PolarisDisplayText
-              data-test-skeleton-page-title-text={{true}}
-              @tagName="h1"
+              data-test-skeleton-page-title-text
+              @htmlTag="h1"
               @size="large"
               @text={{or @title ""}}
             />
           {{else}}
             <PolarisSkeletonDisplayText
-              data-test-skeleton-page-title-text={{true}}
+              data-test-skeleton-page-title-text
               @size="large"
             />
           {{/if}}
@@ -62,7 +62,7 @@
     {{#if this.dummySecondaryActions}}
       <div class="Polaris-SkeletonPage__Actions" data-test-skeleton-page-actions>
         {{#each this.dummySecondaryActions}}
-          <PolarisSkeletonPage::Action data-test-skeleton-page-action={{true}} />
+          <PolarisSkeletonPage::Action data-test-skeleton-page-action />
         {{/each}}
       </div>
     {{/if}}

--- a/docs/display-text.md
+++ b/docs/display-text.md
@@ -18,7 +18,7 @@ Extra-large heading:
 
 ```hbs
 {{#polaris-display-text
-  tagName="h1"
+  htmlTag="h1"
   size="extraLarge"
 }}
   This is a LARGE heading

--- a/tests/integration/components/polaris-display-text-test.js
+++ b/tests/integration/components/polaris-display-text-test.js
@@ -25,7 +25,7 @@ module('Integration | Component | polaris display text', function(hooks) {
 
     // Block form with element and size specified.
     await render(hbs`
-      {{#polaris-display-text tagName="h3" size="extraLarge"}}
+      {{#polaris-display-text htmlTag="h3" size="extraLarge"}}
         This is some BIG text
       {{/polaris-display-text}}
     `);


### PR DESCRIPTION
## 💣 Breaking

We rename here `tagName` -> `htmlTag` (as a match for `polaris-react`'s `element` property), because using `tagName` with angle-bracket syntax seems to result in adding an extra wrapper with `tagName` around the component.