### PR TITLE
Misc updates for v6

### DIFF
--- a/addon/components/component-proxy.js
+++ b/addon/components/component-proxy.js
@@ -23,10 +23,7 @@ export default Component.extend({
    * @private
    */
   layout: computed('componentName', 'propsString', function() {
-    let { componentName, propsString } = this.getProperties(
-      'componentName',
-      'propsString'
-    );
+    let { componentName, propsString } = this;
 
     return compile(`
       {{#if hasBlock}}
@@ -67,7 +64,7 @@ export default Component.extend({
    * @private
    */
   propsString: computed('propNames.[]', function() {
-    let propNames = this.get('propNames') || [];
+    let propNames = this.propNames || [];
     return propNames.reduce((propsString, propName) => {
       return `${propsString} ${propName}=${propName}`;
     }, '');
@@ -77,8 +74,8 @@ export default Component.extend({
     // Unset any properties that were set previously and are now undefined,
     // spread the new passed-in props hash into our component's context,
     // and make a note of which properties are currently set.
-    let oldPropNames = this.get('propNames') || [];
-    let props = this.get('props') || {};
+    let oldPropNames = this.propNames || [];
+    let props = this.props || {};
     let propNames = Object.keys(props);
 
     let propsToUnset = oldPropNames.reduce((propsToUnset, propName) => {

--- a/addon/components/polaris-action-list.js
+++ b/addon/components/polaris-action-list.js
@@ -18,19 +18,19 @@ export default class PolarisActionList extends Component {
    * Collection of actions for list
    *
    * @type {Array}
-   * @default null
+   * @default []
    * @public
    */
-  items = null;
+  items = [];
 
   /**
    * Collection of sectioned action items
    *
    * @type {Array}
-   * @default null
+   * @default []
    * @public
    */
-  sections = null;
+  sections = [];
 
   /**
    * Defines a specific role attribute for each action in the list
@@ -63,12 +63,12 @@ export default class PolarisActionList extends Component {
   get finalSections() {
     let finalSections = [];
 
-    let items = this.get('items');
+    let { items } = this;
     if (isPresent(items)) {
       finalSections.push({ items });
     }
 
-    let sections = this.get('sections') || [];
+    let { sections } = this;
     assert(
       `ember-polaris::polaris-action-list - sections must be an array, you passed ${sections}`,
       isArray(sections)

--- a/addon/components/polaris-action-list/item.js
+++ b/addon/components/polaris-action-list/item.js
@@ -119,7 +119,7 @@ export default class PolarisActionListItem extends Component {
 
   @computed('image')
   get imageBackgroundStyle() {
-    let url = this.get('image');
+    let { image: url } = this;
     return url ? htmlSafe(`background-image: url(${url})`) : '';
   }
 }

--- a/addon/components/polaris-avatar.js
+++ b/addon/components/polaris-avatar.js
@@ -246,7 +246,7 @@ export default class PolarisAvatar extends Component {
       !this.class,
       {
         id: 'ember-polaris.polaris-avatar.class-arg',
-        until: '6.0.0',
+        until: '7.0.0',
       }
     );
   }

--- a/addon/components/polaris-avatar.js
+++ b/addon/components/polaris-avatar.js
@@ -162,7 +162,7 @@ export default class PolarisAvatar extends Component {
    */
   @computed('nameString')
   get styleClass() {
-    let nameString = this.get('nameString');
+    let { nameString } = this;
     let styleIndex = isEmpty(nameString)
       ? 0
       : nameString.charCodeAt(0) % styleClasses.length;
@@ -178,7 +178,7 @@ export default class PolarisAvatar extends Component {
    */
   @computed('size')
   get sizeClass() {
-    let size = this.get('size');
+    let { size } = this;
     if (allowedSizes.indexOf(size) === -1) {
       size = defaultSize;
     }
@@ -194,7 +194,6 @@ export default class PolarisAvatar extends Component {
   @computed('hasImage', 'hasLoaded')
   get hiddenClass() {
     let { hasImage, hasLoaded } = this;
-
     return hasImage && !hasLoaded ? 'Polaris-Avatar--hidden' : null;
   }
 
@@ -205,15 +204,15 @@ export default class PolarisAvatar extends Component {
    */
   @computed('avatarSourcePath', 'customer', 'nameString')
   get customerImageSource() {
-    if (!this.get('customer')) {
+    if (!this.customer) {
       return null;
     }
 
-    let nameString = this.get('nameString');
+    let { nameString } = this;
     let avatarIndex = isEmpty(nameString)
       ? 0
       : nameString.charCodeAt(0) % avatarImages.length;
-    return `${this.get('avatarSourcePath')}/avatar-${++avatarIndex}.svg`;
+    return `${this.avatarSourcePath}/avatar-${++avatarIndex}.svg`;
   }
 
   /**

--- a/addon/components/polaris-badge.js
+++ b/addon/components/polaris-badge.js
@@ -139,7 +139,7 @@ export default class PolarisBadge extends Component {
       !this.class,
       {
         id: 'ember-polaris.polaris-badge.class-arg',
-        until: '6.0.0',
+        until: '7.0.0',
       }
     );
   }

--- a/addon/components/polaris-breadcrumbs.js
+++ b/addon/components/polaris-breadcrumbs.js
@@ -41,7 +41,7 @@ export default class PolarisBreadcrumbs extends Component {
       !this.class,
       {
         id: 'ember-polaris.polaris-breadcrumbs.class-arg',
-        until: '6.0.0',
+        until: '7.0.0',
       }
     );
   }

--- a/addon/components/polaris-button.js
+++ b/addon/components/polaris-button.js
@@ -394,7 +394,7 @@ export default class PolarisButtonComponent extends Component {
       !this.externalClasses,
       {
         id: 'ember-polaris.polaris-button.externalClasses-arg',
-        until: '6.0.0',
+        until: '7.0.0',
       }
     );
   }

--- a/addon/components/polaris-checkbox.js
+++ b/addon/components/polaris-checkbox.js
@@ -2,7 +2,6 @@ import Component from '@ember/component';
 import { action, computed } from '@ember/object';
 import { equal } from '@ember/object/computed';
 import { guidFor } from '@ember/object/internals';
-import { deprecate } from '@ember/debug';
 import { tagName, layout } from '@ember-decorators/component';
 import template from '../templates/components/polaris-checkbox';
 
@@ -21,18 +20,6 @@ export default class PolarisCheckbox extends Component {
    * @public
    */
   label = null;
-
-  /**
-   * Component to render for the checkbox's label
-   *
-   * DEPRECATED: pass the component as `label` instead.
-   *
-   * @type {String | Component}
-   * @default null
-   * @deprecated
-   * @public
-   */
-  labelComponent = null;
 
   /**
    * Visually hide the label
@@ -176,19 +163,6 @@ export default class PolarisCheckbox extends Component {
     }
 
     return describedBy.length ? describedBy.join(' ') : undefined;
-  }
-
-  didReceiveAttrs() {
-    super.didReceiveAttrs(...arguments);
-
-    deprecate(
-      'Passing an explicit `labelComponent` to `polaris-checkbox` is deprecated - pass the component as `label` instead',
-      !this.labelComponent,
-      {
-        id: 'ember-polaris.polaris-checkbox.label-component',
-        until: '2.0.0',
-      }
-    );
   }
 
   @action

--- a/addon/components/polaris-choice.js
+++ b/addon/components/polaris-choice.js
@@ -30,17 +30,6 @@ export default class PolarisChoice extends Component {
   label = null;
 
   /**
-   * Component to render for the choice's label
-   *
-   * DEPRECATED: pass the component as `label` instead.
-   *
-   * @type {String | Component}
-   * @default null
-   * @public
-   */
-  labelComponent = null;
-
-  /**
    * Whether the associated form control is disabled
    *
    * @type {Boolean}

--- a/addon/components/polaris-color-picker.js
+++ b/addon/components/polaris-color-picker.js
@@ -54,7 +54,7 @@ export default class PolarisColorPicker extends Component {
    */
   @(computed('color.{hue,alpha}').readOnly())
   get colorLayerStyle() {
-    const { hue, alpha = 1 } = this.get('color');
+    const { hue, alpha = 1 } = this.color;
     const { red, green, blue } = hsbaToRgba({
       hue,
       saturation: 1,

--- a/addon/components/polaris-color-picker/alpha-picker.js
+++ b/addon/components/polaris-color-picker/alpha-picker.js
@@ -51,11 +51,11 @@ export default class AlphaPicker extends Component {
    */
   @(computed('color.{hue,saturation,brightness}').readOnly())
   get colorLayerStyle() {
-    const color = this.get('color');
+    const { color } = this;
     const { red, green, blue } = hsbaToRgba(color);
-
     const rgb = `${red}, ${green}, ${blue}`;
     const background = `linear-gradient(to top, rgba(${rgb}, 0) 18px, rgba(${rgb}, 1) calc(100% - 18px))`;
+
     return htmlSafe(`background: ${background};`);
   }
 

--- a/addon/components/polaris-color-picker/slidable.js
+++ b/addon/components/polaris-color-picker/slidable.js
@@ -60,7 +60,7 @@ export default class Slidable extends Component {
    * @private
    */
   handleMove(event) {
-    if (!this.get('isDragging')) {
+    if (!this.isDragging) {
       return;
     }
 
@@ -98,12 +98,12 @@ export default class Slidable extends Component {
    * @private
    */
   handleDraggerMove(clientX, clientY) {
-    const moveHandler = this.get('onChange');
+    const { onChange: moveHandler } = this;
     if (typeof moveHandler !== 'function') {
       return;
     }
 
-    const element = this.get('sliderElement');
+    const { sliderElement: element } = this;
     if (isNone(element)) {
       return;
     }
@@ -120,7 +120,7 @@ export default class Slidable extends Component {
   setElementAndTriggerHeightChanged(element) {
     this.set('sliderElement', element);
 
-    const onDraggerHeightChanged = this.get('onDraggerHeightChanged');
+    const { onDraggerHeightChanged } = this;
     if (typeOf(onDraggerHeightChanged) === 'function') {
       // Publish the height of our dragger.
       const draggerElement = element.querySelector(

--- a/addon/components/polaris-connected.js
+++ b/addon/components/polaris-connected.js
@@ -46,7 +46,7 @@ export default class PolarisConnected extends Component {
       this.dataTestConnected === true,
       {
         id: 'ember-polaris.polaris-connected.dataTestConnected-arg',
-        until: '6.0.0',
+        until: '7.0.0',
       }
     );
     this.dataTestConnected = this.dataTestConnected || true;

--- a/addon/components/polaris-data-table.js
+++ b/addon/components/polaris-data-table.js
@@ -242,18 +242,18 @@ export default class PolarisDataTable extends Component.extend(
    */
   @(computed('footerContent', 'heights.[]').readOnly())
   get scrollContainerStyle() {
-    if (isBlank(this.get('footerContent'))) {
+    if (isBlank(this.footerContent)) {
       return null;
     }
 
-    return htmlSafe(`margin-bottom: ${this.get('heights.lastObject')}px;`);
+    return htmlSafe(`margin-bottom: ${this.heights.lastObject}px;`);
   }
 
   resetScrollPosition() {
-    let scrollContainer = this.get('scrollContainer');
+    let { scrollContainer } = this;
 
     if (scrollContainer) {
-      let { left, top } = this.get('preservedScrollPosition');
+      let { left, top } = this.preservedScrollPosition;
 
       if (left) {
         scrollContainer.scrollLeft = left;
@@ -346,13 +346,11 @@ export default class PolarisDataTable extends Component.extend(
   }
 
   scrollListener() {
-    if (this.get('isDestroying') || this.get('isDestroyed')) {
+    if (this.isDestroying || this.isDestroyed) {
       return;
     }
 
-    this.setProperties(
-      this.calculateColumnVisibilityData(this.get('collapsed'))
-    );
+    this.setProperties(this.calculateColumnVisibilityData(this.collapsed));
   }
 
   tallestCellHeights() {
@@ -426,13 +424,11 @@ export default class PolarisDataTable extends Component.extend(
 
       // TODO: use run loop instead of `requestAnimationFrame` here?
       requestAnimationFrame(() => {
-        if (this.get('isDestroying') || this.get('isDestroyed')) {
+        if (this.isDestroying || this.isDestroyed) {
           return;
         }
 
-        this.setProperties(
-          this.calculateColumnVisibilityData(this.get('collapsed'))
-        );
+        this.setProperties(this.calculateColumnVisibilityData(this.collapsed));
       });
     }
   }

--- a/addon/components/polaris-data-table/cell.js
+++ b/addon/components/polaris-data-table/cell.js
@@ -200,7 +200,7 @@ export default class Cell extends Component {
    */
   @(computed('height').readOnly())
   get style() {
-    let height = this.get('height');
+    let { height } = this;
     return height ? htmlSafe(`height: ${height}px`) : undefined;
   }
 
@@ -212,7 +212,6 @@ export default class Cell extends Component {
   @(computed('sorted', 'sortDirection', 'defaultSortDirection').readOnly())
   get direction() {
     let { sorted, sortDirection, defaultSortDirection } = this;
-
     return sorted ? sortDirection : defaultSortDirection;
   }
 
@@ -223,7 +222,7 @@ export default class Cell extends Component {
    */
   @(computed('direction').readOnly())
   get source() {
-    return `caret-${this.get('direction') === 'ascending' ? 'up' : 'down'}`;
+    return `caret-${this.direction === 'ascending' ? 'up' : 'down'}`;
   }
 
   /**
@@ -233,9 +232,7 @@ export default class Cell extends Component {
    */
   @(computed('sortDirection').readOnly())
   get oppositeDirection() {
-    return this.get('sortDirection') === 'ascending'
-      ? 'descending'
-      : 'ascending';
+    return this.sortDirection === 'ascending' ? 'descending' : 'ascending';
   }
 
   /**

--- a/addon/components/polaris-data-table/heading.js
+++ b/addon/components/polaris-data-table/heading.js
@@ -94,7 +94,7 @@ export default class Heading extends Component {
    */
   @(computed('truncate', 'heights.[]').readOnly())
   get height() {
-    return !this.get('truncate') ? this.get('heights.firstObject') : undefined;
+    return !this.truncate ? this.heights.firstObject : undefined;
   }
 
   /**
@@ -104,6 +104,6 @@ export default class Heading extends Component {
    */
   @(computed('isSorted', 'sortDirection').readOnly())
   get direction() {
-    return this.get('isSorted') ? this.get('sortDirection') : 'none';
+    return this.isSorted ? this.sortDirection : 'none';
   }
 }

--- a/addon/components/polaris-display-text.js
+++ b/addon/components/polaris-display-text.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { classify } from '@ember/string';
+import { deprecate } from '@ember/application/deprecations';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../templates/components/polaris-display-text';
 
@@ -52,6 +53,19 @@ export default class PolarisDisplayText extends Component {
    * @public
    */
   text = null;
+
+  init() {
+    super.init(...arguments);
+
+    deprecate(
+      `[polaris-display-text] Passing 'tagName' argument is deprecated! Use '@htmlTag' instead`,
+      !this.tagName,
+      {
+        id: 'ember-polaris.polaris-display-text.tagName-arg',
+        until: '7.0.0',
+      }
+    );
+  }
 
   @computed('size')
   get sizeClassName() {

--- a/addon/components/polaris-heading.js
+++ b/addon/components/polaris-heading.js
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import { deprecate } from '@ember/application/deprecations';
 import { tagName, layout } from '@ember-decorators/component';
 import template from '../templates/components/polaris-heading';
 
@@ -10,9 +11,9 @@ import template from '../templates/components/polaris-heading';
  *
  *   {{polaris-heading text="This is a heading"}}
  *
- * Customised block usage (note the use of tagName instead of element - this is an ember thing):
+ * Customised block usage (note the use of htmlTag instead of element - this is an ember thing):
  *
- *   {{#polaris-heading tagName="em"}}
+ *   {{#polaris-heading htmlTag="em"}}
  *     This is an emphasised heading
  *   {{/polaris-heading}}
  */
@@ -31,4 +32,27 @@ export default class PolarisHeadingComponent extends Component {
    * @public
    */
   text = null;
+
+  /**
+   * Name of element to use for text
+   * NOTE: Matches polaris-react's `element`
+   *
+   * @type {String}
+   * @default h2
+   * @public
+   */
+  htmlTag = 'h2';
+
+  init() {
+    super.init(...arguments);
+
+    deprecate(
+      `[polaris-heading] Passing 'tagName' argument is deprecated! Use '@htmlTag' instead`,
+      !this.tagName,
+      {
+        id: 'ember-polaris.polaris-heading.tagName-arg',
+        until: '7.0.0',
+      }
+    );
+  }
 }

--- a/addon/components/polaris-icon.js
+++ b/addon/components/polaris-icon.js
@@ -111,7 +111,7 @@ export default class PolarisIcon extends Component.extend(SvgHandling) {
       !this.class,
       {
         id: 'ember-polaris.polaris-icon.class-arg',
-        until: '6.0.0',
+        until: '7.0.0',
       }
     );
   }

--- a/addon/components/polaris-labelled.js
+++ b/addon/components/polaris-labelled.js
@@ -108,7 +108,7 @@ export default class PolarisLabelledComponent extends Component {
       this.dataTestLabelled === true,
       {
         id: 'ember-polaris.polaris-labelled.dataTestLabelled-arg',
-        until: '6.0.0',
+        until: '7.0.0',
       }
     );
     this.dataTestLabelled = this.dataTestLabelled || true;

--- a/addon/components/polaris-link.js
+++ b/addon/components/polaris-link.js
@@ -67,7 +67,7 @@ export default class PolarisLink extends Component {
   get linkClass() {
     let linkClasses = ['Polaris-Link'];
 
-    if (this.get('monochrome')) {
+    if (this.monochrome) {
       linkClasses.push('Polaris-Link--monochrome');
     }
 

--- a/addon/components/polaris-page.js
+++ b/addon/components/polaris-page.js
@@ -181,7 +181,7 @@ export default class PolarisPageComponent extends Component {
       !this.class,
       {
         id: 'ember-polaris.polaris-page.class-arg',
-        until: '6.0.0',
+        until: '7.0.0',
       }
     );
   }

--- a/addon/components/polaris-popover.js
+++ b/addon/components/polaris-popover.js
@@ -164,7 +164,7 @@ export default class PolarisPopover extends Component {
     let component;
 
     // Hack to get the component's container
-    // element since this component uses `tagName: ''`
+    // element since this component is tagless
     // https://github.com/emberjs/rfcs/issues/168#issue-178381310
     if (ViewUtils && ViewUtils.getViewBounds) {
       component = ViewUtils.getViewBounds(this).parentElement;

--- a/addon/components/polaris-stack.js
+++ b/addon/components/polaris-stack.js
@@ -144,7 +144,7 @@ export default class PolarisStackComponent extends Component {
       !this.class,
       {
         id: 'ember-polaris.polaris-stack.class-arg',
-        until: '6.0.0',
+        until: '7.0.0',
       }
     );
   }

--- a/addon/components/polaris-stack.js
+++ b/addon/components/polaris-stack.js
@@ -74,7 +74,7 @@ export default class PolarisStackComponent extends Component {
 
   @computed('spacing')
   get spacingClassName() {
-    const spacing = this.get('spacing');
+    const { spacing } = this;
     if (isBlank(spacing)) {
       return null;
     }
@@ -84,7 +84,7 @@ export default class PolarisStackComponent extends Component {
 
   @computed('alignment')
   get alignmentClassName() {
-    const alignment = this.get('alignment');
+    const { alignment } = this;
     if (isBlank(alignment)) {
       return null;
     }
@@ -94,7 +94,7 @@ export default class PolarisStackComponent extends Component {
 
   @computed('distribution')
   get distributionClassName() {
-    const distribution = this.get('distribution');
+    const { distribution } = this;
     if (isBlank(distribution) || distribution === 'baseline') {
       return null;
     }

--- a/addon/components/polaris-stack/item.js
+++ b/addon/components/polaris-stack/item.js
@@ -46,7 +46,7 @@ export default class StackItemComponent extends Component {
       !this.class,
       {
         id: 'ember-polaris.polaris-stack-item.class-arg',
-        until: '6.0.0',
+        until: '7.0.0',
       }
     );
   }

--- a/addon/components/polaris-subheading.js
+++ b/addon/components/polaris-subheading.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import { action } from '@ember/object';
+import { deprecate } from '@ember/application/deprecations';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../templates/components/polaris-subheading';
 
@@ -11,9 +12,9 @@ import layout from '../templates/components/polaris-subheading';
  *
  *   {{polaris-subheading text="This is a subheading"}}
  *
- * Customised block usage (note the use of tagName instead of element - this is an ember thing):
+ * Customised block usage (note the use of htmlTag instead of element - this is an ember thing):
  *
- *   {{#polaris-subheading tagName="u"}}
+ *   {{#polaris-subheading htmlTag="u"}}
  *     This is an underlined subheading
  *   {{/polaris-subheading}}
  */
@@ -32,6 +33,19 @@ export default class PolarisSubheadingComponent extends Component {
    * @public
    */
   text = null;
+
+  init() {
+    super.init(...arguments);
+
+    deprecate(
+      `[polaris-subheading] Passing 'tagName' argument is deprecated! Use '@htmlTag' instead`,
+      !this.tagName,
+      {
+        id: 'ember-polaris.polaris-subheading.tagName-arg',
+        until: '7.0.0',
+      }
+    );
+  }
 
   @action
   setAriaLabel(element) {

--- a/addon/components/polaris-text-field.js
+++ b/addon/components/polaris-text-field.js
@@ -4,6 +4,7 @@ import { bool } from '@ember/object/computed';
 import { guidFor } from '@ember/object/internals';
 import { htmlSafe } from '@ember/string';
 import { typeOf, isPresent } from '@ember/utils';
+import { deprecate } from '@ember/application/deprecations';
 import { tagName, layout } from '@ember-decorators/component';
 import { getCode } from 'ember-keyboard';
 import { runTask, cancelTask } from 'ember-lifeline';
@@ -519,6 +520,15 @@ export default class PolarisTextFieldComponent extends Component {
       height: null,
       id,
     });
+
+    deprecate(
+      `[polaris-text-field] Passing 'dataTestTextField' argument is deprecated! Switch to angle bracket invocation and pass an HTML attribute instead`,
+      !this.class,
+      {
+        id: 'ember-polaris.polaris-text-field.dataTestTextField-arg',
+        until: '6.0.0',
+      }
+    );
   }
 
   @action

--- a/addon/components/polaris-text-field.js
+++ b/addon/components/polaris-text-field.js
@@ -526,7 +526,7 @@ export default class PolarisTextFieldComponent extends Component {
       !this.class,
       {
         id: 'ember-polaris.polaris-text-field.dataTestTextField-arg',
-        until: '6.0.0',
+        until: '7.0.0',
       }
     );
   }

--- a/addon/components/polaris-text-field.js
+++ b/addon/components/polaris-text-field.js
@@ -6,7 +6,7 @@ import { htmlSafe } from '@ember/string';
 import { typeOf, isPresent } from '@ember/utils';
 import { tagName, layout } from '@ember-decorators/component';
 import { getCode } from 'ember-keyboard';
-import { runTask, cancelTask, runDisposables } from 'ember-lifeline';
+import { runTask, cancelTask } from 'ember-lifeline';
 import template from '../templates/components/polaris-text-field';
 import { normalizeAutoCompleteProperty } from '../utils/normalize-auto-complete';
 
@@ -25,80 +25,72 @@ export default class PolarisTextFieldComponent extends Component {
   /**
    * ID for the input
    *
-   * @property id
-   * @public
    * @type {String}
    * @default null
+   * @public
    */
   id = null;
 
   /**
    * Text to display before value
    *
-   * @property prefix
-   * @public
    * @type {String|Component}
    * @default null
+   * @public
    */
   prefix = null;
 
   /**
    * Text to display after value
    *
-   * @property suffix
-   * @public
    * @type {String|Component}
    * @default null
+   * @public
    */
   suffix = null;
 
   /**
    * Hint text to display
    *
-   * @property placeholder
-   * @public
    * @type {String}
    * @default null
+   * @public
    */
   placeholder = null;
 
   /**
    * Initial value for the input
    *
-   * @property value
-   * @public
    * @type {String}
    * @default null
+   * @public
    */
   value = null;
 
   /**
    * Additional hint text to display
    *
-   * @property helpText
-   * @public
    * @type {String|Component}
    * @default null
+   * @public
    */
   helpText = null;
 
   /**
    * Label for the input
    *
-   * @property label
-   * @public
    * @type {String}
    * @default null
+   * @public
    */
   label = null;
 
   /**
    * Adds an action to the label
    *
-   * @property labelAction
-   * @public
    * @type {Object}
    * @default null
+   * @public
    *
    * Currently supports:
    * { onAction, text, accessibilityLabel }
@@ -108,140 +100,126 @@ export default class PolarisTextFieldComponent extends Component {
   /**
    * Visually hide the label
    *
-   * @property labelHidden
-   * @public
    * @type {Boolean}
    * @default false
+   * @public
    */
   labelHidden = false;
 
   /**
    * Disable the input
    *
-   * @property disabled
-   * @public
    * @type {Boolean}
    * @default null
+   * @public
    */
   disabled = null;
 
   /**
    * Disable editing of the input
    *
-   * @property readOnly
-   * @public
    * @type {Boolean}
    * @default null
+   * @public
    */
   readOnly = null;
 
   /**
    * Automatically focus the input
    *
-   * @property autoFocus
-   * @public
    * @type {Boolean}
    * @default null
+   * @public
    */
   autoFocus = null;
 
   /**
    * Force the focus state on the input
    *
-   * @property focused
-   * @public
    * @type {Boolean}
    * @default null
+   * @public
    */
   focused = null;
 
   /**
    * Allow for multiple lines of input
    *
-   * @property multiline
-   * @public
    * @type {Boolean|Number}
    * @default null
+   * @public
    */
   multiline = null;
 
   /**
    * Error to display beneath the label
    *
-   * @property error
-   * @public
    * @type {String|Component|Boolean|(String|Component)[]}
    * @default null
+   * @public
    */
   error = null;
 
   /**
    * An element connected to the right of the input
    *
-   * @property connectedRight
-   * @public
    * @type {String|Component}
    * @default null
+   * @public
    */
   connectedRight = null;
 
   /**
    * An element connected to the left of the input
    *
-   * @property connectedLeft
-   * @public
    * @type {String|Component}
    * @default null
+   * @public
    */
   connectedLeft = null;
 
   /**
    * Determine type of input
    *
-   * @property type
-   * @public
    * @type {String}
    * @default text
+   * @public
    */
   type = 'text';
 
   /**
    * Name of the input
    *
-   * @property name
-   * @public
    * @type {String}
    * @default null
+   * @public
    */
   name = null;
 
   /**
    * Defines a specific role attribute for the input
    *
-   * @property role
-   * @public
    * @type {String}
    * @default null
+   * @public
    */
   role = null;
 
   /**
    * Limit increment value for numeric and date-time inputs
    *
-   * @property step
-   * @public
    * @type {Number}
    * @default null
+   * @public
    */
   step = null;
 
   /**
    * Enable automatic completion by the browser
    *
-   * @property autoComplete
-   * @public
    * @type {Boolean}
    * @default null
+   * @public
    */
   autoComplete = null;
 
@@ -249,20 +227,18 @@ export default class PolarisTextFieldComponent extends Component {
    * Mimics the behavior of the native HTML attribute,
    * limiting how high the spinner can increment the value
    *
-   * @property max
-   * @public
    * @type {Number}
    * @default null
+   * @public
    */
   max = null;
 
   /**
    * Maximum character length for an input
    *
-   * @property maxLength
-   * @public
    * @type {Number}
    * @default null
+   * @public
    */
   maxLength = null;
 
@@ -270,120 +246,108 @@ export default class PolarisTextFieldComponent extends Component {
    * Mimics the behavior of the native HTML attribute,
    * limiting how low the spinner can decrement the value
    *
-   * @property min
-   * @public
    * @type {Number}
    * @default null
+   * @public
    */
   min = null;
 
   /**
    * Minimum character length for an input
    *
-   * @property minLength
-   * @public
    * @type {Number}
    * @default null
+   * @public
    */
   minLength = null;
 
   /**
    * A regular expression to check the value against
    *
-   * @property pattern
-   * @public
    * @type {String}
    * @default null
+   * @public
    */
   pattern = null;
 
   /**
    * Indicate whether value should have spelling checked
    *
-   * @property spellCheck
-   * @public
    * @type {Boolean}
    * @default null
+   * @public
    */
   spellCheck = null;
 
   /**
    * Indicates the id of a component owned by the input
    *
-   * @property ariaOwns
-   * @public
    * @type {String}
    * @default null
+   * @public
    */
   ariaOwns = null;
 
   /**
    * Indicates the id of a component controlled by the input
    *
-   * @property ariaControls
-   * @public
    * @type {String}
    * @default null
+   * @public
    */
   ariaControls = null;
 
   /**
    * Indicates the id of a related component's visually focused element ot the input
    *
-   * @property ariaActiveDescendant
-   * @public
    * @type {String}
    * @default null
+   * @public
    */
   ariaActiveDescendant = null;
 
   /**
    * Indicates what kind of user input completion suggestions are provided
    *
-   * @property ariaAutocomplete
-   * @public
    * @type {String}
    * @default null
+   * @public
    */
   ariaAutocomplete = null;
 
   /**
    * Indicates whether or not the character count should be displayed
    *
-   * @property showCharacterCount
-   * @public
    * @type {Boolean}
    * @default null
+   * @public
    */
   showCharacterCount = false;
 
   /**
    * Callback when value is changed
    *
-   * @property onChange
-   * @public
    * @type {Function}
    * @default noop
+   * @public
    */
   onChange(/* value, id */) {}
 
   /**
    * Callback when input is focused
    *
-   * @property onFocus
-   * @public
    * @type {Function}
    * @default noop
+   * @public
    */
   onFocus() {}
 
   /**
    * Callback when focus is removed
    *
-   * @property onBlur
-   * @public
    * @type {Function}
    * @default noop
+   * @public
    */
   onBlur() {}
 
@@ -545,10 +509,43 @@ export default class PolarisTextFieldComponent extends Component {
     return this.focused || false;
   }
 
-  setInput() {
-    this.set('input', document.querySelector(`[id='${this.id}']`));
+  init() {
+    super.init(...arguments);
+
+    let { id } = this;
+    id = id || `TextField-${guidFor(this)}`;
+
+    this.setProperties({
+      height: null,
+      id,
+    });
   }
 
+  @action
+  handleFocusChange() {
+    let { wasFocused, focused, input } = this;
+
+    if (!wasFocused && focused) {
+      input.focus();
+    } else if (wasFocused && !focused) {
+      input.blur();
+    }
+
+    this.set('wasFocused', focused);
+  }
+
+  @action
+  setInput(element) {
+    this.set('input', element);
+
+    if (!this.focused) {
+      return;
+    }
+
+    this.input.focus();
+  }
+
+  @action
   handleButtonPress(onChange) {
     let minInterval = 50;
     let decrementBy = 10;
@@ -567,51 +564,9 @@ export default class PolarisTextFieldComponent extends Component {
     this.buttonPressTaskId = runTask(this, onChangeInterval, interval);
   }
 
+  @action
   handleButtonRelease() {
     cancelTask(this, this.buttonPressTaskId);
-  }
-
-  init() {
-    super.init(...arguments);
-
-    let { id } = this;
-    id = id || `TextField-${guidFor(this)}`;
-
-    this.setProperties({
-      height: null,
-      id,
-    });
-  }
-
-  didInsertElement() {
-    super.didInsertElement(...arguments);
-
-    this.setInput();
-
-    if (!this.focused) {
-      return;
-    }
-
-    this.input.focus();
-  }
-
-  didUpdateAttrs() {
-    super.didUpdateAttrs(...arguments);
-
-    let { wasFocused, focused, input } = this;
-
-    if (!wasFocused && focused) {
-      input.focus();
-    } else if (wasFocused && !focused) {
-      input.blur();
-    }
-
-    this.set('wasFocused', focused);
-  }
-
-  willDestroyElement() {
-    super.willDestroyElement(...arguments);
-    runDisposables(this);
   }
 
   @action

--- a/addon/components/polaris-text-field/resizer.js
+++ b/addon/components/polaris-text-field/resizer.js
@@ -91,9 +91,7 @@ export default class PolarisTextFieldResizerComponent extends Component {
     let { currentHeight, onHeightChange } = this;
 
     if (newHeight !== currentHeight) {
-      this.scheduleTask('actions', () => {
-        onHeightChange(newHeight);
-      });
+      onHeightChange(newHeight);
     }
   }
 

--- a/addon/components/polaris-text-field/resizer.js
+++ b/addon/components/polaris-text-field/resizer.js
@@ -1,10 +1,8 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { computed, action } from '@ember/object';
 import { htmlSafe } from '@ember/string';
-import { attribute, classNames, layout } from '@ember-decorators/component';
-import ContextBoundTasksMixin from 'ember-lifeline/mixins/run';
-import ContextBoundEventListenersMixin from 'ember-lifeline/mixins/dom';
-import template from '../../templates/components/polaris-text-field/resizer';
+import { tagName, layout as templateLayout } from '@ember-decorators/component';
+import layout from '../../templates/components/polaris-text-field/resizer';
 
 const REPLACE_REGEX = /[\n&<>]/g;
 
@@ -19,29 +17,24 @@ function replaceEntity(entity) {
   return ENTITIES_TO_REPLACE[entity] || entity;
 }
 
-@classNames('Polaris-TextField__Resizer')
-@layout(template)
-export default class ResizerComponent extends Component.extend(
-  ContextBoundTasksMixin,
-  ContextBoundEventListenersMixin
-) {
+@tagName('')
+@templateLayout(layout)
+export default class PolarisTextFieldResizerComponent extends Component {
   /**
    * The value of the textarea
    *
-   * @property contents
-   * @public
    * @type {String}
    * @default null
+   * @public
    */
   contents = null;
 
   /**
    * The height (in px) of the textarea
    *
-   * @property currentHeight
-   * @public
    * @type {Number}
    * @default null
+   * @public
    */
   currentHeight = null;
 
@@ -49,32 +42,24 @@ export default class ResizerComponent extends Component.extend(
    * The multiline value of the textarea if
    * a numeric value was passed-in to the polaris-text-field
    *
-   * @property minimumLines
-   * @public
    * @type {Number}
    * @default null
+   * @public
    */
   minimumLines = null;
 
   /**
    * Callback when the height of the resize container changes
    *
-   * @property onHeightChange
-   * @public
    * @type {Function}
    * @default noop
+   * @public
    */
   onHeightChange /* height */() {}
-
-  @attribute('aria-hidden')
-  ariaHidden = 'true';
-
-  'data-test-text-field-resizer' = true;
 
   @computed('contents')
   get finalContents() {
     let { contents } = this;
-
     contents = contents
       ? `${contents.replace(REPLACE_REGEX, replaceEntity)}<br>`
       : '<br>';
@@ -93,11 +78,9 @@ export default class ResizerComponent extends Component.extend(
     return htmlSafe(content);
   }
 
+  @action
   handleHeightCheck() {
-    let [contentNode, minimumLinesNode] = this.element.querySelectorAll(
-      '.Polaris-TextField__DummyInput'
-    );
-
+    let { contentNode, minimumLinesNode } = this;
     if (!contentNode || !minimumLinesNode) {
       return;
     }
@@ -114,18 +97,13 @@ export default class ResizerComponent extends Component.extend(
     }
   }
 
-  addResizeHandler() {
-    this.addEventListener('resize', this.handleHeightCheck);
+  @action
+  setContentNode(element) {
+    this.set('contentNode', element);
   }
 
-  didInsertElement() {
-    super.didInsertElement(...arguments);
-    this.handleHeightCheck();
-    this.addResizeHandler();
-  }
-
-  didUpdateAttrs() {
-    super.didUpdateAttrs(...arguments);
-    this.handleHeightCheck();
+  @action
+  setMinimumLinesNode(element) {
+    this.set('minimumLinesNode', element);
   }
 }

--- a/addon/components/polaris-text-field/spinner.js
+++ b/addon/components/polaris-text-field/spinner.js
@@ -5,24 +5,22 @@ import template from '../../templates/components/polaris-text-field/spinner';
 
 @tagName('')
 @layout(template)
-export default class SpinnerComponent extends Component {
+export default class PolarisTextFieldSpinnerComponent extends Component {
   /**
    * Called when the up/down icons are clicked
    *
-   * @property onChange
-   * @public
    * @type {Function}
    * @default noop
+   * @public
    */
   onChange(/* number */) {}
 
   /**
    * Additional callback when any icon in the component is clicked
    *
-   * @property onClick
-   * @public
    * @type {Function}
    * @default noop
+   * @public
    */
   onClick() {}
 

--- a/addon/components/polaris-text-style.js
+++ b/addon/components/polaris-text-style.js
@@ -98,7 +98,7 @@ export default class PolarisTextStyle extends Component {
       !this.classes,
       {
         id: 'ember-polaris.polaris-text-style.classes-arg',
-        until: '6.0.0',
+        until: '7.0.0',
       }
     );
   }

--- a/addon/components/polaris-unstyled-link.js
+++ b/addon/components/polaris-unstyled-link.js
@@ -123,7 +123,7 @@ export default class PolarisUnstyledLinkComponent extends Component {
       !this.dataTestId,
       {
         id: 'ember-polaris.polaris-unstyled-link.dataTestId-arg',
-        until: '6.0.0',
+        until: '7.0.0',
       }
     );
     deprecate(
@@ -131,7 +131,7 @@ export default class PolarisUnstyledLinkComponent extends Component {
       !this.id,
       {
         id: 'ember-polaris.polaris-unstyled-link.id-arg',
-        until: '6.0.0',
+        until: '7.0.0',
       }
     );
     deprecate(
@@ -139,7 +139,7 @@ export default class PolarisUnstyledLinkComponent extends Component {
       !this.class,
       {
         id: 'ember-polaris.polaris-unstyled-link.class-arg',
-        until: '6.0.0',
+        until: '7.0.0',
       }
     );
   }

--- a/addon/components/render-content.js
+++ b/addon/components/render-content.js
@@ -14,7 +14,7 @@ export default Component.extend({
   contentIsComponentHash: notEmpty('content.componentName').readOnly(),
 
   contentIsComponentDefinition: computed('content', function() {
-    return isComponentDefinition(this.get('content'));
+    return isComponentDefinition(this.content);
   }).readOnly(),
 }).reopenClass({
   positionalParams: ['content'],

--- a/addon/components/wrapper-element.js
+++ b/addon/components/wrapper-element.js
@@ -17,14 +17,11 @@ export default Component.extend({
   blacklistedAttributeBindings,
 
   updateAttributeBindings() {
-    if (isBlank(this.get('tagName'))) {
+    if (isBlank(this.tagName)) {
       return;
     }
 
-    let { attrs, blacklistedAttributeBindings } = this.getProperties(
-      'attrs',
-      'blacklistedAttributeBindings'
-    );
+    let { attrs, blacklistedAttributeBindings } = this;
 
     let newAttributeBindings = Object.keys(attrs)
       .filter((attr) => {

--- a/addon/mixins/components/svg-handling.js
+++ b/addon/mixins/components/svg-handling.js
@@ -41,11 +41,11 @@ export default Mixin.create({
    * @type {DOMNode}
    */
   get svgElement() {
-    return document.querySelector(`#${this.get('svgElementId')}`);
+    return document.querySelector(`#${this.svgElementId}`);
   },
 
   removeFillsFromSvgElement() {
-    this.removeSvgFills(this.get('svgElement'));
+    this.removeSvgFills(this.svgElement);
   },
 
   /**

--- a/addon/templates/components/polaris-banner.hbs
+++ b/addon/templates/components/polaris-banner.hbs
@@ -26,7 +26,7 @@
   <div>
     {{#if @title}}
       <div class="Polaris-Banner__Heading" id={{this.headingId}}>
-        <PolarisHeading @tagName="p" @text={{@title}} />
+        <PolarisHeading @htmlTag="p" @text={{@title}} />
       </div>
     {{/if}}
 

--- a/addon/templates/components/polaris-checkbox.hbs
+++ b/addon/templates/components/polaris-checkbox.hbs
@@ -1,7 +1,6 @@
 <PolarisChoice
   @inputId={{this._id}}
   @label={{@label}}
-  @labelComponent={{@labelComponent}}
   @labelHidden={{this.labelHidden}}
   @helpText={{@helpText}}
   @error={{@error}}

--- a/addon/templates/components/polaris-choice.hbs
+++ b/addon/templates/components/polaris-choice.hbs
@@ -2,7 +2,6 @@
   (component "polaris-choice/label"
     inputId=@inputId
     label=@label
-    labelComponent=@labelComponent
     labelHidden=this.labelHidden
     disabled=this.disabled
   )

--- a/addon/templates/components/polaris-choice/label.hbs
+++ b/addon/templates/components/polaris-choice/label.hbs
@@ -9,10 +9,6 @@
   </span>
 
   <span class="Polaris-Choice__Label">
-    {{#if @labelComponent}}
-      {{component @labelComponent}}
-    {{else}}
-      {{render-content @label}}
-    {{/if}}
+    {{render-content @label}}
   </span>
 </label>

--- a/addon/templates/components/polaris-display-text.hbs
+++ b/addon/templates/components/polaris-display-text.hbs
@@ -1,4 +1,4 @@
-{{#let (element (or (or @htmlTag @tagName) "p")) as |DisplayText|}}
+{{#let (element (or @htmlTag @tagName "p")) as |DisplayText|}}
   <DisplayText
     class="Polaris-DisplayText {{this.sizeClassName}}"
     data-test-display-text

--- a/addon/templates/components/polaris-display-text.hbs
+++ b/addon/templates/components/polaris-display-text.hbs
@@ -1,4 +1,4 @@
-{{#let (element (or @htmlTag "p")) as |DisplayText|}}
+{{#let (element (or (or @htmlTag @tagName) "p")) as |DisplayText|}}
   <DisplayText
     class="Polaris-DisplayText {{this.sizeClassName}}"
     data-test-display-text

--- a/addon/templates/components/polaris-heading.hbs
+++ b/addon/templates/components/polaris-heading.hbs
@@ -1,5 +1,9 @@
-{{#let (element (or @tagName "h2")) as |Heading|}}
-  <Heading class="Polaris-Heading" ...attributes>
+{{#let (element (or (or @htmlTag @tagName) "h2")) as |Heading|}}
+  <Heading
+    class="Polaris-Heading"
+    data-test-polaris-heading
+    ...attributes
+  >
     {{#if hasBlock}}
       {{yield}}
     {{else}}

--- a/addon/templates/components/polaris-heading.hbs
+++ b/addon/templates/components/polaris-heading.hbs
@@ -1,4 +1,4 @@
-{{#let (element (or (or @htmlTag @tagName) "h2")) as |Heading|}}
+{{#let (element (or @htmlTag @tagName "h2")) as |Heading|}}
   <Heading
     class="Polaris-Heading"
     data-test-polaris-heading

--- a/addon/templates/components/polaris-resource-list.hbs
+++ b/addon/templates/components/polaris-resource-list.hbs
@@ -1,4 +1,4 @@
-{{#polaris-resource-list/provider value=this.context}}
+<PolarisResourceList::Provider @value={{this.context}}>
   {{#with
     (component "polaris-resource-list/loading-overlay"
       loading=@loading
@@ -165,4 +165,4 @@
       {{/if}}
     </div>
   {{/with}}
-{{/polaris-resource-list/provider}}
+</PolarisResourceList::Provider>

--- a/addon/templates/components/polaris-subheading.hbs
+++ b/addon/templates/components/polaris-subheading.hbs
@@ -1,4 +1,4 @@
-{{#let (element (or (or @htmlTag @tagName) "h3")) as |Subheading|}}
+{{#let (element (or @htmlTag @tagName "h3")) as |Subheading|}}
   <Subheading
     class="Polaris-Subheading"
     aria-label={{this.ariaLabel}}

--- a/addon/templates/components/polaris-subheading.hbs
+++ b/addon/templates/components/polaris-subheading.hbs
@@ -1,4 +1,4 @@
-{{#let (element (or @tagName "h3")) as |Subheading|}}
+{{#let (element (or (or @htmlTag @tagName) "h3")) as |Subheading|}}
   <Subheading
     class="Polaris-Subheading"
     aria-label={{this.ariaLabel}}

--- a/addon/templates/components/polaris-text-field.hbs
+++ b/addon/templates/components/polaris-text-field.hbs
@@ -1,121 +1,104 @@
-{{#polaris-labelled
-  dataTestLabelled=dataTestTextField
-  id=id
-  label=label
-  error=error
-  action=labelAction
-  labelHidden=labelHidden
-  helpText=helpText
-}}
-
-  {{#polaris-connected
-    left=connectedLeft
-    right=connectedRight
-  }}
+<PolarisLabelled
+  @dataTestLabelled={{this.dataTestTextField}}
+  @id={{this.id}}
+  @label={{@label}}
+  @error={{@error}}
+  @action={{@labelAction}}
+  @labelHidden={{labelHidden}}
+  @helpText={{@helpText}}
+  ...attributes
+>
+  <PolarisConnected @left={{@connectedLeft}} @right={{@connectedRight}}>
     {{! template-lint-disable no-invalid-interactive }}
     <div
       data-test-text-field-wrapper
-      class={{textFieldClasses}}
-      onfocus={{action "handleFocus"}}
-      onblur={{action "handleBlur"}}
-      onclick={{action "handleClick"}}
+      class={{this.textFieldClasses}}
+      {{on "focus" this.handleFocus}}
+      {{on "blur" this.handleBlur}}
+      {{on "click" this.handleClick}}
     >
-
-      {{#if prefix}}
-        <div data-test-text-field-prefix class="Polaris-TextField__Prefix" id="{{id}}Prefix">
-          {{render-content prefix}}
+      {{#if @prefix}}
+        <div data-test-text-field-prefix class="Polaris-TextField__Prefix" id="{{this.id}}Prefix">
+          {{render-content @prefix}}
         </div>
       {{/if}}
 
-      {{! template-lint-disable attribute-indentation }}
-      {{!-- TODO remove rule above once linter handles this correctly --}}
-      {{#with
-        (component "wrapper-element"
-          data-test-text-field-input=true
-          name=name
-          id=id
-          disabled=disabled
-          readonly=readOnly
-          role=role
-          autofocus=autoFocus
-          placeholder=placeholder
-          autocomplete=autoCompleteInputs
-          max=max
-          min=min
-          step=step
-          minlength=minLength
-          maxlength=maxLength
-          spellcheck=spellCheck
-          value=normalizedValue
-          class=inputClassName
-          aria-describedby=ariaDescribedBy
-          aria-label=label
-          aria-labelledby=ariaLabelledBy
-          aria-invalid=ariaInvalid
-          aria-owns=ariaOwns
-          aria-activedescendant=ariaActiveDescendant
-          aria-autocomplete=ariaAutocomplete
-          aria-controls=ariaControls
-          oninput=(action "handleChange")
-          onfocus=(action onFocus)
-          onblur=(action onBlur)
-          onkeypress=(action "handleKeyPress")
-        )
-        as |inputElement|
-      }}
-        {{#if multiline}}
-          {{component
-            inputElement
-            tagName="textarea"
-            aria-multiline=true
-            style=heightStyle
-          }}
-        {{else}}
-          {{component
-            inputElement
-            tagName="input"
-            type=inputType
-          }}
-        {{/if}}
-      {{/with}}
+      {{#let (element (if @multiline "textarea" "input")) as |Input|}}
+        <Input
+          data-test-text-field-input
+          type={{unless @multiline this.inputType}}
+          style={{if @multiline this.heightStyle}}
+          name={{@name}}
+          id={{this.id}}
+          disabled={{@disabled}}
+          readonly={{@readOnly}}
+          role={{@role}}
+          autofocus={{@autoFocus}}
+          placeholder={{@placeholder}}
+          autocomplete={{this.autoCompleteInputs}}
+          max={{@max}}
+          min={{@min}}
+          step={{@step}}
+          minlength={{@minLength}}
+          maxlength={{@maxLength}}
+          spellcheck={{@spellCheck}}
+          value={{this.normalizedValue}}
+          class={{this.inputClassName}}
+          aria-multiline={{@multiline}}
+          aria-describedby={{this.ariaDescribedBy}}
+          aria-label={{@label}}
+          aria-labelledby={{this.ariaLabelledBy}}
+          aria-invalid={{this.ariaInvalid}}
+          aria-owns={{@ariaOwns}}
+          aria-activedescendant={{@ariaActiveDescendant}}
+          aria-autocomplete={{@ariaAutocomplete}}
+          aria-controls={{@ariaControls}}
+          {{did-insert this.setInput}}
+          {{did-update this.handleFocusChange @focused}}
+          {{on "input" this.handleChange}}
+          {{on "focus" this.onFocus}}
+          {{on "blur" this.onBlur}}
+          {{on "keypress" this.handleKeyPress}}
+        />
+      {{/let}}
 
-      {{#if suffix}}
-        <div data-test-text-field-suffix class="Polaris-TextField__Suffix" id="{{id}}Suffix">
-          {{render-content suffix}}
+      {{#if @suffix}}
+        <div data-test-text-field-suffix class="Polaris-TextField__Suffix" id="{{this.id}}Suffix">
+          {{render-content @suffix}}
         </div>
       {{/if}}
 
-      {{#if showCharacterCount}}
+      {{#if @showCharacterCount}}
         <div
-          id={{concat id "CharacterCounter"}}
-          class={{characterCountClassName}}
-          aria-label={{characterCountLabel}}
+          id="{{this.id}}CharacterCounter"
+          class={{this.characterCountClassName}}
+          aria-label={{this.characterCountLabel}}
           aria-live="polite"
           aria-atomic="true"
           data-test-text-field-character-count
         >
-          {{characterCountText}}
+          {{this.characterCountText}}
         </div>
       {{/if}}
 
-      {{#if shouldShowSpinner}}
-        {{polaris-text-field/spinner
-          onChange=(action "handleNumberChange")
-          onMouseDown=(action handleButtonPress)
-          onMouseUp=(action handleButtonRelease)
-        }}
+      {{#if this.shouldShowSpinner}}
+        <PolarisTextField::Spinner
+          @onChange={{this.handleNumberChange}}
+          @onMouseDown={{this.handleButtonPress}}
+          @onMouseUp={{this.handleButtonRelease}}
+        />
       {{/if}}
 
       <div class="Polaris-TextField__Backdrop"></div>
 
-      {{#if multiline}}
-        {{polaris-text-field/resizer
-          contents=(or normalizedValue placeholder)
-          currentHeight=height
-          minimumLines=minimumLines
-          onHeightChange=(action "handleExpandingResize")
-        }}
+      {{#if @multiline}}
+        <PolarisTextField::Resizer
+          @contents={{or this.normalizedValue @placeholder}}
+          @currentHeight={{this.height}}
+          @minimumLines={{@minimumLines}}
+          @onHeightChange={{this.handleExpandingResize}}
+        />
       {{/if}}
     </div>
-  {{/polaris-connected}}
-{{/polaris-labelled}}
+  </PolarisConnected>
+</PolarisLabelled>

--- a/addon/templates/components/polaris-text-field.hbs
+++ b/addon/templates/components/polaris-text-field.hbs
@@ -1,5 +1,5 @@
 <PolarisLabelled
-  data-test={{this.dataTestTextField}}
+  data-test-labelled={{this.dataTestTextField}}
   @id={{this.id}}
   @label={{@label}}
   @error={{@error}}

--- a/addon/templates/components/polaris-text-field.hbs
+++ b/addon/templates/components/polaris-text-field.hbs
@@ -44,7 +44,7 @@
           spellcheck={{@spellCheck}}
           value={{this.normalizedValue}}
           class={{this.inputClassName}}
-          aria-multiline={{@multiline}}
+          aria-multiline={{if @multiline "true"}}
           aria-describedby={{this.ariaDescribedBy}}
           aria-label={{@label}}
           aria-labelledby={{this.ariaLabelledBy}}
@@ -95,7 +95,7 @@
         <PolarisTextField::Resizer
           @contents={{or this.normalizedValue @placeholder}}
           @currentHeight={{this.height}}
-          @minimumLines={{@minimumLines}}
+          @minimumLines={{this.minimumLines}}
           @onHeightChange={{this.handleExpandingResize}}
         />
       {{/if}}

--- a/addon/templates/components/polaris-text-field.hbs
+++ b/addon/templates/components/polaris-text-field.hbs
@@ -1,5 +1,5 @@
 <PolarisLabelled
-  @dataTestLabelled={{this.dataTestTextField}}
+  data-test={{this.dataTestTextField}}
   @id={{this.id}}
   @label={{@label}}
   @error={{@error}}

--- a/addon/templates/components/polaris-text-field.hbs
+++ b/addon/templates/components/polaris-text-field.hbs
@@ -44,11 +44,11 @@
           spellcheck={{@spellCheck}}
           value={{this.normalizedValue}}
           class={{this.inputClassName}}
-          aria-multiline={{if @multiline "true"}}
+          aria-multiline={{if @multiline "true" "false"}}
           aria-describedby={{this.ariaDescribedBy}}
           aria-label={{@label}}
           aria-labelledby={{this.ariaLabelledBy}}
-          aria-invalid={{this.ariaInvalid}}
+          aria-invalid={{if this.ariaInvalid "true" "false"}}
           aria-owns={{@ariaOwns}}
           aria-activedescendant={{@ariaActiveDescendant}}
           aria-autocomplete={{@ariaAutocomplete}}

--- a/addon/templates/components/polaris-text-field/resizer.hbs
+++ b/addon/templates/components/polaris-text-field/resizer.hbs
@@ -15,7 +15,7 @@
   {{did-insert this.handleHeightCheck}}
   {{did-update this.handleHeightCheck @contents @currentHeight @minimumLines}}
 >
-  <div class="Polaris-TextField__DummyInput" {{did-insert this.this.setContentNode}}>{{this.finalContents}}</div>
+  <div class="Polaris-TextField__DummyInput" {{did-insert this.setContentNode}}>{{this.finalContents}}</div>
 
   {{#if @minimumLines}}
     <div class="Polaris-TextField__DummyInput" {{did-insert this.setMinimumLinesNode}}>{{this.contentsForMinimumLines}}</div>

--- a/addon/templates/components/polaris-text-field/resizer.hbs
+++ b/addon/templates/components/polaris-text-field/resizer.hbs
@@ -15,19 +15,9 @@
   {{did-insert this.handleHeightCheck}}
   {{did-update this.handleHeightCheck @contents @currentHeight @minimumLines}}
 >
-  <div
-    class="Polaris-TextField__DummyInput"
-    {{did-insert this.this.setContentNode}}
-  >
-    {{this.finalContents}}
-  </div>
+  <div class="Polaris-TextField__DummyInput" {{did-insert this.this.setContentNode}}>{{this.finalContents}}</div>
 
   {{#if @minimumLines}}
-    <div
-      class="Polaris-TextField__DummyInput"
-      {{did-insert this.setMinimumLinesNode}}
-    >
-      {{this.contentsForMinimumLines}}
-    </div>
+    <div class="Polaris-TextField__DummyInput" {{did-insert this.setMinimumLinesNode}}>{{this.contentsForMinimumLines}}</div>
   {{/if}}
 </div>

--- a/addon/templates/components/polaris-text-field/resizer.hbs
+++ b/addon/templates/components/polaris-text-field/resizer.hbs
@@ -5,7 +5,29 @@
   This is because of the `white-space: pre-wrap` style applied by Polaris,
   which replicates the white space/wrapping behaviour of the textarea control.
 --}}
-<div class="Polaris-TextField__DummyInput">{{finalContents}}</div>
-{{#if minimumLines}}
-  <div class="Polaris-TextField__DummyInput">{{contentsForMinimumLines}}</div>
-{{/if}}
+{{!-- template-lint-disable no-invalid-interactive --}}
+<div
+  class="Polaris-TextField__Resizer"
+  aria-hidden="true"
+  data-test-text-field-resizer
+  ...attributes
+  {{on "resize" this.handleHeightCheck}}
+  {{did-insert this.handleHeightCheck}}
+  {{did-update this.handleHeightCheck @contents @currentHeight @minimumLines}}
+>
+  <div
+    class="Polaris-TextField__DummyInput"
+    {{did-insert this.this.setContentNode}}
+  >
+    {{this.finalContents}}
+  </div>
+
+  {{#if @minimumLines}}
+    <div
+      class="Polaris-TextField__DummyInput"
+      {{did-insert this.setMinimumLinesNode}}
+    >
+      {{this.contentsForMinimumLines}}
+    </div>
+  {{/if}}
+</div>

--- a/addon/templates/components/polaris-text-field/spinner.hbs
+++ b/addon/templates/components/polaris-text-field/spinner.hbs
@@ -2,20 +2,21 @@
 <div
   data-test-text-field-spinner
   class="Polaris-TextField__Spinner"
-  aria-hidden="true"
-  onclick={{action onClick}}
+  aria-hidden
+  ...attributes
+  {{on "click" this.onClick}}
 >
   <div
     data-test-text-field-spinner-incr-button
     role="button"
     class="Polaris-TextField__Segment"
     tabindex="-1"
-    onclick={{action onChange 1}}
-    onmousedown={{action "handleMouseDown" (action onChange 1)}}
-    onmouseup={{action onMouseUp}}
+    {{on "click" (fn @onChange 1)}}
+    {{on "mousedown" (fn this.handleMouseDown (fn @onChange 1))}}
+    {{on "mouseup" this.onMouseUp}}
   >
     <div class="Polaris-TextField__SpinnerIcon">
-      {{polaris-icon source="caret-up"}}
+      <PolarisIcon @source="caret-up" />
     </div>
   </div>
 
@@ -24,12 +25,12 @@
     role="button"
     class="Polaris-TextField__Segment"
     tabindex="-1"
-    onclick={{action onChange -1}}
-    onmousedown={{action "handleMouseDown" (action onChange -1)}}
-    onmouseup={{action onMouseUp}}
+    {{on "click" (fn @onChange -1)}}
+    {{on "mousedown" (fn this.handleMouseDown (fn @onChange -1))}}
+    {{on "mouseup" this.onMouseUp}}
   >
     <div class="Polaris-TextField__SpinnerIcon">
-      {{polaris-icon source="caret-down"}}
+      <PolarisIcon @source="caret-down" />
     </div>
   </div>
 </div>

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "ember-cli-htmlbars": "^4.3.1",
     "ember-cli-sass": "^10.0.1",
     "ember-context": "^0.1.0",
-    "ember-element-helper": "^0.1.1",
+    "ember-element-helper": "^0.3.1",
     "ember-invoke-action": "^1.5.1",
     "ember-keyboard": "^5.0.0",
     "ember-lifeline": "^4.1.5",

--- a/tests/dummy/app/templates/components/resource-list/bulk-actions.hbs
+++ b/tests/dummy/app/templates/components/resource-list/bulk-actions.hbs
@@ -1,43 +1,19 @@
-{{polaris-resource-list
-  resourceName=(hash
+<PolarisResourceList
+  @resourceName={{hash
     singular="customer"
     plural="customers"
-  )
-  items=(array
-    (hash
-      id=341
-      url="customers/341"
-      name="Mae Jemison"
-      location="Decatur, USA"
-    )
-    (hash
-      id=256
-      url="customers/256"
-      name="Ellen Ochoa"
-      location="Los Angeles, USA"
-    )
-  )
-  itemComponent="resource-list/simple/item"
-  selectedItems=selectedItems
-  onSelectionChange=(action (mut selectedItems))
-  promotedBulkActions=(array
-    (hash
-      content="Edit customers"
-      onAction=(action (mut dummy))
-    )
-  )
-  bulkActions=(array
-    (hash
-      text="Add tags"
-      onAction=(action (mut dummy))
-    )
-    (hash
-      text="Remove tags"
-      onAction=(action (mut dummy))
-    )
-    (hash
-      text="Delete customers"
-      onAction=(action (mut dummy))
-    )
-  )
-}}
+  }}
+  @items={{array
+    (hash id=341 url="customers/341" name="Mae Jemison" location="Decatur, USA")
+    (hash id=256 url="customers/256" name="Ellen Ochoa" location="Los Angeles, USA")
+  }}
+  @itemComponent="resource-list/simple/item"
+  @selectedItems={{selectedItems}}
+  @onSelectionChange={{action (mut selectedItems)}}
+  @promotedBulkActions={{array (hash content="Edit customers" onAction=(action (mut dummy)))}}
+  @bulkActions={{array
+    (hash text="Add tags" onAction=(action (mut dummy)))
+    (hash text="Remove tags" onAction=(action (mut dummy)))
+    (hash text="Delete customers" onAction=(action (mut dummy)))
+  }}
+/>

--- a/tests/dummy/app/templates/components/resource-list/filtering.hbs
+++ b/tests/dummy/app/templates/components/resource-list/filtering.hbs
@@ -1,24 +1,14 @@
-{{polaris-resource-list
-  resourceName=(hash
+<PolarisResourceList
+  @resourceName={{hash
     singular="customer"
     plural="customers"
-  )
-  items=(array
-    (hash
-      id=341
-      url="customers/341"
-      name="Mae Jemison"
-      location="Decatur, USA"
-    )
-    (hash
-      id=256
-      url="customers/256"
-      name="Ellen Ochoa"
-      location="Los Angeles, USA"
-    )
-  )
-  itemComponent="resource-list/simple/item"
-  filterControl=(component "polaris-resource-list/filter-control"
+  }}
+  @items={{array
+    (hash id=341 url="customers/341" name="Mae Jemison" location="Decatur, USA")
+    (hash id=256 url="customers/256" name="Ellen Ochoa" location="Los Angeles, USA")
+  }}
+  @itemComponent="resource-list/simple/item"
+  @filterControl={{component "polaris-resource-list/filter-control"
     filters=(array
       (hash
         key="orderCountFilter"
@@ -42,5 +32,5 @@
       text="Save"
       onAction=(action (mut dummy))
     )
-  )
-}}
+  }}
+/>

--- a/tests/dummy/app/templates/components/resource-list/persist-actions.hbs
+++ b/tests/dummy/app/templates/components/resource-list/persist-actions.hbs
@@ -1,23 +1,11 @@
-{{polaris-resource-list
-  resourceName=(hash
+<PolarisResourceList
+  @resourceName={{hash
     singular="customer"
     plural="customers"
-  )
-  items=(array
-    (hash
-      id=341
-      url="customers/341"
-      name="Mae Jemison"
-      location="Decatur, USA"
-      latestOrderUrl="orders/1456"
-    )
-    (hash
-      id=256
-      url="customers/256"
-      name="Ellen Ochoa"
-      location="Los Angeles, USA"
-      latestOrderUrl="orders/1457"
-    )
-  )
-  itemComponent="resource-list/persist-actions/item"
-}}
+  }}
+  @items={{array
+    (hash id=341 url="customers/341" name="Mae Jemison" location="Decatur, USA" latestOrderUrl="orders/1456")
+    (hash id=256 url="customers/256" name="Ellen Ochoa" location="Los Angeles, USA" latestOrderUrl="orders/1457")
+  }}
+  @itemComponent="resource-list/persist-actions/item"
+/>

--- a/tests/dummy/app/templates/components/resource-list/persist-actions/item.hbs
+++ b/tests/dummy/app/templates/components/resource-list/persist-actions/item.hbs
@@ -1,28 +1,20 @@
-{{#polaris-resource-list/item
-  itemId=itemId
-  url=item.url
-  accessibilityLabel=accessibilityLabel
-  media=(component
+<PolarisResourceList::Item
+  @itemId={{itemId}}
+  @url={{item.url}}
+  @accessibilityLabel={{accessibilityLabel}}
+  @media={{component
     "polaris-avatar"
     customer=true
     size="medium"
     name=item.name
-  )
-  shortcutActions=(if item.latestOrderUrl
-    (array
-      (hash
-        text="View latest order"
-        url=item.latestOrderUrl
-      )
-    )
-  )
-  persistActions=true
-}}
+  }}
+  @shortcutActions={{if item.latestOrderUrl
+    (array (hash text="View latest order" url=item.latestOrderUrl))
+  }}
+  @persistActions={{true}}
+>
   <h3>
-    {{polaris-text-style
-      variation="strong"
-      text=item.name
-    }}
+    <PolarisTextStyle @variation="strong" @text={{item.name}} />
   </h3>
   <div>{{item.location}}</div>
-{{/polaris-resource-list/item}}
+</PolarisResourceList::Item>

--- a/tests/dummy/app/templates/components/resource-list/simple.hbs
+++ b/tests/dummy/app/templates/components/resource-list/simple.hbs
@@ -1,21 +1,11 @@
-{{polaris-resource-list
-  resourceName=(hash
+<PolarisResourceList
+  @resourceName={{hash
     singular="customer"
     plural="customers"
-  )
-  items=(array
-    (hash
-      id=341
-      url="customers/341"
-      name="Mae Jemison"
-      location="Decatur, USA"
-    )
-    (hash
-      id=256
-      url="customers/256"
-      name="Ellen Ochoa"
-      location="Los Angeles, USA"
-    )
-  )
-  itemComponent="resource-list/simple/item"
-}}
+  }}
+  @items={{array
+    (hash id=341 url="customers/341" name="Mae Jemison" location="Decatur, USA")
+    (hash id=256 url="customers/256" name="Ellen Ochoa" location="Los Angeles, USA")
+  }}
+  @itemComponent="resource-list/simple/item"
+/>

--- a/tests/dummy/app/templates/components/resource-list/simple/item.hbs
+++ b/tests/dummy/app/templates/components/resource-list/simple/item.hbs
@@ -1,19 +1,16 @@
-{{#polaris-resource-list/item
-  itemId=itemId
-  url=item.url
-  accessibilityLabel=accessibilityLabel
-  media=(component
+<PolarisResourceList::Item
+  @itemId={{itemId}}
+  @url={{item.url}}
+  @accessibilityLabel={{accessibilityLabel}}
+  @media={{component
     "polaris-avatar"
     customer=true
     size="medium"
     name=item.name
-  )
-}}
+  }}
+>
   <h3>
-    {{polaris-text-style
-      variation="strong"
-      text=item.name
-    }}
+    <PolarisTextStyle @variation="strong" @text={{item.name}} />
   </h3>
   <div>{{item.location}}</div>
-{{/polaris-resource-list/item}}
+</PolarisResourceList::Item>

--- a/tests/dummy/app/templates/components/resource-list/sorting.hbs
+++ b/tests/dummy/app/templates/components/resource-list/sorting.hbs
@@ -1,27 +1,17 @@
-{{polaris-resource-list
-  resourceName=(hash
+<PolarisResourceList
+  @resourceName={{hash
     singular="customer"
     plural="customers"
-  )
-  items=(array
-    (hash
-      id=341
-      url="customers/341"
-      name="Mae Jemison"
-      location="Decatur, USA"
-    )
-    (hash
-      id=256
-      url="customers/256"
-      name="Ellen Ochoa"
-      location="Los Angeles, USA"
-    )
-  )
-  itemComponent="resource-list/simple/item"
-  sortValue=sortValue
-  sortOptions=(array
+  }}
+  @items={{array
+    (hash id=341 url="customers/341" name="Mae Jemison" location="Decatur, USA")
+    (hash id=256 url="customers/256" name="Ellen Ochoa" location="Los Angeles, USA")
+  }}
+  @itemComponent="resource-list/simple/item"
+  @sortValue={{sortValue}}
+  @sortOptions={{array
     (hash label="Newest update" value="DATE_MODIFIED_DESC")
     (hash label="Oldest update" value="DATE_MODIFIED_ASC")
-  )
-  onSortChange=(action (mut sortValue))
-}}
+  }}
+  @onSortChange={{action (mut sortValue)}}
+/>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,79 +1,50 @@
-{{#polaris-page
-  title="This is the application route"
-  breadcrumbs=(array
-    (hash
-      content="Test Route"
-      url="/test"
-    )
-  )
-  primaryAction=(hash
+<PolarisPage
+  @title="This is the application route"
+  @breadcrumbs={{array (hash content="Test Route" url="/test")}}
+  @primaryAction={{hash
     text="Primary"
     onAction=(action (mut primaryClicked) true)
-  )
-  secondaryActions=(array
-    (hash
-      text="Secondary 1"
-      onAction=(action (mut secondary1Clicked) true)
-    )
-    (hash
-      text="Secondary 2"
-      onAction=(action (mut secondary2Clicked) true)
-    )
-  )
-  actionGroups=(array
+  }}
+  @secondaryActions={{array
+    (hash text="Secondary 1" onAction=(action (mut secondary1Clicked) true))
+    (hash text="Secondary 2" onAction=(action (mut secondary2Clicked) true))
+  }}
+  @actionGroups={{array
     (hash
       title="Action group with details"
       actions=(array
-        (hash
-          text="Group action 1.1"
-          onAction=(action (mut group1Button1Clicked) true)
-        )
-        (hash
-          text="Group action 1.2"
-          onAction=(action (mut group1Button2Clicked) true)
-        )
+        (hash text="Group action 1.1" onAction=(action (mut group1Button1Clicked) true))
+        (hash text="Group action 1.2" onAction=(action (mut group1Button2Clicked) true))
       )
-      details=(component
-        "polaris-text-style"
-        variation="positive"
-        text="This is an action group with details"
-      )
+      details=(component "polaris-text-style" variation="positive" text="This is an action group with details")
     )
     (hash
       title="Action group with actions"
       actions=(array
-        (hash
-          text="Group action 2.1"
-          onAction=(action (mut group2Button1Clicked) true)
-        )
-        (hash
-          text="Group action 2.2"
-          onAction=(action (mut group2Button2Clicked) true)
-        )
+        (hash text="Group action 2.1" onAction=(action (mut group2Button1Clicked) true))
+        (hash text="Group action 2.2" onAction=(action (mut group2Button2Clicked) true))
       )
     )
-  )
-}}
-
-  {{#polaris-list as |list|}}
+  }}
+>
+  <PolarisList as |list|>
     {{#each model as |testPage|}}
-      {{#list.item}}
-        {{#link-to testPage.path}}
+      <list.item>
+        <LinkTo @route={{testPage.path}}>
           {{testPage.text}}
-        {{/link-to}}
-      {{/list.item}}
+        </LinkTo>
+      </list.item>
     {{/each}}
-  {{/polaris-list}}
+  </PolarisList>
 
-  {{polaris-link
-    url="https://github.com/smile-io/ember-polaris"
-    external=true
-    text="Ember Polaris on GitHub"
-  }}
+  <PolarisLink
+    @url="https://github.com/smile-io/ember-polaris"
+    @external={{true}}
+    @text="Ember Polaris on GitHub"
+  />
 
-  {{key-event-listener
-    key="KeyM"
-    onKeyDown=(action (mut application.hideMagicSection) (not application.hideMagicSection))
-  }}
-
-{{/polaris-page}}
+  <KeyEventListener
+    @key="KeyM"
+    @onKeyDown={{action (mut application.hideMagicSection) (not application.hideMagicSection)}}
+  />
+</PolarisPage>

--- a/tests/dummy/app/templates/layout/annotated-layout.hbs
+++ b/tests/dummy/app/templates/layout/annotated-layout.hbs
@@ -1,25 +1,22 @@
-{{#polaris-layout as |layout|}}
-  {{#layout.annotatedSection
-    title="Test Details"
-    description="A good description goes here"
-  }}
-    {{#polaris-card sectioned=true}}
-      {{#polaris-form-layout as |formLayout|}}
-        {{#formLayout.group}}
-          {{polaris-text-field
-            label="First name"
-            placeholder="e.g. SpongeBob"
-            value=firstName
-            onChange=(action (mut firstName))
-          }}
-          {{polaris-text-field
-            label="Last name"
-            placeholder="e.g. SquarePants"
-            value=lastName
-            onChange=(action (mut lastName))
-          }}
-        {{/formLayout.group}}
-      {{/polaris-form-layout}}
-    {{/polaris-card}}
-  {{/layout.annotatedSection}}
-{{/polaris-layout}}
+<PolarisLayout as |layout|>
+  <layout.annotatedSection @title="Test Details" @description="A good description goes here">
+    <PolarisCard @sectioned={{true}}>
+      <PolarisFormLayout as |formLayout|>
+        <formLayout.group>
+          <PolarisTextField
+            @label="First name"
+            @placeholder="e.g. SpongeBob"
+            @value={{firstName}}
+            @onChange={{action (mut firstName)}}
+          />
+          <PolarisTextField
+            @label="Last name"
+            @placeholder="e.g. SquarePants"
+            @value={{lastName}}
+            @onChange={{action (mut lastName)}}
+          />
+        </formLayout.group>
+      </PolarisFormLayout>
+    </PolarisCard>
+  </layout.annotatedSection>
+</PolarisLayout>

--- a/tests/dummy/app/templates/resource-list.hbs
+++ b/tests/dummy/app/templates/resource-list.hbs
@@ -1,38 +1,23 @@
-{{#polaris-page title="Resource list examples" singleColumn=true}}
-  {{#polaris-card sectioned=true}}
-    {{polaris-select
-      label="Example type"
-      placeholder="Select"
-      options=(array
-        (hash
-          label="Simple resource list"
-          value="simple"
-        )
-        (hash
-          label="Resource list with bulk actions"
-          value="bulk-actions"
-        )
-        (hash
-          label="Resource list with sorting"
-          value="sorting"
-        )
-        (hash
-          label="Resource list with filtering"
-          value="filtering"
-        )
-        (hash
-          label="Resource list with persistent item shortcut actions"
-          value="persist-actions"
-        )
-      )
-      value=(or exampleType "")
-      onChange=(action (mut exampleType))
-    }}
-  {{/polaris-card}}
+<PolarisPage @title="Resource list examples" @singleColumn={{true}}>
+  <PolarisCard @sectioned={{true}}>
+    <PolarisSelect
+      @label="Example type"
+      @placeholder="Select"
+      @options={{array
+        (hash label="Simple resource list" value="simple")
+        (hash label="Resource list with bulk actions" value="bulk-actions")
+        (hash label="Resource list with sorting" value="sorting")
+        (hash label="Resource list with filtering" value="filtering")
+        (hash label="Resource list with persistent item shortcut actions" value="persist-actions")
+      }}
+      @value={{or exampleType ""}}
+      @onChange={{action (mut exampleType)}}
+    />
+  </PolarisCard>
 
   {{#if exampleType}}
-    {{#polaris-card}}
+    <PolarisCard>
       {{component (concat "resource-list/" exampleType)}}
-    {{/polaris-card}}
+    </PolarisCard>
   {{/if}}
-{{/polaris-page}}
+</PolarisPage>

--- a/tests/dummy/app/templates/select.hbs
+++ b/tests/dummy/app/templates/select.hbs
@@ -1,36 +1,29 @@
 {{!--
   Ember port of the React test at https://codesandbox.io/s/53q709kxo4
 --}}
-{{#polaris-page title="Select test"}}
-  {{#polaris-card sectioned=true}}
-    {{polaris-select
-      label="Select test"
-      labelAction=(hash
+<PolarisPage @title="Select test">
+  <PolarisCard @sectioned={{true}}>
+    <PolarisSelect
+      @label="Select test"
+      @labelAction={{hash
         text="Clear"
         onAction=(action (mut value) null)
-      )
-      options=(array
+      }}
+      @options={{array
         "Single string"
         (hash
           title="Group"
           options=(array
             "Group string"
-            (hash
-              value="Group object (disabled)"
-              label="Group object (disabled)"
-              disabled=true
-            )
+            (hash value="Group object (disabled)" label="Group object (disabled)" disabled=true)
           )
         )
-        (hash
-          value="Single object (enabled)"
-          label="Single object (enabled)"
-        )
-      )
-      value=(or value "")
-      placeholder="Select a value"
-      helpText=(if value (concat "Selected: " value))
-      onChange=(action (mut value))
-    }}
-  {{/polaris-card}}
-{{/polaris-page}}
+        (hash value="Single object (enabled)" label="Single object (enabled)")
+      }}
+      @value={{or value ""}}
+      @placeholder="Select a value"
+      @helpText={{if value (concat "Selected: " value)}}
+      @onChange={{action (mut value)}}
+    />
+  </PolarisCard>
+</PolarisPage>

--- a/tests/dummy/app/templates/sticky.hbs
+++ b/tests/dummy/app/templates/sticky.hbs
@@ -2,44 +2,44 @@
   Ember port of the React test at https://codesandbox.io/s/pmonqjp3q7
 --}}
 
-{{#polaris-page title="Sticky testing"}}
-  {{#polaris-layout as |layout|}}
-    {{#layout.section}}
-      {{#polaris-card title="Order details" sectioned=true}}
+<PolarisPage @title="Sticky testing">
+  <PolarisLayout as |layout|>
+    <layout.section>
+      <PolarisCard @title="Order details" @sectioned={{true}}>
         <p>View a summary of your order.</p>
-      {{/polaris-card}}
-      {{#polaris-card title="Order details" sectioned=true}}
+      </PolarisCard>
+      <PolarisCard @title="Order details" @sectioned={{true}}>
         <p>View a summary of your order.</p>
-      {{/polaris-card}}
-      {{#polaris-card title="Order details" sectioned=true}}
+      </PolarisCard>
+      <PolarisCard @title="Order details" @sectioned={{true}}>
         <p>View a summary of your order.</p>
-      {{/polaris-card}}
-      {{#polaris-card title="Order details" sectioned=true}}
+      </PolarisCard>
+      <PolarisCard @title="Order details" @sectioned={{true}}>
         <p>View a summary of your order.</p>
-      {{/polaris-card}}
-      {{#polaris-card title="Order details" sectioned=true}}
+      </PolarisCard>
+      <PolarisCard @title="Order details" @sectioned={{true}}>
         <p>View a summary of your order.</p>
-      {{/polaris-card}}
-      {{#polaris-card title="Order details" sectioned=true}}
+      </PolarisCard>
+      <PolarisCard @title="Order details" @sectioned={{true}}>
         <p>View a summary of your order.</p>
-      {{/polaris-card}}
-      {{#polaris-card title="Order details" sectioned=true}}
+      </PolarisCard>
+      <PolarisCard @title="Order details" @sectioned={{true}}>
         <p>View a summary of your order.</p>
-      {{/polaris-card}}
-      {{#polaris-card title="Order details" sectioned=true}}
+      </PolarisCard>
+      <PolarisCard @title="Order details" @sectioned={{true}}>
         <p>View a summary of your order.</p>
-      {{/polaris-card}}
-      {{#polaris-card title="Order details" sectioned=true}}
+      </PolarisCard>
+      <PolarisCard @title="Order details" @sectioned={{true}}>
         <p>View a summary of your order.</p>
-      {{/polaris-card}}
-    {{/layout.section}}
+      </PolarisCard>
+    </layout.section>
 
-    {{#layout.section secondary=true}}
-      {{#polaris-sticky}}
-        {{#polaris-card title="Tags" sectioned=true subdued=true}}
+    <layout.section @secondary={{true}}>
+      <PolarisSticky>
+        <PolarisCard @title="Tags" @sectioned={{true}} @subdued={{true}}>
           <p>Add tags to your order.</p>
-        {{/polaris-card}}
-      {{/polaris-sticky}}
-    {{/layout.section}}
-  {{/polaris-layout}}
-{{/polaris-page}}
+        </PolarisCard>
+      </PolarisSticky>
+    </layout.section>
+  </PolarisLayout>
+</PolarisPage>

--- a/tests/dummy/app/templates/test.hbs
+++ b/tests/dummy/app/templates/test.hbs
@@ -1,11 +1,11 @@
-{{#polaris-button-group as |group|}}
-  {{#group.item}}
-    {{polaris-button text="Button 1" onClick=(action (mut dummy))}}
-  {{/group.item}}
+<PolarisButtonGroup as |group|>
+  <group.item>
+    <PolarisButton @text="Button 1" @onClick={{action (mut dummy)}} />
+  </group.item>
 
-  {{#group.item}}
-    {{polaris-button text="Button 2" onClick=(action (mut dummy))}}
-  {{/group.item}}
+  <group.item>
+    <PolarisButton @text="Button 2" @onClick={{action (mut dummy)}} />
+  </group.item>
 
-  {{polaris-button text="Button 2" onClick=(action (mut dummy))}}
-{{/polaris-button-group}}
+  <PolarisButton @text="Button 2" @onClick={{action (mut dummy)}} />
+</PolarisButtonGroup>

--- a/tests/dummy/app/templates/test/child/index.hbs
+++ b/tests/dummy/app/templates/test/child/index.hbs
@@ -1,13 +1,7 @@
-{{polaris-page
-  title="This is the child route"
-  breadcrumbs=(array
-    (hash
-      text="Application"
-      route="index"
-    )
-    (hash
-      text="Test"
-      route="test"
-    )
-  )
-}}
+<PolarisPage
+  @title="This is the child route"
+  @breadcrumbs={{array
+    (hash text="Application" route="index")
+    (hash text="Test" route="test")
+  }}
+/>

--- a/tests/dummy/app/templates/test/index.hbs
+++ b/tests/dummy/app/templates/test/index.hbs
@@ -1,5 +1,3 @@
-{{#polaris-page
-  title="Test Route"
-}}
+<PolarisPage @title="Test Route">
 
-{{/polaris-page}}
+</PolarisPage>

--- a/tests/integration/components/polaris-choice-test.js
+++ b/tests/integration/components/polaris-choice-test.js
@@ -74,6 +74,11 @@ module('Integration | Component | polaris choice', function(hooks) {
     'svg'
   );
 
+  const labelComponentSelector = buildNestedSelector(
+    labelContentSelector,
+    'div.test-label-component'
+  );
+
   test('it renders the correct HTML when no error or helpText are provided', async function(assert) {
     await render(hbs`
       {{#polaris-choice inputId="test-choice" label="This is my label"}}
@@ -260,167 +265,65 @@ module('Integration | Component | polaris choice', function(hooks) {
     );
   });
 
-  test('it handles label components correctly when no description is present', async function(assert) {
-    this.setProperties({
-      label: null,
-      labelComponent: 'test-label',
-    });
+  test('it handles label correctly when no description is present', async function(assert) {
+    await render(hbs`
+      {{polaris-choice label="some label"}}
+    `);
+
+    assert.dom(labelContentSelector).exists('renders the label');
+    assert
+      .dom(labelContentSelector)
+      .hasText(
+        'some label',
+        'with label as plain string - renders the correct label content'
+      );
 
     await render(hbs`
       {{polaris-choice
-        label=label
-        labelComponent=labelComponent
+        label=(component "test-label" text="test label component from component")
       }}
     `);
 
-    let labelContent = assert.dom(labelContentSelector);
-    labelContent.exists('renders the label');
-
-    const labelComponentSelector = buildNestedSelector(
-      labelContentSelector,
-      'div.test-label-component'
-    );
-    let labelComponent = assert.dom(labelComponentSelector);
-
-    labelComponent.exists(
-      'with label component string - renders the label component'
-    );
-    labelContent.hasText(
-      'test label component',
-      'with label component string - renders the correct label content'
-    );
-
-    this.set('label', 'literal label');
-    labelContent.hasText(
-      'test label component',
-      'with label component string and label - renders the correct label content'
-    );
-
-    this.set('labelComponent', null);
-    labelContent.hasText(
-      'literal label',
-      'with label - renders the correct label content'
-    );
-
-    this.setProperties({
-      label: null,
-      useLabelComponent: true,
-    });
-    await render(hbs`
-      {{polaris-choice
-        label=label
-        labelComponent=(if useLabelComponent (
-          component "test-label" text="test label component from component closure"
-        ))
-      }}
-    `);
-
-    labelContent = assert.dom(labelContentSelector);
-    assert.ok(labelContent, 'renders the label');
-
-    labelComponent = assert.dom(labelComponentSelector);
-    assert.ok(
-      labelComponent,
-      'with label component closure - renders the label component'
-    );
-    labelContent.hasText(
-      'test label component from component closure',
-      'with label component closure - renders the correct label content'
-    );
-
-    this.set('label', 'literal label');
-    labelContent.hasText(
-      'test label component from component closure',
-      'with label component closure and label - renders the correct label content'
-    );
-
-    this.set('useLabelComponent', false);
-    labelContent.hasText(
-      'literal label',
-      'with label - renders the correct label content'
-    );
+    assert
+      .dom(labelComponentSelector)
+      .exists('with label as component - renders the label component');
+    assert
+      .dom(labelContentSelector)
+      .hasText(
+        'test label component from component',
+        'with label component - renders the correct label content'
+      );
   });
 
   test('it handles label components correctly when a description is supplied', async function(assert) {
-    this.setProperties({
-      label: null,
-      labelComponent: 'test-label',
-    });
-
     await render(hbs`
       {{polaris-choice
-        label=label
-        labelComponent=labelComponent
+        label="some label"
         description="testing label components"
       }}
     `);
 
-    let labelContent = assert.dom(labelContentSelector);
-    assert.ok(labelContent, 'renders the label');
+    assert
+      .dom(labelContentSelector)
+      .exists('with label as plain string - renders the label');
 
-    const labelComponentSelector = buildNestedSelector(
-      labelContentSelector,
-      'div.test-label-component'
-    );
-    let labelComponent = assert.dom(labelComponentSelector);
-    assert.ok(
-      labelComponent,
-      'with label component string - renders the label component'
-    );
-    labelContent.hasText(
-      'test label component',
-      'with label component string - renders the correct label content'
-    );
-
-    this.set('label', 'literal label');
-    labelContent.hasText(
-      'test label component',
-      'with label component string and label - renders the correct label content'
-    );
-
-    this.set('labelComponent', null);
-    labelContent.hasText(
-      'literal label',
-      'with label - renders the correct label content'
-    );
-
-    this.setProperties({
-      label: null,
-      useLabelComponent: true,
-    });
     await render(hbs`
       {{polaris-choice
-        label=label
-        labelComponent=(if useLabelComponent (
-          component "test-label" text="test label component from component closure"
-        ))
+        label=(component "test-label" text="test label component from component")
       }}
     `);
 
-    labelContent = assert.dom(labelContentSelector);
-    assert.ok(labelContent, 'renders the label');
+    assert.dom(labelContentSelector).exists('renders the label');
 
-    labelComponent = assert.dom(labelComponentSelector);
-    assert.ok(
-      labelComponent,
-      'with label component closure - renders the label component'
-    );
-    labelContent.hasText(
-      'test label component from component closure',
-      'with label component closure - renders the correct label content'
-    );
-
-    this.set('label', 'literal label');
-    labelContent.hasText(
-      'test label component from component closure',
-      'with label component closure and label - renders the correct label content'
-    );
-
-    this.set('useLabelComponent', false);
-    labelContent.hasText(
-      'literal label',
-      'with label - renders the correct label content'
-    );
+    assert
+      .dom(labelComponentSelector)
+      .exists('with label as component - renders the label component');
+    assert
+      .dom(labelContentSelector)
+      .hasText(
+        'test label component from component',
+        'with label as component - renders the correct label content'
+      );
   });
 
   test('it handles the disabled attribute correctly', async function(assert) {

--- a/tests/integration/components/polaris-heading-test.js
+++ b/tests/integration/components/polaris-heading-test.js
@@ -3,6 +3,8 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
+const headingSelector = '[data-test-polaris-heading]';
+
 module('Integration | Component | polaris heading', function(hooks) {
   setupRenderingTest(hooks);
 
@@ -10,32 +12,48 @@ module('Integration | Component | polaris heading', function(hooks) {
     // Inline form with defaults.
     await render(hbs`{{polaris-heading text="This is a heading"}}`);
 
-    let headingSelector = 'h2.Polaris-Heading';
-    let heading = assert.dom('h2.Polaris-Heading');
-    heading.exists(
-      { count: 1 },
-      'inline with defaults - renders one h2 heading'
-    );
+    assert
+      .dom(headingSelector)
+      .exists({ count: 1 }, 'inline with defaults - renders one h2 heading');
+    assert
+      .dom(headingSelector)
+      .hasText(
+        'This is a heading',
+        'inline with defaults - renders correct text'
+      );
+    assert.dom(headingSelector).hasTagName('h2', 'renders correct element');
 
-    heading.hasText(
-      'This is a heading',
-      'inline with defaults - renders correct text'
-    );
-
-    // Block form with element specified.
+    // Block form with element specified using deprecated form
     await render(hbs`
       {{#polaris-heading tagName="em"}}
         This is an emphasised heading
       {{/polaris-heading}}
     `);
 
-    headingSelector = 'em.Polaris-Heading';
-    heading = assert.dom(headingSelector);
+    assert
+      .dom(headingSelector)
+      .hasText(
+        'This is an emphasised heading',
+        'block with customisation - renders correct text'
+      );
+    assert
+      .dom(headingSelector)
+      .hasTagName('em', 'block with customisation - renders correct element');
 
-    heading.exists({ count: 1 });
-    heading.hasText(
-      'This is an emphasised heading',
-      'block with customisation - renders correct text'
-    );
+    await render(hbs`
+      <PolarisHeading @htmlTag="em">
+        This is an emphasised heading
+      </PolarisHeading>
+    `);
+
+    assert
+      .dom(headingSelector)
+      .hasText(
+        'This is an emphasised heading',
+        'block with customisation - renders correct text'
+      );
+    assert
+      .dom(headingSelector)
+      .hasTagName('em', 'block with customisation - renders correct element');
   });
 });

--- a/tests/integration/components/polaris-text-field-test.js
+++ b/tests/integration/components/polaris-text-field-test.js
@@ -72,13 +72,15 @@ module('Integration | Component | polaris-text-field', function(hooks) {
 
     let input = assert.dom(inputSelector);
     input.hasClass('Polaris-TextField__Input', 'input has correct class');
-    input.hasNoAttribute(
+    input.hasAttribute(
       'aria-multiline',
-      'input element has no aria-multiline attribute'
+      'false',
+      'input element has aria-multiline attribute set to `false`'
     );
-    input.hasNoAttribute(
+    input.hasAttribute(
       'aria-invalid',
-      'input element has no aria-invalid attribute'
+      'false',
+      'input element has no aria-invalid attribute set to `false`'
     );
     input.hasNoClass(
       'Polaris-TextField__Input--suffixed',
@@ -233,7 +235,7 @@ module('Integration | Component | polaris-text-field', function(hooks) {
         .dom(inputSelector)
         .hasAttribute(
           'aria-invalid',
-          '',
+          'true',
           'input has aria-invalid attribute true'
         );
 
@@ -254,7 +256,7 @@ module('Integration | Component | polaris-text-field', function(hooks) {
         .dom(inputSelector)
         .hasAttribute(
           'aria-invalid',
-          '',
+          'true',
           'input has aria-invalid attribute true'
         );
     });
@@ -294,7 +296,7 @@ module('Integration | Component | polaris-text-field', function(hooks) {
         .dom(inputSelector)
         .hasAttribute(
           'aria-invalid',
-          '',
+          'true',
           'input has aria-invalid attribute true'
         );
       assert
@@ -539,7 +541,7 @@ module('Integration | Component | polaris-text-field', function(hooks) {
       .dom(inputSelector)
       .hasAttribute(
         'aria-multiline',
-        '',
+        'true',
         'input element has aria-multiline attribute'
       );
     assert.dom(resizerSelector).exists('when true - renders a resizer');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2018,6 +2018,19 @@ async-disk-cache@^1.2.1:
     rsvp "^3.0.18"
     username-sync "^1.0.2"
 
+async-disk-cache@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/async-disk-cache/-/async-disk-cache-2.1.0.tgz#e0f37b187ed8c41a5991518a9556d206ae2843a2"
+  integrity sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==
+  dependencies:
+    debug "^4.1.1"
+    heimdalljs "^0.2.3"
+    istextorbinary "^2.5.1"
+    mkdirp "^0.5.0"
+    rimraf "^3.0.0"
+    rsvp "^4.8.5"
+    username-sync "^1.0.2"
+
 async-each@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
@@ -2340,6 +2353,11 @@ babel-plugin-htmlbars-inline-precompile@^3.0.1:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-3.1.0.tgz#85085b50385277f2b331ebd54e22fa91aadc24e8"
   integrity sha512-ar6c4YVX6OV7Dzpq7xRyllQrHwVEzJf41qysYULnD6tu6TS+y1FxT2VcEvMC6b9Rq9xoHMzvB79HO3av89JCGg==
+
+babel-plugin-htmlbars-inline-precompile@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-4.1.0.tgz#11796422e65d900a968481fa3fb37e0425c928dd"
+  integrity sha512-gM+UP6HO5RlGiOQzJVGRUHgAsefJeOdh5Pn+rZRS6Tr1MnEqVgTJ2G2ywnl+G+Zcuec18fz7XA+O2tHhsmct6w==
 
 babel-plugin-istanbul@^5.1.0:
   version "5.2.0"
@@ -2814,7 +2832,7 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
 
-"binaryextensions@1 || 2":
+"binaryextensions@1 || 2", binaryextensions@^2.1.2:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-2.3.0.tgz#1d269cbf7e6243ea886aa41453c3651ccbe13c22"
   integrity sha512-nAihlQsYGyc5Bwq6+EsubvANYGExeJKHDO3RjnvwU042fawQTQfM3Kxn7IHUXQOz4bzfwsGYYHGSvXyW4zOGLg==
@@ -3338,6 +3356,24 @@ broccoli-persistent-filter@^2.2.1, broccoli-persistent-filter@^2.2.2, broccoli-p
     sync-disk-cache "^1.3.3"
     walk-sync "^1.0.0"
 
+broccoli-persistent-filter@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.0.tgz#5812abbc000b2409ef40addeeed16a2a9482696e"
+  integrity sha512-yHHPv7M04qb9ajo3QkbGWetpshekVYG8sSjNdgAPQQ3spiRvS6RthYBddni5iw9b2DidSCpe/YPGRnp7LL4OIQ==
+  dependencies:
+    async-disk-cache "^2.0.0"
+    async-promise-queue "^1.0.3"
+    broccoli-plugin "^4.0.3"
+    fs-tree-diff "^2.0.0"
+    hash-for-dep "^1.5.0"
+    heimdalljs "^0.2.1"
+    heimdalljs-logger "^0.1.7"
+    mkdirp "^0.5.1"
+    promise-map-series "^0.2.1"
+    rimraf "^3.0.0"
+    symlink-or-copy "^1.0.1"
+    sync-disk-cache "^2.0.0"
+
 broccoli-plugin@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-1.1.0.tgz#73e2cfa05f8ea1e3fc1420c40c3d9e7dc724bf02"
@@ -3381,7 +3417,7 @@ broccoli-plugin@^3.1.0:
     rimraf "^2.3.4"
     symlink-or-copy "^1.1.8"
 
-broccoli-plugin@^4.0.1, broccoli-plugin@^4.0.2:
+broccoli-plugin@^4.0.1, broccoli-plugin@^4.0.2, broccoli-plugin@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-4.0.3.tgz#9dcfbfb6a1b27a37cc22e65c071719ce9f92bc1e"
   integrity sha512-CtAIEYq5K+4yQv8c/BHymOteuyjDAJfvy/asu4LudIWcMSS7dTn3yGI5gNBkwHG+qlRangYkHJNVAcDZMQbSVQ==
@@ -5007,6 +5043,14 @@ editions@^1.1.1:
   resolved "https://registry.yarnpkg.com/editions/-/editions-1.3.4.tgz#3662cb592347c3168eb8e498a0ff73271d67f50b"
   integrity sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==
 
+editions@^2.2.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/editions/-/editions-2.3.1.tgz#3bc9962f1978e801312fbd0aebfed63b49bfe698"
+  integrity sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==
+  dependencies:
+    errlop "^2.0.0"
+    semver "^6.3.0"
+
 editor@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/editor/-/editor-1.0.0.tgz#60c7f87bd62bcc6a894fa8ccd6afb7823a24f742"
@@ -5125,7 +5169,7 @@ ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.16.0, ember-cli-babel@^6.6.0, 
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.11.0, ember-cli-babel@^7.11.1, ember-cli-babel@^7.12.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.18.0, ember-cli-babel@^7.19.0, ember-cli-babel@^7.2.0, ember-cli-babel@^7.4.1, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.11.0, ember-cli-babel@^7.11.1, ember-cli-babel@^7.12.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.17.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.19.0, ember-cli-babel@^7.2.0, ember-cli-babel@^7.4.1, ember-cli-babel@^7.7.3:
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.21.0.tgz#c79e888876aee87dfc3260aee7cb580b74264bbc"
   integrity sha512-jHVi9melAibo0DrAG3GAxid+29xEyjBoU53652B4qcu3Xp58feZGTH/JGXovH7TjvbeNn65zgNyoV3bk1onULw==
@@ -5269,6 +5313,27 @@ ember-cli-htmlbars@^4.2.0, ember-cli-htmlbars@^4.3.1:
     semver "^6.3.0"
     strip-bom "^4.0.0"
     walk-sync "^2.0.2"
+
+ember-cli-htmlbars@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-5.2.0.tgz#5ceccd0d18163dd810dea29f6fd777d0baa01e23"
+  integrity sha512-EdjuUc7sq9ve6sgsG59qIzOj4svWjgYhO/QEhuV1UbOQ3ATeqNPiD++bFeAGjUhravw9HPhQPPoHnMlAikqLIw==
+  dependencies:
+    "@ember/edition-utils" "^1.2.0"
+    babel-plugin-htmlbars-inline-precompile "^4.1.0"
+    broccoli-debug "^0.6.5"
+    broccoli-persistent-filter "^3.1.0"
+    broccoli-plugin "^4.0.3"
+    common-tags "^1.8.0"
+    ember-cli-babel-plugin-helpers "^1.1.0"
+    fs-tree-diff "^2.0.1"
+    hash-for-dep "^1.5.1"
+    heimdalljs-logger "^0.1.10"
+    json-stable-stringify "^1.0.1"
+    semver "^7.3.2"
+    silent-error "^1.1.1"
+    strip-bom "^4.0.0"
+    walk-sync "^2.1.0"
 
 ember-cli-inject-live-reload@^2.0.2:
   version "2.0.2"
@@ -5538,7 +5603,7 @@ ember-cli@~3.18.0:
     watch-detector "^1.0.0"
     yam "^1.0.0"
 
-ember-compatibility-helpers@^1.1.2:
+ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.1.tgz#87c92c4303f990ff455c28ca39fb3ee11441aa16"
   integrity sha512-6wzYvnhg1ihQUT5yGqnLtleq3Nv5KNv79WhrEuNU9SwR4uIxCO+KpyC7r3d5VI0EM7/Nmv9Nd0yTkzmTMdVG1A==
@@ -5583,12 +5648,14 @@ ember-disable-prototype-extensions@^1.1.3:
   resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz#1969135217654b5e278f9fe2d9d4e49b5720329e"
   integrity sha1-GWkTUhdlS14nj5/i2dTkm1cgMp4=
 
-ember-element-helper@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/ember-element-helper/-/ember-element-helper-0.1.1.tgz#ffd2a0566b22a13c0e7780ae96443f4ffda2e63d"
-  integrity sha512-MfES7MbZ5UcHTo1lutJCcz6hI+/CadurWcOR3kOQl0jKcBKdAWyYIJXK4u0FDXzlgKczX9vL3R2eJUtnGe144w==
+ember-element-helper@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/ember-element-helper/-/ember-element-helper-0.3.1.tgz#dd6017a64a9952058c16050c7a9eb0fff5ebfe90"
+  integrity sha512-U3tXkhiPsL1uIz2jCBZS4Lot0Le0wt7RM7TArYAR5OZRLGdCaLkRjQ0Xx5IlwWbBS0KOrfARevc1OLnX1AIgZQ==
   dependencies:
-    ember-cli-babel "^6.16.0"
+    ember-cli-babel "^7.17.2"
+    ember-cli-htmlbars "^5.1.0"
+    ember-compatibility-helpers "^1.2.1"
 
 ember-event-helpers@^0.1.0:
   version "0.1.0"
@@ -5945,6 +6012,11 @@ entities@^2.0.0, entities@~2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
   integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
+
+errlop@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/errlop/-/errlop-2.2.0.tgz#1ff383f8f917ae328bebb802d6ca69666a42d21b"
+  integrity sha512-e64Qj9+4aZzjzzFpZC7p5kmm/ccCrbLhAJplhsDXQFs87XTsXwOpH4s1Io2s90Tau/8r2j9f4l/thhDevRjzxw==
 
 errno@^0.1.3, errno@~0.1.7:
   version "0.1.7"
@@ -8352,6 +8424,15 @@ istextorbinary@2.1.0:
     binaryextensions "1 || 2"
     editions "^1.1.1"
     textextensions "1 || 2"
+
+istextorbinary@^2.5.1:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/istextorbinary/-/istextorbinary-2.6.0.tgz#60776315fb0fa3999add276c02c69557b9ca28ab"
+  integrity sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==
+  dependencies:
+    binaryextensions "^2.1.2"
+    editions "^2.2.0"
+    textextensions "^2.5.0"
 
 isurl@^1.0.0-alpha5:
   version "1.0.0"
@@ -12568,6 +12649,17 @@ sync-disk-cache@^1.3.3:
     rimraf "^2.2.8"
     username-sync "^1.0.2"
 
+sync-disk-cache@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz#01e879edc41c34a01fcdda5b39d47dd496e154a6"
+  integrity sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==
+  dependencies:
+    debug "^4.1.1"
+    heimdalljs "^0.2.6"
+    mkdirp "^0.5.0"
+    rimraf "^3.0.0"
+    username-sync "^1.0.2"
+
 table@^5.2.3:
   version "5.4.6"
   resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
@@ -12689,7 +12781,7 @@ text-table@^0.2.0, text-table@~0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-"textextensions@1 || 2":
+"textextensions@1 || 2", textextensions@^2.5.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/textextensions/-/textextensions-2.6.0.tgz#d7e4ab13fe54e32e08873be40d51b74229b00fc4"
   integrity sha512-49WtAWS+tcsy93dRt6P0P3AMD2m5PvXRhuEA0kaXos5ZLlujtYmpmFsB+QvWUSxE1ZsstmYXfQ7L40+EcQgpAQ==
@@ -13308,6 +13400,16 @@ walk-sync@^2.0.0, walk-sync@^2.0.2:
     "@types/minimatch" "^3.0.3"
     ensure-posix-path "^1.1.0"
     matcher-collection "^2.0.0"
+
+walk-sync@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-2.2.0.tgz#80786b0657fcc8c0e1c0b1a042a09eae2966387a"
+  integrity sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==
+  dependencies:
+    "@types/minimatch" "^3.0.3"
+    ensure-posix-path "^1.1.0"
+    matcher-collection "^2.0.0"
+    minimatch "^3.0.4"
 
 walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
- adds few files missed for `text-field` component during modernization PR
- deprecates passing `@tagName` to some components and replaces it with `htmlTag`
- some cleanup: no `.get` where it's not needed
- fixes the version for new deprecations added - _this will be `v6` so we'll support those through to `v7`_
- [Breaking] removes long deprecated `labelComponent` for `choice` component