### PR TITLE
Stop curring click event to action handlers

### DIFF
--- a/addon/components/polaris-button.js
+++ b/addon/components/polaris-button.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { action, computed } from '@ember/object';
 import { or } from '@ember/object/computed';
 import { isPresent } from '@ember/utils';
 import { classify } from '@ember/string';
@@ -370,5 +370,10 @@ export default class PolarisButtonComponent extends Component {
         until: '7.0.0',
       }
     );
+  }
+
+  @action
+  handleClick(/* event */) {
+    this.onClick();
   }
 }

--- a/addon/components/polaris-link.js
+++ b/addon/components/polaris-link.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { action, computed } from '@ember/object';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../templates/components/polaris-link';
 
@@ -72,5 +72,10 @@ export default class PolarisLink extends Component {
     }
 
     return linkClasses.join(' ');
+  }
+
+  @action
+  handleClick(/* event */) {
+    this.onClick();
   }
 }

--- a/addon/components/polaris-page/action.js
+++ b/addon/components/polaris-page/action.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { action, computed } from '@ember/object';
 import { isBlank } from '@ember/utils';
 import { tagName, layout } from '@ember-decorators/component';
 import template from '../../templates/components/polaris-page/action';
@@ -66,8 +66,6 @@ export default class ActionComponent extends Component {
    */
   onAction() {}
 
-  type = 'button';
-
   handleMouseUpByBlurring = handleMouseUpByBlurring;
 
   @computed('text', 'icon')
@@ -87,5 +85,10 @@ export default class ActionComponent extends Component {
     }
 
     return classes.join(' ');
+  }
+
+  @action
+  handleClick(/* event */) {
+    this.onAction();
   }
 }

--- a/addon/components/polaris-resource-list/checkable-button.js
+++ b/addon/components/polaris-resource-list/checkable-button.js
@@ -111,7 +111,8 @@ export default class CheckableButton extends Component {
   }
 
   @action
-  toggleAll(/* event */) {
+  toggleAll(event) {
+    event.stopPropagation();
     this.onToggleAll();
   }
 }

--- a/addon/components/polaris-resource-list/checkable-button.js
+++ b/addon/components/polaris-resource-list/checkable-button.js
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import { action, computed } from '@ember/object';
 import { not, and } from '@ember/object/computed';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../templates/components/polaris-resource-list/checkable-button';
@@ -76,4 +77,41 @@ export default class CheckableButton extends Component {
 
   @and('isNotPlain', 'measuring')
   shouldApplyMeasuringClass;
+
+  @computed(
+    'plain',
+    'shouldApplySelectModeClass',
+    'shouldApplySelectedClass',
+    'shouldApplyMeasuringClass'
+  )
+  get classes() {
+    let classes = ['Polaris-ResourceList-CheckableButton'];
+    if (this.plain) {
+      classes.push(
+        'Polaris-ResourceList-CheckableButton__CheckableButton--plain'
+      );
+    }
+    if (this.shouldApplySelectModeClass) {
+      classes.push(
+        'Polaris-ResourceList-CheckableButton__CheckableButton--selectMode'
+      );
+    }
+    if (this.shouldApplySelectedClass) {
+      classes.push(
+        'Polaris-ResourceList-CheckableButton__CheckableButton--selected'
+      );
+    }
+    if (this.shouldApplyMeasuringClass) {
+      classes.push(
+        'Polaris-ResourceList-CheckableButton__CheckableButton--measuring'
+      );
+    }
+
+    return classes.join(' ');
+  }
+
+  @action
+  toggleAll(/* event */) {
+    this.onToggleAll();
+  }
 }

--- a/addon/components/polaris-unstyled-link.js
+++ b/addon/components/polaris-unstyled-link.js
@@ -147,6 +147,6 @@ export default class PolarisUnstyledLinkComponent extends Component {
   @action
   handleClick(event) {
     event.stopPropagation();
-    this.onClick(event);
+    this.onClick();
   }
 }

--- a/addon/templates/components/polaris-button.hbs
+++ b/addon/templates/components/polaris-button.hbs
@@ -1,4 +1,4 @@
-{{#with
+{{#let
   (component
     "polaris-button/content"
     text=@text
@@ -40,10 +40,10 @@
         @external={{@external}}
         @download={{@download}}
         @ariaLabel={{@accessibilityLabel}}
-        @onClick={{action this.onClick}}
-        @onFocus={{action this.onFocus}}
-        @onBlur={{action this.onBlur}}
-        @onMouseUp={{action this.handleMouseUpByBlurring}}
+        @onClick={{this.handleClick}}
+        @onFocus={{this.onFocus}}
+        @onBlur={{this.onBlur}}
+        @onMouseUp={{this.handleMouseUpByBlurring}}
         ...attributes
       >
         {{#if hasBlock}}
@@ -68,7 +68,7 @@
       aria-controls={{@ariaControls}}
       aria-expanded={{if @ariaExpanded "true"}}
       aria-pressed={{if @ariaPressed "true"}}
-      {{on "click" this.onClick}}
+      {{on "click" this.handleClick}}
       {{on "focus" this.onFocus}}
       {{on "blur" this.onBlur}}
       {{on "keydown" this.onKeyDown}}
@@ -86,4 +86,4 @@
       {{/if}}
     </button>
   {{/if}}
-{{/with}}
+{{/let}}

--- a/addon/templates/components/polaris-button.hbs
+++ b/addon/templates/components/polaris-button.hbs
@@ -68,7 +68,7 @@
       aria-controls={{@ariaControls}}
       aria-expanded={{if @ariaExpanded "true"}}
       aria-pressed={{if @ariaPressed "true"}}
-      {{on "click" this.handleClick}}
+      {{on "click" (stop-propagation this.handleClick)}}
       {{on "focus" this.onFocus}}
       {{on "blur" this.onBlur}}
       {{on "keydown" this.onKeyDown}}

--- a/addon/templates/components/polaris-link.hbs
+++ b/addon/templates/components/polaris-link.hbs
@@ -3,7 +3,7 @@
     class={{this.linkClass}}
     @url={{@url}}
     @external={{@external}}
-    @onClick={{fn (or @onClick this.onClick)}}
+    @onClick={{this.handleClick}}
   >
     {{#if hasBlock}}
       {{yield}}
@@ -15,7 +15,7 @@
   <button
     type="button"
     class={{this.linkClass}}
-    {{on "click" (stop-propagation (or @onClick this.onClick))}}
+    {{on "click" (stop-propagation this.handleClick)}}
   >
     {{#if hasBlock}}
       {{yield}}

--- a/addon/templates/components/polaris-page/action.hbs
+++ b/addon/templates/components/polaris-page/action.hbs
@@ -1,10 +1,10 @@
 {{! TODO: support url }}
 <button
+  type="button"
   class={{this.classes}}
   aria-label={{@accessibilityLabel}}
   disabled={{@disabled}}
-  type={{this.type}}
-  {{on "click" this.onAction}}
+  {{on "click" this.handleClick}}
   {{on "mouseup" this.handleMouseUpByBlurring}}
 >
   {{#if (or @icon @disclosure)}}

--- a/addon/templates/components/polaris-page/action.hbs
+++ b/addon/templates/components/polaris-page/action.hbs
@@ -4,7 +4,7 @@
   class={{this.classes}}
   aria-label={{@accessibilityLabel}}
   disabled={{@disabled}}
-  {{on "click" this.handleClick}}
+  {{on "click" (stop-propagation this.handleClick)}}
   {{on "mouseup" this.handleMouseUpByBlurring}}
 >
   {{#if (or @icon @disclosure)}}

--- a/addon/templates/components/polaris-resource-list/checkable-button.hbs
+++ b/addon/templates/components/polaris-resource-list/checkable-button.hbs
@@ -1,12 +1,7 @@
 {{!-- template-lint-disable no-invalid-interactive --}}
 <div
-  {{on "click" (fn (or @onToggleAll this.onToggleAll))}}
-  class="Polaris-ResourceList-CheckableButton
-    {{if this.plain "Polaris-ResourceList-CheckableButton__CheckableButton--plain"}}
-    {{if this.shouldApplySelectModeClass "Polaris-ResourceList-CheckableButton__CheckableButton--selectMode"}}
-    {{if this.shouldApplySelectedClass "Polaris-ResourceList-CheckableButton__CheckableButton--selected"}}
-    {{if this.shouldApplyMeasuringClass "Polaris-ResourceList-CheckableButton__CheckableButton--measuring"}}
-  "
+  class={{this.classes}}
+  {{on "click" this.toggleAll}}
   ...attributes
 >
   <div class="Polaris-ResourceList-CheckableButton__Checkbox">

--- a/tests/integration/components/polaris-button-test.js
+++ b/tests/integration/components/polaris-button-test.js
@@ -235,31 +235,21 @@ module('Integration | Component | polaris-button', function(hooks) {
     module('onClick()', function() {
       test('is called when the button is clicked', async function(assert) {
         this.set('handleClick', (_myArg, event) => {
-          assert.ok(true, 'triggers onClick handler');
-          assert.ok(
-            event instanceof MouseEvent,
-            'receives the MouseEvent as last argument'
-          );
+          assert.ok(true, 'triggers @onClick handler');
+          assert.notOk(event, 'does not curry click event to @onClick');
         });
 
-        await render(
-          hbs`{{polaris-button onClick=(action handleClick "myArg")}}`
-        );
+        await render(hbs`{{polaris-button onClick=this.handleClick}}`);
         await click('button');
       });
 
       test('is called when the link is clicked', async function(assert) {
-        this.set('handleClick', (_myArg, event) => {
-          assert.ok(true, 'triggers onClick handler');
-          assert.ok(
-            event instanceof MouseEvent,
-            'receives the MouseEvent as last argument'
-          );
+        this.set('handleClick', (event) => {
+          assert.ok(true, 'triggers @onClick handler');
+          assert.notOk(event, 'does not curry click event to @onClick');
         });
 
-        await render(
-          hbs`{{polaris-button onClick=(action handleClick "myArg") url="#"}}`
-        );
+        await render(hbs`{{polaris-button onClick=this.handleClick url="#"}}`);
         await click('[data-polaris-unstyled]');
       });
     });

--- a/tests/integration/components/polaris-button-test.js
+++ b/tests/integration/components/polaris-button-test.js
@@ -234,22 +234,34 @@ module('Integration | Component | polaris-button', function(hooks) {
 
     module('onClick()', function() {
       test('is called when the button is clicked', async function(assert) {
-        this.set('handleClick', (_myArg, event) => {
+        this.handleWrapperClick = () =>
+          assert.notOk(true, "click event doesn't bubble");
+        this.handleClick = (event) => {
           assert.ok(true, 'triggers @onClick handler');
           assert.notOk(event, 'does not curry click event to @onClick');
-        });
+        };
 
-        await render(hbs`{{polaris-button onClick=this.handleClick}}`);
+        await render(hbs`
+          {{!-- template-lint-disable no-invalid-interactive--}}
+          <div {{on "click" this.handleWrapperClick}}>{{polaris-button onClick=this.handleClick}}</div>
+        `);
+
         await click('button');
       });
 
       test('is called when the link is clicked', async function(assert) {
-        this.set('handleClick', (event) => {
+        this.handleWrapperClick = () =>
+          assert.notOk("click event doesn't bubble");
+        this.handleClick = (event) => {
           assert.ok(true, 'triggers @onClick handler');
           assert.notOk(event, 'does not curry click event to @onClick');
-        });
+        };
 
-        await render(hbs`{{polaris-button onClick=this.handleClick url="#"}}`);
+        await render(hbs`
+          {{!-- template-lint-disable no-invalid-interactive--}}
+          <div {{on "click" this.handleWrapperClick}}>{{polaris-button onClick=this.handleClick url="#"}}</div>
+        `);
+
         await click('[data-polaris-unstyled]');
       });
     });

--- a/tests/integration/components/polaris-link-test.js
+++ b/tests/integration/components/polaris-link-test.js
@@ -195,10 +195,7 @@ module('Integration | Component | polaris link', function(hooks) {
       assert.notOk(true, "click event doesn't bubble to the parent");
     this.handleClick = (event) => {
       assert.ok(true, '@onClick handler is fired');
-      assert.notOk(
-        event,
-        'click event is not passed as argument to @onClick handler'
-      );
+      assert.notOk(event, 'click event is not curried to @onClick handler');
     };
 
     await render(hbs`
@@ -225,10 +222,7 @@ module('Integration | Component | polaris link', function(hooks) {
       assert.notOk(true, "click event doesn't bubble to the parent");
     this.handleClick = (event) => {
       assert.ok(true, '@onClick handler is fired');
-      assert.notOk(
-        event,
-        'click event is not passed as argument to @onClick handler'
-      );
+      assert.notOk(event, 'click event is not curried to @onClick handler');
     };
 
     await render(hbs`

--- a/tests/integration/components/polaris-link-test.js
+++ b/tests/integration/components/polaris-link-test.js
@@ -6,12 +6,6 @@ import hbs from 'htmlbars-inline-precompile';
 module('Integration | Component | polaris link', function(hooks) {
   setupRenderingTest(hooks);
 
-  hooks.beforeEach(function() {
-    this.actions = {};
-    this.send = (actionName, ...args) =>
-      this.actions[actionName].apply(this, args);
-  });
-
   const linkSelector = 'a.Polaris-Link';
   const linkButtonSelector = 'button.Polaris-Link';
 
@@ -20,29 +14,34 @@ module('Integration | Component | polaris link', function(hooks) {
       hbs`{{polaris-link url="http://www.somewhere.com/" text="This is an inline link"}}`
     );
 
-    const links = assert.dom(linkSelector);
-    links.exists({ count: 1 }, 'renders one link');
+    assert.dom(linkSelector).exists({ count: 1 }, 'renders one link');
+    assert
+      .dom(linkSelector)
+      .hasAttribute(
+        'href',
+        'http://www.somewhere.com/',
+        'renders the correct href'
+      );
+    assert
+      .dom(linkSelector)
+      .hasText('This is an inline link', 'renders the correct link text');
 
-    links.hasAttribute(
-      'href',
-      'http://www.somewhere.com/',
-      'renders the correct href'
-    );
-    links.hasText('This is an inline link', 'renders the correct link text');
-
-    links.hasAttribute(
-      'data-polaris-unstyled',
-      'true',
-      'applies data-polaris-unstyled to the link'
-    );
-    links.doesNotHaveAttribute(
-      'target',
-      'does not set a target attribute on the link'
-    );
-    links.doesNotHaveAttribute(
-      'rel',
-      'does not set a rel attribute on the link'
-    );
+    assert
+      .dom(linkSelector)
+      .hasAttribute(
+        'data-polaris-unstyled',
+        'true',
+        'applies data-polaris-unstyled to the link'
+      );
+    assert
+      .dom(linkSelector)
+      .doesNotHaveAttribute(
+        'target',
+        'does not set a target attribute on the link'
+      );
+    assert
+      .dom(linkSelector)
+      .doesNotHaveAttribute('rel', 'does not set a rel attribute on the link');
   });
 
   test('it renders the correct HTML in basic block usage with a URL', async function(assert) {
@@ -52,28 +51,33 @@ module('Integration | Component | polaris link', function(hooks) {
       {{/polaris-link}}
     `);
 
-    const links = assert.dom(linkSelector);
-    links.exists({ count: 1 }, 'renders one link');
-
-    links.hasAttribute(
-      'href',
-      'http://www.somewhere.com/',
-      'renders the correct href'
-    );
-    links.hasText('This is a block link', 'renders the correct link text');
-    links.hasAttribute(
-      'data-polaris-unstyled',
-      'true',
-      'applies data-polaris-unstyled to the link'
-    );
-    links.doesNotHaveAttribute(
-      'target',
-      'does not set a target attribute on the link'
-    );
-    links.doesNotHaveAttribute(
-      'rel',
-      'does not set a rel attribute on the link'
-    );
+    assert.dom(linkSelector).exists({ count: 1 }, 'renders one link');
+    assert
+      .dom(linkSelector)
+      .hasAttribute(
+        'href',
+        'http://www.somewhere.com/',
+        'renders the correct href'
+      );
+    assert
+      .dom(linkSelector)
+      .hasText('This is a block link', 'renders the correct link text');
+    assert
+      .dom(linkSelector)
+      .hasAttribute(
+        'data-polaris-unstyled',
+        'true',
+        'applies data-polaris-unstyled to the link'
+      );
+    assert
+      .dom(linkSelector)
+      .doesNotHaveAttribute(
+        'target',
+        'does not set a target attribute on the link'
+      );
+    assert
+      .dom(linkSelector)
+      .doesNotHaveAttribute('rel', 'does not set a rel attribute on the link');
   });
 
   test('it renders the correct HTML with external attribute', async function(assert) {
@@ -85,20 +89,21 @@ module('Integration | Component | polaris link', function(hooks) {
       }}
     `);
 
-    const links = assert.dom(linkSelector);
-    links.exists({ count: 1 }, 'renders one link');
+    assert
+      .dom(linkSelector)
+      .hasAttribute(
+        'target',
+        '_blank',
+        'sets the correct target attribute on the link'
+      );
 
-    links.hasAttribute(
-      'target',
-      '_blank',
-      'sets the correct target attribute on the link'
-    );
-
-    links.hasAttribute(
-      'rel',
-      'noopener noreferrer',
-      'sets the correct rel attribute on the link'
-    );
+    assert
+      .dom(linkSelector)
+      .hasAttribute(
+        'rel',
+        'noopener noreferrer',
+        'sets the correct rel attribute on the link'
+      );
   });
 
   test('it renders the correct HTML with monochrome attribute', async function(assert) {
@@ -110,25 +115,26 @@ module('Integration | Component | polaris link', function(hooks) {
       }}
     `);
 
-    const links = assert.dom(linkSelector);
-    links.exists({ count: 1 }, 'renders one link');
-
-    links.hasClass(
-      'Polaris-Link--monochrome',
-      'sets the monochrome class on the link'
-    );
+    assert
+      .dom(linkSelector)
+      .hasClass(
+        'Polaris-Link--monochrome',
+        'sets the monochrome class on the link'
+      );
   });
 
   test('it renders the correct HTML in basic inline usage without a URL', async function(assert) {
     await render(hbs`{{polaris-link text="This is an inline link button"}}`);
 
-    const linkButtons = assert.dom(linkButtonSelector);
-    linkButtons.exists({ count: 1 }, 'renders one link button');
-
-    linkButtons.hasText(
-      'This is an inline link button',
-      'renders the correct link text'
-    );
+    assert
+      .dom(linkButtonSelector)
+      .exists({ count: 1 }, 'renders one link button');
+    assert
+      .dom(linkButtonSelector)
+      .hasText(
+        'This is an inline link button',
+        'renders the correct link text'
+      );
   });
 
   test('it renders the correct HTML in basic block usage without a URL', async function(assert) {
@@ -138,44 +144,38 @@ module('Integration | Component | polaris link', function(hooks) {
       {{/polaris-link}}
     `);
 
-    const linkButton = assert.dom(linkButtonSelector);
-
-    linkButton.exists({ count: 1 }, 'renders one link button');
-
-    linkButton.hasText(
-      'This is a block link button',
-      'renders the correct link text'
-    );
+    assert
+      .dom(linkButtonSelector)
+      .exists({ count: 1 }, 'renders one link button');
+    assert
+      .dom(linkButtonSelector)
+      .hasText('This is a block link button', 'renders the correct link text');
   });
 
   test('it handles click events correctly', async function(assert) {
-    let clickHandlerCalled = false;
-    this.actions.click = () => (clickHandlerCalled = true);
+    this.handleClick = () => assert.ok('onClick is fired correctly');
 
-    await render(hbs`{{polaris-link onClick=(action "click")}}`);
+    await render(hbs`{{polaris-link onClick=this.handleClick}}`);
 
     assert
       .dom(linkButtonSelector)
       .exists({ count: 1 }, 'renders one link button');
 
     await click(linkButtonSelector);
-    assert.ok(clickHandlerCalled, 'click handler fired');
   });
 
   test('clicking a link navigates but does not bubble to the parent', async function(assert) {
     // Reset the hash part of the browser URL to keep this test valid on reruns.
     window.location.hash = 'linkNotClicked';
 
-    let parentHandlerCalled = false;
-    this.actions.parentClicked = () => (parentHandlerCalled = true);
+    this.handleParentClicked = () => assert.notOk("click event doesn't bubble");
 
     await render(hbs`
-      <div {{action (action "parentClicked")}}>
+      {{!-- template-lint-disable no-invalid-interactive --}}
+      <div {{on "click" this.handleParentClicked}}>
         {{polaris-link url="#linkClicked"}}
       </div>
     `);
-
-    assert.dom(linkSelector).exists({ count: 1 }, 'renders one link');
 
     await click(linkSelector);
     assert.equal(
@@ -183,27 +183,32 @@ module('Integration | Component | polaris link', function(hooks) {
       '#linkClicked',
       'app navigates to specified URL'
     );
-    assert.notOk(parentHandlerCalled, 'parent click handler is not fired');
   });
 
   test('clicking a link fires the onClick handler if present', async function(assert) {
     // Reset the hash part of the browser URL to keep this test valid on reruns.
     window.location.hash = 'linkNotClicked';
 
-    this.set('clickHandlerCalled', false);
-    let parentHandlerCalled = false;
-    this.actions.parentClicked = () => (parentHandlerCalled = true);
+    assert.expect(3);
+
+    this.handleParentClicked = () =>
+      assert.notOk(true, "click event doesn't bubble to the parent");
+    this.handleClick = (event) => {
+      assert.ok(true, '@onClick handler is fired');
+      assert.notOk(
+        event,
+        'click event is not passed as argument to @onClick handler'
+      );
+    };
 
     await render(hbs`
-      <div {{action (action "parentClicked")}}>
+      <div {{on "click" this.handleParentClicked}}>
         {{polaris-link
           url="#linkClicked"
-          onClick=(action (mut clickHandlerCalled) true)
+          onClick=this.handleClick
         }}
       </div>
     `);
-
-    assert.dom(linkSelector).exists({ count: 1 }, 'renders one link');
 
     await click(linkSelector);
     assert.equal(
@@ -211,20 +216,24 @@ module('Integration | Component | polaris link', function(hooks) {
       '#linkClicked',
       'app navigates to specified URL'
     );
-    assert.ok(this.get('clickHandlerCalled'), 'link click handler is fired');
-    assert.notOk(parentHandlerCalled, 'parent click handler is not fired');
   });
 
   test('clicking a link button performs the button action but does not bubble to the parent', async function(assert) {
-    let parentHandlerCalled = false;
-    let buttonHandlerCalled = false;
+    assert.expect(3);
 
-    this.actions.parentClicked = () => (parentHandlerCalled = true);
-    this.actions.buttonClicked = () => (buttonHandlerCalled = true);
+    this.handleParentClicked = () =>
+      assert.notOk(true, "click event doesn't bubble to the parent");
+    this.handleClick = (event) => {
+      assert.ok(true, '@onClick handler is fired');
+      assert.notOk(
+        event,
+        'click event is not passed as argument to @onClick handler'
+      );
+    };
 
     await render(hbs`
-      <div {{action (action "parentClicked")}}>
-        {{polaris-link onClick=(action "buttonClicked")}}
+      <div {{on "click" this.handleParentClicked}}>
+        {{polaris-link onClick=this.handleClick}}
       </div>
     `);
 
@@ -233,8 +242,6 @@ module('Integration | Component | polaris link', function(hooks) {
       .exists({ count: 1 }, 'renders one link button');
 
     await click(linkButtonSelector);
-    assert.ok(buttonHandlerCalled, 'button click handler is fired');
-    assert.notOk(parentHandlerCalled, 'parent click handler is not fired');
   });
 
   test('it applies passed-in classes to the rendered element when rendering a link', async function(assert) {

--- a/tests/integration/components/polaris-page-test.js
+++ b/tests/integration/components/polaris-page-test.js
@@ -146,11 +146,16 @@ module('Integration | Component | polaris page', function(hooks) {
   });
 
   test('it handles primary action correctly when supplied', async function(assert) {
-    let primaryActionFired = false;
-    this.actions.primaryActionFired = () => {
-      primaryActionFired = true;
-    };
+    assert.expect(8);
+
     this.setProperties({
+      handleClick: (event) => {
+        assert.ok(true, 'triggers @onAction handler');
+        assert.notOk(
+          event,
+          'does not curry click event to the @onAction handler'
+        );
+      },
       primaryActionDisabled: true,
       primaryActionLoading: false,
     });
@@ -160,47 +165,48 @@ module('Integration | Component | polaris page', function(hooks) {
         title="This is the title"
         primaryAction=(hash
           text="Take action!"
-          disabled=primaryActionDisabled
-          loading=primaryActionLoading
-          onAction=(action "primaryActionFired")
+          disabled=this.primaryActionDisabled
+          loading=this.primaryActionLoading
+          onAction=this.handleClick
         )
       }}
     `);
 
-    const primaryButtons = assert.dom(primaryButtonSelector);
-    primaryButtons.exists({ count: 1 }, 'renders one primary button');
-
-    primaryButtons.hasText(
-      'Take action!',
-      'uses correct text on primary button'
-    );
-
-    primaryButtons.isDisabled('primary action button is initially disabled');
-    primaryButtons.hasNoClass(
-      'Polaris-Button--loading',
-      'primary action button is not initially in loading state'
-    );
+    assert
+      .dom(primaryButtonSelector)
+      .exists({ count: 1 }, 'renders one primary button');
+    assert
+      .dom(primaryButtonSelector)
+      .hasText('Take action!', 'uses correct text on primary button');
+    assert
+      .dom(primaryButtonSelector)
+      .isDisabled('primary action button is initially disabled');
+    assert
+      .dom(primaryButtonSelector)
+      .hasNoClass(
+        'Polaris-Button--loading',
+        'primary action button is not initially in loading state'
+      );
 
     this.setProperties({
       primaryActionDisabled: false,
       primaryActionLoading: true,
     });
 
-    primaryButtons.hasClass(
-      'Polaris-Button--loading',
-      'primary action button goes into loading state'
-    );
+    assert
+      .dom(primaryButtonSelector)
+      .hasClass(
+        'Polaris-Button--loading',
+        'primary action button goes into loading state'
+      );
 
     this.set('primaryActionLoading', false);
 
-    primaryButtons.isNotDisabled('primary action button becomes enabled');
-    assert.notOk(
-      primaryActionFired,
-      "hasn't fired primary action before clicking button"
-    );
+    assert
+      .dom(primaryButtonSelector)
+      .isNotDisabled('primary action button becomes enabled');
 
     await click(primaryButtonSelector);
-    assert.ok(primaryActionFired, 'fires primary action on click');
   });
 
   test('it handles secondary actions correctly when supplied', async function(assert) {

--- a/tests/integration/components/polaris-page-test.js
+++ b/tests/integration/components/polaris-page-test.js
@@ -218,21 +218,26 @@ module('Integration | Component | polaris page', function(hooks) {
     this.actions.secondaryAction2 = () => {
       secondaryAction2Fired = true;
     };
+    this.handleWrapperClick = () =>
+      assert.notOk(true, "click event doesn't bubble");
 
     await render(hbs`
-      {{polaris-page
-        title="This is the title"
-        secondaryActions=(array
-          (hash
-            text="First secondary action"
-            onAction=(action "secondaryAction1")
+      {{!-- template-lint-disable no-invalid-interactive--}}
+      <div {{on "click" this.handleWrapperClick}}>
+        {{polaris-page
+          title="This is the title"
+          secondaryActions=(array
+            (hash
+              text="First secondary action"
+              onAction=(action "secondaryAction1")
+            )
+            (hash
+              text="Second secondary action"
+              onAction=(action "secondaryAction2")
+            )
           )
-          (hash
-            text="Second secondary action"
-            onAction=(action "secondaryAction2")
-          )
-        )
-      }}
+        }}
+      </div>
     `);
 
     assert

--- a/tests/integration/components/polaris-resource-list/checkable-button-test.js
+++ b/tests/integration/components/polaris-resource-list/checkable-button-test.js
@@ -56,17 +56,21 @@ module(
     });
 
     test('onToggleAll action works', async function(assert) {
-      this.set('toggled', false);
+      assert.expect(2);
+
+      this.set('handleToggle', (event) => {
+        assert.ok(true, 'triggers @onToggleAll handler');
+        assert.notOk(
+          event,
+          'does not curry click event to the @onToggleAll handler'
+        );
+      });
 
       await render(hbs`
-      {{polaris-resource-list/checkable-button
-        onToggleAll=(action (mut toggled) true)
-      }}
-    `);
+        {{polaris-resource-list/checkable-button onToggleAll=this.handleToggle}}
+      `);
 
       await click(componentSelector);
-
-      assert.ok(this.get('toggled'), 'onToggleAll action fires');
     });
   }
 );

--- a/tests/integration/components/polaris-resource-list/checkable-button-test.js
+++ b/tests/integration/components/polaris-resource-list/checkable-button-test.js
@@ -58,16 +58,21 @@ module(
     test('onToggleAll action works', async function(assert) {
       assert.expect(2);
 
-      this.set('handleToggle', (event) => {
+      this.handleWrapperClick = () =>
+        assert.notOk(true, "click event doesn't bubble");
+      this.handleToggle = (event) => {
         assert.ok(true, 'triggers @onToggleAll handler');
         assert.notOk(
           event,
           'does not curry click event to the @onToggleAll handler'
         );
-      });
+      };
 
       await render(hbs`
-        {{polaris-resource-list/checkable-button onToggleAll=this.handleToggle}}
+        {{!-- template-lint-disable no-invalid-interactive--}}
+        <div {{on "click" this.handleWrapperClick}}>
+          {{polaris-resource-list/checkable-button onToggleAll=this.handleToggle}}
+        </div>
       `);
 
       await click(componentSelector);

--- a/tests/integration/components/polaris-unstyled-link-test.js
+++ b/tests/integration/components/polaris-unstyled-link-test.js
@@ -44,16 +44,21 @@ module('Integration | Component | polaris-unstyled-link', function(hooks) {
   test('supports onClick action', async function(assert) {
     assert.expect(2);
 
-    this.set('handleClick', (event) => {
+    this.handleWrapperClick = () =>
+      assert.notOk(true, "click event doesn't bubble");
+    this.handleClick = (event) => {
       assert.ok(true, 'triggers @onClick handler');
       assert.notOk(event, 'does not curry click event to the @onClick handler');
-    });
+    };
 
     await render(hbs`
-      <PolarisUnstyledLink
-        data-test="unstyled-link"
-        @onClick={{action handleClick}}
-      />
+      {{!-- template-lint-disable no-invalid-interactive--}}
+      <div {{on "click" this.handleWrapperClick}}>
+        <PolarisUnstyledLink
+          data-test="unstyled-link"
+          @onClick={{action handleClick}}
+        />
+      </div>
     `);
 
     await click(linkSelector);

--- a/tests/integration/components/polaris-unstyled-link-test.js
+++ b/tests/integration/components/polaris-unstyled-link-test.js
@@ -45,8 +45,8 @@ module('Integration | Component | polaris-unstyled-link', function(hooks) {
     assert.expect(2);
 
     this.set('handleClick', (event) => {
-      assert.ok(true, 'triggers onClick action');
-      assert.ok(event instanceof MouseEvent);
+      assert.ok(true, 'triggers @onClick handler');
+      assert.notOk(event, 'does not curry click event to the @onClick handler');
     });
 
     await render(hbs`


### PR DESCRIPTION
When we replaced usage of `mapEventToAction` utility for click handlers, we
introduced back currying of the click event to the action handlers. This fixes
it.