### PR TITLE
Improve backwards compatibility support

### DIFF
--- a/addon/components/polaris-action-list.js
+++ b/addon/components/polaris-action-list.js
@@ -50,15 +50,9 @@ export default class PolarisActionList extends Component {
    */
   onActionAnyItem() {}
 
-  /**
-   * @private
-   */
   @gt('finalSections.length', 1)
   hasMultipleSections;
 
-  /**
-   * @private
-   */
   @computed('items', 'sections.[]')
   get finalSections() {
     let finalSections = [];

--- a/addon/components/polaris-action-list/item.js
+++ b/addon/components/polaris-action-list/item.js
@@ -99,22 +99,22 @@ export default class PolarisActionListItem extends Component {
 
   @computed('destructive', 'disabled', 'active')
   get itemClasses() {
-    let classNames = ['Polaris-ActionList__Item'];
+    let cssClasses = ['Polaris-ActionList__Item'];
     let { destructive, disabled, active } = this;
 
     if (destructive) {
-      classNames.push('Polaris-ActionList--destructive');
+      cssClasses.push('Polaris-ActionList--destructive');
     }
 
     if (disabled) {
-      classNames.push('Polaris-ActionList--disabled');
+      cssClasses.push('Polaris-ActionList--disabled');
     }
 
     if (active) {
-      classNames.push('Polaris-ActionList--active');
+      cssClasses.push('Polaris-ActionList--active');
     }
 
-    return classNames.join(' ');
+    return cssClasses.join(' ');
   }
 
   @computed('image')

--- a/addon/components/polaris-avatar.js
+++ b/addon/components/polaris-avatar.js
@@ -3,9 +3,9 @@ import { action, computed } from '@ember/object';
 import { or } from '@ember/object/computed';
 import { isEmpty } from '@ember/utils';
 import { classify } from '@ember/string';
-import { deprecate } from '@ember/application/deprecations';
 import { tagName, layout } from '@ember-decorators/component';
 import template from '../templates/components/polaris-avatar';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 const allowedSizes = ['small', 'medium', 'large'];
 const defaultSize = 'medium';
@@ -27,7 +27,9 @@ const styleClasses = ['one', 'two', 'three', 'four', 'five', 'six'];
 
 @tagName('')
 @layout(template)
-export default class PolarisAvatar extends Component {
+export default class PolarisAvatar extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * Size of avatar
    *
@@ -222,19 +224,6 @@ export default class PolarisAvatar extends Component {
   get shouldShowImage() {
     let { finalSource, hasError } = this;
     return finalSource && !hasError;
-  }
-
-  init() {
-    super.init(...arguments);
-
-    deprecate(
-      `[polaris-avatar] Passing 'class' argument is deprecated! Switch to angle bracket invocation and pass an HTML attribute instead`,
-      !this.class,
-      {
-        id: 'ember-polaris.polaris-avatar.class-arg',
-        until: '7.0.0',
-      }
-    );
   }
 
   @action

--- a/addon/components/polaris-badge.js
+++ b/addon/components/polaris-badge.js
@@ -3,9 +3,9 @@ import { computed } from '@ember/object';
 import { notEmpty } from '@ember/object/computed';
 import { isBlank, isPresent } from '@ember/utils';
 import { classify } from '@ember/string';
-import { deprecate } from '@ember/application/deprecations';
 import { tagName, layout } from '@ember-decorators/component';
 import template from '../templates/components/polaris-badge';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 const PROGRESS_LABELS = {
   incomplete: 'Incomplete',
@@ -34,7 +34,9 @@ const DEFAULT_SIZE = SIZES.medium;
  */
 @tagName('')
 @layout(template)
-export default class PolarisBadge extends Component {
+export default class PolarisBadge extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * The content to display inside the badge.
    *
@@ -43,7 +45,7 @@ export default class PolarisBadge extends Component {
    * instead of `text`
    *
    * @type {String}
-   * @default: null
+   * @default null
    * @public
    */
   text = null;
@@ -52,7 +54,7 @@ export default class PolarisBadge extends Component {
    * Set the color of the badge for the given status.
    *
    * @type {String}
-   * @default: null
+   * @default null
    * @public
    */
   status = null;
@@ -61,7 +63,7 @@ export default class PolarisBadge extends Component {
    * Render a pip showing the progress of a given task.
    *
    * @type {String}
-   * @default: null
+   * @default null
    * @public
    */
   progress = null;
@@ -70,7 +72,7 @@ export default class PolarisBadge extends Component {
    * Medium or small size. Use `small` only in the main navigation of an app frame..
    *
    * @type {String}
-   * @default: 'medium'
+   * @default 'medium'
    * @public
    */
   size = DEFAULT_SIZE;
@@ -129,18 +131,5 @@ export default class PolarisBadge extends Component {
     }
 
     return `Polaris-Badge--status${classify(status)}`;
-  }
-
-  init() {
-    super.init(...arguments);
-
-    deprecate(
-      `[polaris-badge] Passing 'class' argument is deprecated! Switch to angle bracket invocation and pass an HTML attribute instead`,
-      !this.class,
-      {
-        id: 'ember-polaris.polaris-badge.class-arg',
-        until: '7.0.0',
-      }
-    );
   }
 }

--- a/addon/components/polaris-banner.js
+++ b/addon/components/polaris-banner.js
@@ -8,6 +8,7 @@ import { tagName, layout } from '@ember-decorators/component';
 import { invokeAction } from 'ember-invoke-action';
 import template from '../templates/components/polaris-banner';
 import { handleMouseUpByBlurring } from '../utils/focus';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 // TODO icon-update: use new icon names here when @shopify/polaris-icons
 // is consumable by Ember apps.
@@ -42,7 +43,9 @@ const supportedStatuses = ['success', 'info', 'warning', 'critical'];
  */
 @tagName('')
 @layout(template)
-export default class PolarisBanner extends Component {
+export default class PolarisBanner extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * Title content for the banner.
    *
@@ -162,6 +165,27 @@ export default class PolarisBanner extends Component {
     }
 
     return `Polaris-Banner--status${capitalize(status)}`;
+  }
+
+  @computed('statusClass', 'hasDismiss', 'withinContentContainer', 'class')
+  get cssClasses() {
+    let cssClasses = ['Polaris-Banner'];
+    if (this.statusClass) {
+      cssClasses.push(this.statusClass);
+    }
+    if (this.hasDismiss) {
+      cssClasses.push('Polaris-Banner--hasDismiss');
+    }
+    if (this.withinContentContainer) {
+      cssClasses.push('Polaris-Banner--withinContentContainer');
+    } else {
+      cssClasses.push('Polaris-Banner--withinPage');
+    }
+    if (this.class) {
+      cssClasses.push(this.class);
+    }
+
+    return cssClasses.join(' ');
   }
 
   @action

--- a/addon/components/polaris-breadcrumbs.js
+++ b/addon/components/polaris-breadcrumbs.js
@@ -1,13 +1,15 @@
 import Component from '@ember/component';
 import { computed, action } from '@ember/object';
-import { deprecate } from '@ember/application/deprecations';
 import { tagName, layout } from '@ember-decorators/component';
 import { handleMouseUpByBlurring } from '../utils/focus';
 import template from '../templates/components/polaris-breadcrumbs';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 @tagName('')
 @layout(template)
-export default class PolarisBreadcrumbs extends Component {
+export default class PolarisBreadcrumbs extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * Collection of breadcrumbs
    *
@@ -24,26 +26,12 @@ export default class PolarisBreadcrumbs extends Component {
    * We're not always guaranteed to get an Ember array,
    * so we can't just use `breadcrumbs.lastObject` in the template.
    *
-   * @private
    * @type {Object}
    */
   @computed('breadcrumbs.[]')
   get breadcrumb() {
     let { breadcrumbs } = this;
     return breadcrumbs[breadcrumbs.length - 1];
-  }
-
-  init() {
-    super.init(...arguments);
-
-    deprecate(
-      `[polaris-breadcrumbs] Passing 'class' argument is deprecated! Switch to angle bracket invocation and pass an HTML attribute instead`,
-      !this.class,
-      {
-        id: 'ember-polaris.polaris-breadcrumbs.class-arg',
-        until: '7.0.0',
-      }
-    );
   }
 
   @action

--- a/addon/components/polaris-button-group.js
+++ b/addon/components/polaris-button-group.js
@@ -1,8 +1,9 @@
 import Component from '@ember/component';
-import { action } from '@ember/object';
+import { action, computed } from '@ember/object';
 import { tagName, layout } from '@ember-decorators/component';
 import template from '../templates/components/polaris-button-group';
 import AutoWrapper from '../-private/auto-wrapper';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 /**
  * Polaris button group component.
@@ -10,7 +11,9 @@ import AutoWrapper from '../-private/auto-wrapper';
  */
 @tagName('')
 @layout(template)
-export default class PolarisButtonGroup extends Component {
+export default class PolarisButtonGroup extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * Button components
    *
@@ -50,6 +53,25 @@ export default class PolarisButtonGroup extends Component {
    * @public
    */
   connectedTop = false;
+
+  @computed('segmented', 'fullWidth', 'connectedTop', 'class')
+  get cssClasses() {
+    let cssClasses = ['Polaris-ButtonGroup'];
+    if (this.segmented) {
+      cssClasses.push('Polaris-ButtonGroup--segmented');
+    }
+    if (this.fullWidth) {
+      cssClasses.push('Polaris-ButtonGroup--fullWidth');
+    }
+    if (this.connectedTop) {
+      cssClasses.push('Polaris-ButtonGroup--connectedTop');
+    }
+    if (this.class) {
+      cssClasses.push(this.class);
+    }
+
+    return cssClasses.join(' ');
+  }
 
   @action
   setupAutoWrapper(element) {

--- a/addon/components/polaris-button-group/item.js
+++ b/addon/components/polaris-button-group/item.js
@@ -1,15 +1,16 @@
 import Component from '@ember/component';
-import { action } from '@ember/object';
+import { action, computed } from '@ember/object';
 import { tagName, layout } from '@ember-decorators/component';
 import template from '../../templates/components/polaris-button-group/item';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 @tagName('')
 @layout(template)
-export default class Item extends Component {
+export default class Item extends Component.extend(TaglessCssDeprecation) {
   /**
    * Elements to display inside group item
    *
-   * @type {string}
+   * @type {String}
    * @default null
    * @public
    */
@@ -18,7 +19,7 @@ export default class Item extends Component {
   /**
    * Use a plain style for the group item
    *
-   * @type {boolean}
+   * @type {Boolean}
    * @default false
    * @public
    */
@@ -27,11 +28,26 @@ export default class Item extends Component {
   /**
    * Whether the group item is focused
    *
-   * @type {boolean}
+   * @type {Boolean}
    * @default false
-   * @private
    */
   focused = false;
+
+  @computed('plain', 'focused', 'class')
+  get cssClasses() {
+    let cssClasses = ['Polaris-ButtonGroup__Item'];
+    if (this.plain) {
+      cssClasses.push('Polaris-ButtonGroup__Item--plain');
+    }
+    if (this.focused) {
+      cssClasses.push('Polaris-ButtonGroup__Item--focused');
+    }
+    if (this.class) {
+      cssClasses.push(this.class);
+    }
+
+    return cssClasses.join(' ');
+  }
 
   @action
   handleFocus() {

--- a/addon/components/polaris-button.js
+++ b/addon/components/polaris-button.js
@@ -1,7 +1,6 @@
 import Component from '@ember/component';
 import { action, computed } from '@ember/object';
 import { or } from '@ember/object/computed';
-import { isPresent } from '@ember/utils';
 import { classify } from '@ember/string';
 import { deprecate } from '@ember/application/deprecations';
 import { tagName, layout } from '@ember-decorators/component';
@@ -293,7 +292,7 @@ export default class PolarisButtonComponent extends Component {
     'fullWidth',
     'isIconOnly'
   )
-  get classes() {
+  get cssClasses() {
     let {
       class: externalClasses,
       primary,
@@ -307,56 +306,48 @@ export default class PolarisButtonComponent extends Component {
       fullWidth,
       isIconOnly,
     } = this;
-    let classes = ['Polaris-Button'];
+    let cssClasses = ['Polaris-Button'];
 
-    if (isPresent(externalClasses)) {
-      classes.push(externalClasses);
+    if (externalClasses) {
+      cssClasses.push(externalClasses);
     }
-
     if (primary) {
-      classes.push('Polaris-Button--primary');
+      cssClasses.push('Polaris-Button--primary');
     }
-
     if (outline) {
-      classes.push('Polaris-Button--outline');
+      cssClasses.push('Polaris-Button--outline');
     }
-
     if (destructive) {
-      classes.push('Polaris-Button--destructive');
+      cssClasses.push('Polaris-Button--destructive');
     }
-
     if (isDisabled) {
-      classes.push('Polaris-Button--disabled');
+      cssClasses.push('Polaris-Button--disabled');
     }
-
     if (loading) {
-      classes.push('Polaris-Button--loading');
+      cssClasses.push('Polaris-Button--loading');
     }
-
     if (plain) {
-      classes.push('Polaris-Button--plain');
+      cssClasses.push('Polaris-Button--plain');
     }
-
     if (monochrome) {
-      classes.push('Polaris-Button--monochrome');
+      cssClasses.push('Polaris-Button--monochrome');
     }
 
     if (size && size !== DEFAULT_SIZE) {
       size = SIZES[size] || null;
       if (size) {
-        classes.push(`Polaris-Button--size${classify(size)}`);
+        cssClasses.push(`Polaris-Button--size${classify(size)}`);
       }
     }
 
     if (fullWidth) {
-      classes.push('Polaris-Button--fullWidth');
+      cssClasses.push('Polaris-Button--fullWidth');
     }
-
     if (isIconOnly) {
-      classes.push('Polaris-Button--iconOnly');
+      cssClasses.push('Polaris-Button--iconOnly');
     }
 
-    return classes.join(' ');
+    return cssClasses.join(' ');
   }
 
   init() {

--- a/addon/components/polaris-callout-card.js
+++ b/addon/components/polaris-callout-card.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { tagName, layout } from '@ember-decorators/component';
 import template from '../templates/components/polaris-callout-card';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 /**
  * Polaris callout card component.
@@ -8,7 +9,9 @@ import template from '../templates/components/polaris-callout-card';
  */
 @tagName('')
 @layout(template)
-export default class PolarisCalloutCard extends Component {
+export default class PolarisCalloutCard extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * The content to display inside the callout card.
    *

--- a/addon/components/polaris-caption.js
+++ b/addon/components/polaris-caption.js
@@ -1,10 +1,13 @@
 import Component from '@ember/component';
 import { tagName, layout } from '@ember-decorators/component';
 import template from '../templates/components/polaris-caption';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 @tagName('')
 @layout(template)
-export default class PolarisCaption extends Component {
+export default class PolarisCaption extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * The content to use as a graph label or timestamp.
    *
@@ -13,7 +16,7 @@ export default class PolarisCaption extends Component {
    * instead of `text`
    *
    * @type {String}
-   * @default: null
+   * @default null
    * @public
    */
   text = null;

--- a/addon/components/polaris-card.js
+++ b/addon/components/polaris-card.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { tagName, layout } from '@ember-decorators/component';
 import template from '../templates/components/polaris-card';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 /**
  * Polaris card component.
@@ -8,12 +9,14 @@ import template from '../templates/components/polaris-card';
  */
 @tagName('')
 @layout(template)
-export default class PolarisCardComponent extends Component {
+export default class PolarisCardComponent extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * Title content for the card
    *
    * @type {String|Component}
-   * @default: null
+   * @default null
    * @public
    */
   title = null;
@@ -26,7 +29,7 @@ export default class PolarisCardComponent extends Component {
    * instead of `text`
    *
    * @type {String}
-   * @default: null
+   * @default null
    * @public
    */
   text = null;
@@ -35,7 +38,7 @@ export default class PolarisCardComponent extends Component {
    * A less prominent card
    *
    * @type {Boolean}
-   * @default: false
+   * @default false
    * @public
    */
   subdued = false;
@@ -44,7 +47,7 @@ export default class PolarisCardComponent extends Component {
    * Auto wrap content in section
    *
    * @type {Boolean}
-   * @default: false
+   * @default false
    * @public
    */
   sectioned = false;
@@ -53,7 +56,7 @@ export default class PolarisCardComponent extends Component {
    * Card header actions
    *
    * @type {Action[]}
-   * @default: null
+   * @default null
    * @public
    */
   headerActions = null;
@@ -62,7 +65,7 @@ export default class PolarisCardComponent extends Component {
    * Primary action in the card footer
    *
    * @type {Action}
-   * @default: null
+   * @default null
    */
   primaryFooterAction = null;
 
@@ -70,7 +73,7 @@ export default class PolarisCardComponent extends Component {
    * Secondary action in the card footer
    *
    * @type {Action}
-   * @default: null
+   * @default null
    */
   secondaryFooterAction = null;
 }

--- a/addon/components/polaris-card/section-header.js
+++ b/addon/components/polaris-card/section-header.js
@@ -1,15 +1,18 @@
 import Component from '@ember/component';
 import { tagName, layout } from '@ember-decorators/component';
 import template from '../../templates/components/polaris-card/section-header';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 @tagName('')
 @layout(template)
-export default class CardSectionHeaderComponent extends Component {
+export default class CardSectionHeaderComponent extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * Title for the section
    *
    * @type {String|Component}
-   * @default: null
+   * @default null
    * @public
    */
   title = null;
@@ -22,7 +25,7 @@ export default class CardSectionHeaderComponent extends Component {
    * instead of `text`
    *
    * @type {String}
-   * @default: null
+   * @default null
    * @public
    */
   text = null;

--- a/addon/components/polaris-card/section.js
+++ b/addon/components/polaris-card/section.js
@@ -1,10 +1,14 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 import { tagName, layout } from '@ember-decorators/component';
 import template from '../../templates/components/polaris-card/section';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 @tagName('')
 @layout(template)
-export default class CardSectionComponent extends Component {
+export default class CardSectionComponent extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * Title for the section
    *
@@ -27,7 +31,7 @@ export default class CardSectionComponent extends Component {
    * A full-width section without any padding
    *
    * @type {Boolean}
-   * @default: false
+   * @default false
    * @public
    */
   fullWidth = false;
@@ -44,4 +48,20 @@ export default class CardSectionComponent extends Component {
    * @public
    */
   text = null;
+
+  @computed('subdued', 'fullWidth', 'class')
+  get cssClasses() {
+    let cssClasses = ['Polaris-Card__Section'];
+    if (this.subdued) {
+      cssClasses.push('Polaris-Card__Section--subdued');
+    }
+    if (this.fullWidth) {
+      cssClasses.push('Polaris-Card__Section--fullWidth');
+    }
+    if (this.class) {
+      cssClasses.push(this.class);
+    }
+
+    return cssClasses.join(' ');
+  }
 }

--- a/addon/components/polaris-checkbox.js
+++ b/addon/components/polaris-checkbox.js
@@ -135,13 +135,13 @@ export default class PolarisCheckbox extends Component {
 
   @computed('isIndeterminate')
   get checkboxClasses() {
-    let classNames = ['Polaris-Checkbox__Input'];
+    let cssClasses = ['Polaris-Checkbox__Input'];
 
     if (this.isIndeterminate) {
-      classNames.push('Polaris-Checkbox__Input--indeterminate');
+      cssClasses.push('Polaris-Checkbox__Input--indeterminate');
     }
 
-    return classNames.join(' ');
+    return cssClasses.join(' ');
   }
 
   @computed('inputId')

--- a/addon/components/polaris-choice-list.js
+++ b/addon/components/polaris-choice-list.js
@@ -6,6 +6,7 @@ import ObjectProxy from '@ember/object/proxy';
 import { tagName, layout } from '@ember-decorators/component';
 import { errorId } from '../utils/id';
 import template from '../templates/components/polaris-choice-list';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 // Wrapper class to add an `isSelected` flag to the supplied choices.
 class CheckedChoice extends ObjectProxy {
@@ -24,7 +25,9 @@ class CheckedChoice extends ObjectProxy {
  */
 @tagName('')
 @layout(template)
-export default class PolarisChoiceList extends Component {
+export default class PolarisChoiceList extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * Label for list of choices
    *

--- a/addon/components/polaris-choice.js
+++ b/addon/components/polaris-choice.js
@@ -15,7 +15,7 @@ export default class PolarisChoice extends Component {
    * A unique identifier for the choice
    *
    * @type {String}
-   * @default: null
+   * @default null
    * @public
    */
   inputId = null;
@@ -24,7 +24,7 @@ export default class PolarisChoice extends Component {
    * Label for the choice
    *
    * @type {String|Component}
-   * @default: null
+   * @default null
    * @public
    */
   label = null;
@@ -33,7 +33,7 @@ export default class PolarisChoice extends Component {
    * Whether the associated form control is disabled
    *
    * @type {Boolean}
-   * @default: null
+   * @default null
    * @public
    */
   disabled = null;
@@ -42,7 +42,7 @@ export default class PolarisChoice extends Component {
    * Display an error message
    *
    * @type {String|Boolean}
-   * @default: null
+   * @default null
    * @public
    */
   error = null;
@@ -51,7 +51,7 @@ export default class PolarisChoice extends Component {
    * Visually hide the label
    *
    * @type {boolean}
-   * @default: false
+   * @default false
    * @public
    */
   labelHidden = false;
@@ -60,7 +60,7 @@ export default class PolarisChoice extends Component {
    * Additional text to aide in use
    *
    * @type {String|Component|Object}
-   * @default: null
+   * @default null
    * @public
    */
   helpText = null;

--- a/addon/components/polaris-choice/label.js
+++ b/addon/components/polaris-choice/label.js
@@ -1,7 +1,25 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 import { tagName, layout } from '@ember-decorators/component';
 import template from '../../templates/components/polaris-choice/label';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 @tagName('')
 @layout(template)
-export default class Label extends Component {}
+export default class Label extends Component.extend(TaglessCssDeprecation) {
+  @computed('labelHidden', 'disabled', 'class')
+  get cssClasses() {
+    let cssClasses = ['Polaris-Choice'];
+    if (this.labelHidden) {
+      cssClasses.push('Polaris-Choice--labelHidden');
+    }
+    if (this.disabled) {
+      cssClasses.push('Polaris-Choice--disabled');
+    }
+    if (this.class) {
+      cssClasses.push(this.class);
+    }
+
+    return cssClasses.join(' ');
+  }
+}

--- a/addon/components/polaris-color-picker.js
+++ b/addon/components/polaris-color-picker.js
@@ -6,6 +6,7 @@ import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import { clamp } from '../utils/math';
 import { hsbaToRgba } from '../utils/color';
 import layout from '../templates/components/polaris-color-picker';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 /**
  * Polaris color picker component.
@@ -13,7 +14,9 @@ import layout from '../templates/components/polaris-color-picker';
  */
 @tagName('')
 @templateLayout(layout)
-export default class PolarisColorPicker extends Component {
+export default class PolarisColorPicker extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * The currently selected color
    *
@@ -41,14 +44,8 @@ export default class PolarisColorPicker extends Component {
    */
   onChange = null;
 
-  /**
-   * @private
-   */
   pickerSize = null;
 
-  /**
-   * @private
-   */
   @(computed('color.{hue,alpha}').readOnly())
   get colorLayerStyle() {
     const { hue, alpha = 1 } = this.color;
@@ -62,9 +59,6 @@ export default class PolarisColorPicker extends Component {
     return htmlSafe(`background-color: ${backgroundColor};`);
   }
 
-  /**
-   * @private
-   */
   @(computed('color.saturation', 'pickerSize').readOnly())
   get draggerX() {
     const {
@@ -74,9 +68,6 @@ export default class PolarisColorPicker extends Component {
     return clamp(saturation * pickerSize, 0, pickerSize);
   }
 
-  /**
-   * @private
-   */
   @(computed('color.brightness', 'pickerSize').readOnly())
   get draggerY() {
     const {

--- a/addon/components/polaris-color-picker/alpha-picker.js
+++ b/addon/components/polaris-color-picker/alpha-picker.js
@@ -6,6 +6,7 @@ import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import { clamp } from '../../utils/math';
 import { hsbaToRgba } from '../../utils/color';
 import layout from '../../templates/components/polaris-color-picker/alpha-picker';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 const VERTICAL_PADDING = 13;
 
@@ -26,7 +27,9 @@ function alphaForOffset(offset, sliderHeight) {
 
 @tagName('')
 @templateLayout(layout)
-export default class AlphaPicker extends Component {
+export default class AlphaPicker extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * The current alpha value
    *
@@ -35,19 +38,9 @@ export default class AlphaPicker extends Component {
    */
   alpha = 1;
 
-  /**
-   * @private
-   */
   sliderHeight = null;
-
-  /**
-   * @private
-   */
   draggerHeight = null;
 
-  /**
-   * @private
-   */
   @(computed('color.{hue,saturation,brightness}').readOnly())
   get colorLayerStyle() {
     const { color } = this;
@@ -58,9 +51,6 @@ export default class AlphaPicker extends Component {
     return htmlSafe(`background: ${background};`);
   }
 
-  /**
-   * @private
-   */
   @(computed('alpha', 'draggerHeight', 'sliderHeight').readOnly())
   get draggerY() {
     const { alpha, sliderHeight, draggerHeight } = this;

--- a/addon/components/polaris-color-picker/hue-picker.js
+++ b/addon/components/polaris-color-picker/hue-picker.js
@@ -4,6 +4,7 @@ import { typeOf } from '@ember/utils';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import { clamp } from '../../utils/math';
 import layout from '../../templates/components/polaris-color-picker/hue-picker';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 const VERTICAL_PADDING = 13;
 
@@ -24,7 +25,7 @@ function hueForOffset(offset, sliderHeight) {
 
 @tagName('')
 @templateLayout(layout)
-export default class HuePicker extends Component {
+export default class HuePicker extends Component.extend(TaglessCssDeprecation) {
   /**
    * The current hue value
    *
@@ -43,19 +44,9 @@ export default class HuePicker extends Component {
    */
   onChange = null;
 
-  /**
-   * @private
-   */
   sliderHeight = null;
-
-  /**
-   * @private
-   */
   draggerHeight = null;
 
-  /**
-   * @private
-   */
   @(computed('draggerHeight', 'hue', 'sliderHeight').readOnly())
   get draggerY() {
     const { hue, sliderHeight, draggerHeight } = this;

--- a/addon/components/polaris-color-picker/slidable.js
+++ b/addon/components/polaris-color-picker/slidable.js
@@ -6,11 +6,12 @@ import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import { getRectForNode } from '@shopify/javascript-utilities/geometry';
 import $Ember from 'jquery';
 import layout from '../../templates/components/polaris-color-picker/slidable';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 // Draggable marker, used to pick hue, saturation, brightness and alpha.
 @tagName('')
 @templateLayout(layout)
-export default class Slidable extends Component {
+export default class Slidable extends Component.extend(TaglessCssDeprecation) {
   /**
    * The current x position of the dragger
    *
@@ -38,14 +39,8 @@ export default class Slidable extends Component {
    */
   onDraggerHeightChanged = null;
 
-  /**
-   * @private
-   */
   isDragging = false;
 
-  /**
-   * @private
-   */
   @(computed('draggerX', 'draggerY').readOnly())
   get draggerStyle() {
     const { draggerX, draggerY } = this;
@@ -53,9 +48,6 @@ export default class Slidable extends Component {
     return htmlSafe(`transform: ${transform};`);
   }
 
-  /**
-   * @private
-   */
   handleMove(event) {
     if (!this.isDragging) {
       return;
@@ -76,9 +68,6 @@ export default class Slidable extends Component {
     this.handleDraggerMove(event.clientX, event.clientY);
   }
 
-  /**
-   * @private
-   */
   handleDragEnd() {
     this.set('isDragging', false);
 
@@ -91,9 +80,6 @@ export default class Slidable extends Component {
     $Ember(window).off('touchcancel');
   }
 
-  /**
-   * @private
-   */
   handleDraggerMove(clientX, clientY) {
     const { onChange: moveHandler } = this;
     if (typeof moveHandler !== 'function') {

--- a/addon/components/polaris-connected/item.js
+++ b/addon/components/polaris-connected/item.js
@@ -3,10 +3,13 @@ import { action, computed } from '@ember/object';
 import { equal } from '@ember/object/computed';
 import { tagName, layout } from '@ember-decorators/component';
 import template from '../../templates/components/polaris-connected/item';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 @tagName('')
 @layout(template)
-export default class PolarisConnectedItem extends Component {
+export default class PolarisConnectedItem extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * The position of the item.
    *
@@ -35,19 +38,22 @@ export default class PolarisConnectedItem extends Component {
   @equal('position', 'primary')
   primary;
 
-  @computed('focused', 'primary')
-  get classes() {
-    let classes = ['Polaris-Connected__Item'];
+  @computed('focused', 'primary', 'class')
+  get cssClasses() {
+    let cssClasses = ['Polaris-Connected__Item'];
     if (this.focused) {
-      classes.push('Polaris-Connected__Item--focused');
+      cssClasses.push('Polaris-Connected__Item--focused');
     }
     if (this.primary) {
-      classes.push('Polaris-Connected__Item--primary');
+      cssClasses.push('Polaris-Connected__Item--primary');
     } else {
-      classes.push('Polaris-Connected__Item--connection');
+      cssClasses.push('Polaris-Connected__Item--connection');
+    }
+    if (this.class) {
+      cssClasses.push(this.class);
     }
 
-    return classes.join(' ');
+    return cssClasses.join(' ');
   }
 
   @action

--- a/addon/components/polaris-data-table.js
+++ b/addon/components/polaris-data-table.js
@@ -10,6 +10,7 @@ import ContextBoundEventListenersMixin from 'ember-lifeline/mixins/dom';
 import ContextBoundTasksMixin from 'ember-lifeline/mixins/run';
 import layout from '../templates/components/polaris-data-table';
 import { measureColumn, getPrevAndCurrentColumns } from '../utils/data-table';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 function elementLookup(selector) {
   return computed('dataTableElement', function() {
@@ -25,7 +26,8 @@ function elementLookup(selector) {
 @templateLayout(layout)
 export default class PolarisDataTable extends Component.extend(
   ContextBoundEventListenersMixin,
-  ContextBoundTasksMixin
+  ContextBoundTasksMixin,
+  TaglessCssDeprecation
 ) {
   /**
    * List of data types, which determines content alignment for each column.
@@ -119,100 +121,84 @@ export default class PolarisDataTable extends Component.extend(
   /**
    * @type {Boolean}
    * @default false
-   * @private
    */
   collapsed = false;
 
   /**
    * @type {Object[]}
-   * @private
    */
   columnVisibilityData = [];
 
   /**
    * @type {Object}
-   * @private
    */
   previousColumn = null;
 
   /**
    * @type {Object}
-   * @private
    */
   currentColumn = null;
 
   /**
    * @type {Number}
-   * @private
    */
   sortedColumnIndex = null;
 
   /**
    * @type {String}
-   * @private
    */
   sortDirection = null;
 
   /**
    * @type {Number[]}
-   * @private
    */
   heights = [];
 
   /**
    * @type {Number}
-   * @private
    */
   fixedColumnWidth = null;
 
   /**
    * @type {Object}
-   * @private
    */
   preservedScrollPosition = {};
 
   /**
    * @type {Boolean}
-   * @private
    */
   isScrolledFarthestLeft = true;
 
   /**
    * @type {Boolean}
-   * @private
    */
   isScrolledFarthestRight = false;
 
   /**
    * @type {String}
-   * @private
    */
   totalsRowHeading = 'Totals';
 
   /**
    * @type {HTMLElement}
-   * @private
    */
   @(elementLookup('.Polaris-DataTable').readOnly())
   dataTable;
 
   /**
    * @type {HTMLElement}
-   * @private
    */
   @(elementLookup('.Polaris-DataTable__Table').readOnly())
   table;
 
   /**
    * @type {HTMLElement}
-   * @private
    */
   @(elementLookup('.Polaris-DataTable__ScrollContainer').readOnly())
   scrollContainer;
 
   /**
    * @type {String}
-   * @private
    */
   @(computed('footerContent', 'heights.[]').readOnly())
   get scrollContainerStyle() {

--- a/addon/components/polaris-data-table/cell.js
+++ b/addon/components/polaris-data-table/cell.js
@@ -96,7 +96,6 @@ export default class Cell extends Component {
 
   /**
    * @type {String}
-   * @private
    */
   @(computed(
     'fixed',
@@ -109,7 +108,7 @@ export default class Cell extends Component {
     'sortable'
   ).readOnly())
   get cellClassNames() {
-    let classNames = ['Polaris-DataTable__Cell'];
+    let cssClasses = ['Polaris-DataTable__Cell'];
 
     let {
       fixed,
@@ -123,43 +122,42 @@ export default class Cell extends Component {
     } = this;
 
     if (fixed) {
-      classNames.push('Polaris-DataTable__Cell--fixed');
+      cssClasses.push('Polaris-DataTable__Cell--fixed');
 
       if (truncate) {
-        classNames.push('Polaris-DataTable__Cell--truncated');
+        cssClasses.push('Polaris-DataTable__Cell--truncated');
       }
     }
 
     if (header) {
-      classNames.push('Polaris-DataTable__Cell--header');
+      cssClasses.push('Polaris-DataTable__Cell--header');
     }
 
     if (total) {
-      classNames.push('Polaris-DataTable__Cell--total');
+      cssClasses.push('Polaris-DataTable__Cell--total');
     }
 
     if (footer) {
-      classNames.push('Polaris-DataTable__Cell--footer');
+      cssClasses.push('Polaris-DataTable__Cell--footer');
     }
 
     if (contentType === 'numeric') {
-      classNames.push('Polaris-DataTable__Cell--numeric');
+      cssClasses.push('Polaris-DataTable__Cell--numeric');
     }
 
     if (sorted) {
-      classNames.push('Polaris-DataTable__Cell--sorted');
+      cssClasses.push('Polaris-DataTable__Cell--sorted');
     }
 
     if (sortable) {
-      classNames.push('Polaris-DataTable__Cell--sortable');
+      cssClasses.push('Polaris-DataTable__Cell--sortable');
     }
 
-    return classNames.join(' ');
+    return cssClasses.join(' ');
   }
 
   /**
    * @type {String}
-   * @private
    */
   @(computed('header', 'contentType').readOnly())
   get headerClassNames() {
@@ -169,18 +167,17 @@ export default class Cell extends Component {
       return '';
     }
 
-    let classNames = ['Polaris-DataTable__Heading'];
+    let cssClasses = ['Polaris-DataTable__Heading'];
 
     if (contentType === 'text') {
-      classNames.push('Polaris-DataTable__Heading--left');
+      cssClasses.push('Polaris-DataTable__Heading--left');
     }
 
-    return classNames.join(' ');
+    return cssClasses.join(' ');
   }
 
   /**
    * @type {String}
-   * @private
    */
   @(computed('height').readOnly())
   get style() {
@@ -190,7 +187,6 @@ export default class Cell extends Component {
 
   /**
    * @type {String}
-   * @private
    */
   @(computed('sorted', 'sortDirection', 'defaultSortDirection').readOnly())
   get direction() {
@@ -200,7 +196,6 @@ export default class Cell extends Component {
 
   /**
    * @type {String}
-   * @private
    */
   @(computed('direction').readOnly())
   get source() {
@@ -209,7 +204,6 @@ export default class Cell extends Component {
 
   /**
    * @type {String}
-   * @private
    */
   @(computed('sortDirection').readOnly())
   get oppositeDirection() {
@@ -218,7 +212,6 @@ export default class Cell extends Component {
 
   /**
    * @type {String}
-   * @private
    */
   @(computed('sorted', 'oppositeDirection', 'direction').readOnly())
   get sortAccessibilityLabel() {

--- a/addon/components/polaris-data-table/heading.js
+++ b/addon/components/polaris-data-table/heading.js
@@ -63,32 +63,20 @@ export default class Heading extends Component {
   defaultSortDirection = null;
 
   /**
-   * @type {function}
+   * @type {Function}
    * @default no-op
    * @public
    */
   defaultOnSort() {}
 
-  /**
-   * @type {boolean}
-   * @private
-   */
   @(equal('headingIndex', 0).readOnly())
   isFixed;
 
-  /**
-   * @type {Number}
-   * @private
-   */
   @(computed('truncate', 'heights.[]').readOnly())
   get height() {
     return !this.truncate ? this.heights.firstObject : undefined;
   }
 
-  /**
-   * @type {String}
-   * @private
-   */
   @(computed('isSorted', 'sortDirection').readOnly())
   get direction() {
     return this.isSorted ? this.sortDirection : 'none';

--- a/addon/components/polaris-data-table/navigation.js
+++ b/addon/components/polaris-data-table/navigation.js
@@ -1,21 +1,24 @@
 import Component from '@ember/component';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../templates/components/polaris-data-table/navigation';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 @tagName('')
 @templateLayout(layout)
-export default class Navigation extends Component {
+export default class Navigation extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * @type {Boolean}
    * @public
    */
-  isScrolledFarthestLeft = null;
+  isScrolledFarthestLeft = false;
 
   /**
    * @type {Boolean}
    * @public
    */
-  isScrolledFarthestRight = null;
+  isScrolledFarthestRight = false;
 
   /**
    * @type {Object[]}

--- a/addon/components/polaris-data-table/row.js
+++ b/addon/components/polaris-data-table/row.js
@@ -3,10 +3,11 @@ import { computed } from '@ember/object';
 import { isPresent } from '@ember/utils';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../templates/components/polaris-data-table/row';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 @tagName('')
 @templateLayout(layout)
-export default class Row extends Component {
+export default class Row extends Component.extend(TaglessCssDeprecation) {
   /**
    * @type {Array}
    * @public
@@ -52,7 +53,6 @@ export default class Row extends Component {
 
   /**
    * @type {Number[]}
-   * @private
    */
   @(computed('totals.[]', 'heights.[]', 'footerContent').readOnly())
   get bodyCellHeights() {

--- a/addon/components/polaris-data-table/total.js
+++ b/addon/components/polaris-data-table/total.js
@@ -37,10 +37,6 @@ export default class Total extends Component {
    */
   totalsRowHeading = null;
 
-  /**
-   * @type {String}
-   * @private
-   */
   @computed('total', 'index')
   get contentType() {
     let { total, index } = this;

--- a/addon/components/polaris-date-picker.js
+++ b/addon/components/polaris-date-picker.js
@@ -15,12 +15,15 @@ import {
   weekdays,
   isSameDay,
 } from '../utils/dates';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 const weekStartsOn = weekdays.Sunday;
 
 @tagName('')
 @templateLayout(layout)
-export default class PolarisDatePicker extends Component {
+export default class PolarisDatePicker extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * The selected date or range of dates
    *

--- a/addon/components/polaris-date-picker/day.js
+++ b/addon/components/polaris-date-picker/day.js
@@ -79,26 +79,26 @@ export default class PolarisDatePickerDay extends Component {
 
   @computed('selected', 'disabled', 'isDateToday', 'inHoveringRange', 'inRange')
   get dayButtonClasses() {
-    let classNames = ['Polaris-DatePicker__Day'];
+    let cssClasses = ['Polaris-DatePicker__Day'];
     let { selected, disabled, isDateToday, inHoveringRange, inRange } = this;
 
     if (selected) {
-      classNames.push('Polaris-DatePicker__Day--selected');
+      cssClasses.push('Polaris-DatePicker__Day--selected');
     }
 
     if (disabled) {
-      classNames.push('Polaris-DatePicker__Day--disabled');
+      cssClasses.push('Polaris-DatePicker__Day--disabled');
     }
 
     if (isDateToday) {
-      classNames.push('Polaris-DatePicker__Day--today');
+      cssClasses.push('Polaris-DatePicker__Day--today');
     }
 
     if (inHoveringRange || inRange) {
-      classNames.push('Polaris-DatePicker__Day--inRange');
+      cssClasses.push('Polaris-DatePicker__Day--inRange');
     }
 
-    return classNames.join(' ');
+    return cssClasses.join(' ');
   }
 
   @computed('day')

--- a/addon/components/polaris-date-picker/month.js
+++ b/addon/components/polaris-date-picker/month.js
@@ -9,10 +9,13 @@ import {
   abbreviationForWeekday,
   getWeekdaysOrdered,
 } from '../../utils/dates';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 @tagName('')
 @templateLayout(layout)
-export default class PolarisDatePickerMonth extends Component {
+export default class PolarisDatePickerMonth extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * @type {Date}
    * @default null

--- a/addon/components/polaris-date-picker/weekday.js
+++ b/addon/components/polaris-date-picker/weekday.js
@@ -1,10 +1,13 @@
 import Component from '@ember/component';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../templates/components/polaris-date-picker/weekday';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 @tagName('')
 @templateLayout(layout)
-export default class PolarisDatePickerWeekday extends Component {
+export default class PolarisDatePickerWeekday extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * @type {String}
    * @default null

--- a/addon/components/polaris-description-list.js
+++ b/addon/components/polaris-description-list.js
@@ -1,10 +1,13 @@
 import Component from '@ember/component';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../templates/components/polaris-description-list';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 @tagName('')
 @templateLayout(layout)
-export default class PolarisDescriptionList extends Component {
+export default class PolarisDescriptionList extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * Collection of items for list
    *

--- a/addon/components/polaris-display-text.js
+++ b/addon/components/polaris-display-text.js
@@ -4,6 +4,7 @@ import { classify } from '@ember/string';
 import { deprecate } from '@ember/application/deprecations';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../templates/components/polaris-display-text';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 /**
  * Polaris display text component.
@@ -21,7 +22,9 @@ import layout from '../templates/components/polaris-display-text';
  */
 @tagName('')
 @templateLayout(layout)
-export default class PolarisDisplayText extends Component {
+export default class PolarisDisplayText extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * Name of element to use for text
    * NOTE: Matches polaris-react's `element`

--- a/addon/components/polaris-drop-zone.js
+++ b/addon/components/polaris-drop-zone.js
@@ -17,6 +17,7 @@ import {
   mediumSizeWidthLimit,
   largeSizeWidthLimit,
 } from '../utils/drop-zone';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 const iconDragDrop = 'drag-drop';
 const iconAlertCircle = 'alert-circle';
@@ -24,7 +25,8 @@ const iconAlertCircle = 'alert-circle';
 @tagName('')
 @layout(template)
 export default class PolarisDropZoneComponent extends Component.extend(
-  ContextBoundEventListenersMixin
+  ContextBoundEventListenersMixin,
+  TaglessCssDeprecation
 ) {
   /**
    * ID for file input
@@ -272,7 +274,7 @@ export default class PolarisDropZoneComponent extends Component.extend(
   @or('active', 'state.dragging')
   isDragging;
 
-  @computed('outline', 'isDragging', 'state.error', 'sizeClass')
+  @computed('outline', 'isDragging', 'state.error', 'sizeClass', 'class')
   get dropZoneClasses() {
     let {
       outline,
@@ -281,21 +283,25 @@ export default class PolarisDropZoneComponent extends Component.extend(
       sizeClass,
     } = this;
 
-    let classNames = ['Polaris-DropZone', sizeClass];
+    let cssClasses = ['Polaris-DropZone', sizeClass];
 
     if (outline) {
-      classNames.push('Polaris-DropZone--hasOutline');
+      cssClasses.push('Polaris-DropZone--hasOutline');
     }
 
     if (isDragging) {
-      classNames.push('Polaris-DropZone--isDragging');
+      cssClasses.push('Polaris-DropZone--isDragging');
     }
 
     if (error) {
-      classNames.push('Polaris-DropZone--hasError');
+      cssClasses.push('Polaris-DropZone--hasError');
     }
 
-    return classNames.join(' ');
+    if (this.class) {
+      cssClasses.push(this.class);
+    }
+
+    return cssClasses.join(' ');
   }
 
   @computed('state.size')

--- a/addon/components/polaris-drop-zone/file-upload.js
+++ b/addon/components/polaris-drop-zone/file-upload.js
@@ -4,6 +4,7 @@ import { readOnly } from '@ember/object/computed';
 import { classify } from '@ember/string';
 import { tagName, layout } from '@ember-decorators/component';
 import template from '../../templates/components/polaris-drop-zone/file-upload';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 const iconDragDrop = 'drag-drop';
 const fileUpload = '/@smile-io/ember-polaris/images/file-upload.svg';
@@ -18,7 +19,9 @@ const fileUploadStrings = {
 
 @tagName('')
 @layout(template)
-export default class FileUploadComponent extends Component {
+export default class FileUploadComponent extends Component.extend(
+  TaglessCssDeprecation
+) {
   iconDragDrop = iconDragDrop;
   fileUpload = fileUpload;
   imageUpload = imageUpload;
@@ -57,12 +60,12 @@ export default class FileUploadComponent extends Component {
 
   @computed('size')
   get imageClasses() {
-    let classes = ['Polaris-DropZone-FileUpload__Image'];
+    let cssClasses = ['Polaris-DropZone-FileUpload__Image'];
     let { size } = this;
     if (['extraLarge', 'large'].includes(size)) {
-      classes.push(`Polaris-DropZone-FileUpload--size${classify(size)}`);
+      cssClasses.push(`Polaris-DropZone-FileUpload--size${classify(size)}`);
     }
 
-    return classes.join(' ');
+    return cssClasses.join(' ');
   }
 }

--- a/addon/components/polaris-empty-state.js
+++ b/addon/components/polaris-empty-state.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../templates/components/polaris-empty-state';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 /**
  * Polaris empty state component.
@@ -8,7 +9,9 @@ import layout from '../templates/components/polaris-empty-state';
  */
 @tagName('')
 @templateLayout(layout)
-export default class PolarisEmptyState extends Component {
+export default class PolarisEmptyState extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * The empty state heading
    *

--- a/addon/components/polaris-empty-state/details.js
+++ b/addon/components/polaris-empty-state/details.js
@@ -1,10 +1,11 @@
 import Component from '@ember/component';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../templates/components/polaris-empty-state/details';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 @tagName('')
 @templateLayout(layout)
-export default class Details extends Component {
+export default class Details extends Component.extend(TaglessCssDeprecation) {
   /**
    * The empty state heading
    *

--- a/addon/components/polaris-footer-help.js
+++ b/addon/components/polaris-footer-help.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../templates/components/polaris-footer-help';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 /**
  * Polaris footer help component.
@@ -8,7 +9,9 @@ import layout from '../templates/components/polaris-footer-help';
  */
 @tagName('')
 @templateLayout(layout)
-export default class PolarisFooterHelp extends Component {
+export default class PolarisFooterHelp extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * The content to display inside the layout.
    *

--- a/addon/components/polaris-form-layout.js
+++ b/addon/components/polaris-form-layout.js
@@ -3,6 +3,7 @@ import { action } from '@ember/object';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../templates/components/polaris-form-layout';
 import AutoWrapper from '../-private/auto-wrapper';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 /**
  * Polaris form layout component.
@@ -12,7 +13,9 @@ import AutoWrapper from '../-private/auto-wrapper';
  */
 @tagName('')
 @templateLayout(layout)
-export default class PolarisFormLayout extends Component {
+export default class PolarisFormLayout extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * The content to display inside the layout
    *

--- a/addon/components/polaris-form-layout/group.js
+++ b/addon/components/polaris-form-layout/group.js
@@ -5,10 +5,13 @@ import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../templates/components/polaris-form-layout/group';
 import { idVariation, helpTextId } from '../../utils/id';
 import AutoWrapper from '../../-private/auto-wrapper';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 @tagName('')
 @templateLayout(layout)
-export default class PolarisFormLayoutGroup extends Component {
+export default class PolarisFormLayoutGroup extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * Elements to display inside group item
    *
@@ -62,24 +65,6 @@ export default class PolarisFormLayoutGroup extends Component {
 
     return helpTextId(this.elementId);
   }
-
-  // didRender() {
-  //   super.didRender(...arguments);
-
-  //   let itemsContainer = this.element.querySelector(
-  //     '.Polaris-FormLayout__Items'
-  //   );
-
-  //   let nodesToWrap = rejectNodesByClassName(
-  //     itemsContainer.children,
-  //     'Polaris-FormLayout__Item'
-  //   );
-  //   let wrapper = document.createElement('div');
-
-  //   wrapper.classList.add('Polaris-FormLayout__Item');
-  //   wrapper.setAttribute('data-test-form-layout-item', true);
-  //   wrapChildren(nodesToWrap, wrapper);
-  // }
 
   @action
   setupAutoWrapper(formLayouItemsElement) {

--- a/addon/components/polaris-form-layout/item.js
+++ b/addon/components/polaris-form-layout/item.js
@@ -1,7 +1,10 @@
 import Component from '@ember/component';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../templates/components/polaris-form-layout/item';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 @tagName('')
 @templateLayout(layout)
-export default class PolarisFormLayoutItem extends Component {}
+export default class PolarisFormLayoutItem extends Component.extend(
+  TaglessCssDeprecation
+) {}

--- a/addon/components/polaris-form.js
+++ b/addon/components/polaris-form.js
@@ -3,10 +3,13 @@ import { action } from '@ember/object';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../templates/components/polaris-form';
 import { normalizeAutoCompleteProperty } from '../utils/normalize-auto-complete';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 @tagName('')
 @templateLayout(layout)
-export default class PolarisForm extends Component {
+export default class PolarisForm extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * Space separated list of character encodings
    *

--- a/addon/components/polaris-heading.js
+++ b/addon/components/polaris-heading.js
@@ -2,6 +2,7 @@ import Component from '@ember/component';
 import { deprecate } from '@ember/application/deprecations';
 import { tagName, layout } from '@ember-decorators/component';
 import template from '../templates/components/polaris-heading';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 /**
  * Polaris heading component.
@@ -19,7 +20,9 @@ import template from '../templates/components/polaris-heading';
  */
 @tagName('')
 @layout(template)
-export default class PolarisHeadingComponent extends Component {
+export default class PolarisHeadingComponent extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * The content to display inside the heading
    *

--- a/addon/components/polaris-icon.js
+++ b/addon/components/polaris-icon.js
@@ -2,15 +2,18 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { equal } from '@ember/object/computed';
 import { classify } from '@ember/string';
-import { deprecate } from '@ember/application/deprecations';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../templates/components/polaris-icon';
 import SvgHandling from '../mixins/components/svg-handling';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 // TODO: look into importing icons properly.
 @tagName('')
 @templateLayout(layout)
-export default class PolarisIcon extends Component.extend(SvgHandling) {
+export default class PolarisIcon extends Component.extend(
+  SvgHandling,
+  TaglessCssDeprecation
+) {
   /**
    * The SVG contents to display in the icon
    * If the source doesn't have a slash in the name, it will look for Polaris
@@ -87,32 +90,22 @@ export default class PolarisIcon extends Component.extend(SvgHandling) {
     return source.indexOf('/') === -1 ? `${this.sourcePath}/${source}` : source;
   }
 
-  @computed('color', 'isColored', 'backdrop')
-  get classes() {
-    let classes = ['Polaris-Icon'];
+  @computed('color', 'isColored', 'backdrop', 'class')
+  get cssClasses() {
+    let cssClasses = ['Polaris-Icon'];
     if (this.color) {
-      classes.push(`Polaris-Icon--color${classify(this.color)}`);
+      cssClasses.push(`Polaris-Icon--color${classify(this.color)}`);
     }
     if (this.isColored) {
-      classes.push('Polaris-Icon--isColored');
+      cssClasses.push('Polaris-Icon--isColored');
     }
     if (this.backdrop) {
-      classes.push('Polaris-Icon--hasBackdrop');
+      cssClasses.push('Polaris-Icon--hasBackdrop');
+    }
+    if (this.class) {
+      cssClasses.push(this.class);
     }
 
-    return classes.join(' ');
-  }
-
-  init() {
-    super.init(...arguments);
-
-    deprecate(
-      `[PolarisIcon] Passing 'class' argument is deprecated! Switch to angle bracket invocation and pass an HTML attribute instead`,
-      !this.class,
-      {
-        id: 'ember-polaris.polaris-icon.class-arg',
-        until: '7.0.0',
-      }
-    );
+    return cssClasses.join(' ');
   }
 }

--- a/addon/components/polaris-labelled.js
+++ b/addon/components/polaris-labelled.js
@@ -83,7 +83,6 @@ export default class PolarisLabelledComponent extends Component {
    * ID for the help text div
    *
    * @type {String}
-   * @private
    */
   @computedHelpTextId('id')
   helpTextId;
@@ -92,7 +91,6 @@ export default class PolarisLabelledComponent extends Component {
    * Flag indicating whether to render the error component
    *
    * @type {Boolean}
-   * @private
    */
   @computed('error')
   get shouldRenderError() {

--- a/addon/components/polaris-layout.js
+++ b/addon/components/polaris-layout.js
@@ -1,10 +1,13 @@
 import Component from '@ember/component';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../templates/components/polaris-layout';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 @tagName('')
 @templateLayout(layout)
-export default class PolarisLayout extends Component {
+export default class PolarisLayout extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * Automatically adds sections to layout
    *

--- a/addon/components/polaris-layout/annotated-section.js
+++ b/addon/components/polaris-layout/annotated-section.js
@@ -1,10 +1,13 @@
 import Component from '@ember/component';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../templates/components/polaris-layout/annotated-section';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 @tagName('')
 @templateLayout(layout)
-export default class PolarisLayoutAnnotatedSection extends Component {
+export default class PolarisLayoutAnnotatedSection extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * Title for the section
    *

--- a/addon/components/polaris-layout/annotation-content.js
+++ b/addon/components/polaris-layout/annotation-content.js
@@ -1,10 +1,13 @@
 import Component from '@ember/component';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../templates/components/polaris-layout/annotation-content';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 @tagName('')
 @templateLayout(layout)
-export default class PolarisLayoutAnnotationContent extends Component {
+export default class PolarisLayoutAnnotationContent extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * Inner content of the section
    *

--- a/addon/components/polaris-layout/annotation.js
+++ b/addon/components/polaris-layout/annotation.js
@@ -2,10 +2,13 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../templates/components/polaris-layout/annotation';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 @tagName('')
 @templateLayout(layout)
-export default class Annotation extends Component {
+export default class Annotation extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * Title for the section
    *

--- a/addon/components/polaris-layout/section.js
+++ b/addon/components/polaris-layout/section.js
@@ -2,32 +2,38 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../templates/components/polaris-layout/section';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 @tagName('')
 @templateLayout(layout)
-export default class PolarisLayoutSection extends Component {
+export default class PolarisLayoutSection extends Component.extend(
+  TaglessCssDeprecation
+) {
   text = null;
   secondary = false;
   fullWidth = false;
   oneHalf = false;
   oneThird = false;
 
-  @computed('secondary', 'fullWidth', 'oneHalf', 'oneThird')
-  get classes() {
-    let classes = ['Polaris-Layout__Section'];
+  @computed('secondary', 'fullWidth', 'oneHalf', 'oneThird', 'class')
+  get cssClasses() {
+    let cssClasses = ['Polaris-Layout__Section'];
     if (this.secondary) {
-      classes.push('Polaris-Layout__Section--secondary');
+      cssClasses.push('Polaris-Layout__Section--secondary');
     }
     if (this.fullWidth) {
-      classes.push('Polaris-Layout__Section--fullWidth');
+      cssClasses.push('Polaris-Layout__Section--fullWidth');
     }
     if (this.oneHalf) {
-      classes.push('Polaris-Layout__Section--oneHalf');
+      cssClasses.push('Polaris-Layout__Section--oneHalf');
     }
     if (this.oneThird) {
-      classes.push('Polaris-Layout__Section--oneThird');
+      cssClasses.push('Polaris-Layout__Section--oneThird');
+    }
+    if (this.class) {
+      cssClasses.push(this.class);
     }
 
-    return classes.join(' ');
+    return cssClasses.join(' ');
   }
 }

--- a/addon/components/polaris-link.js
+++ b/addon/components/polaris-link.js
@@ -55,9 +55,6 @@ export default class PolarisLink extends Component {
    */
   onClick() {}
 
-  /**
-   * @private
-   */
   @(computed('class', 'monochrome').readOnly())
   get linkClass() {
     let linkClasses = ['Polaris-Link'];

--- a/addon/components/polaris-list.js
+++ b/addon/components/polaris-list.js
@@ -47,10 +47,10 @@ export default class PolarisList extends Component {
    */
   @(computed('listType').readOnly())
   get listElementClass() {
-    let classNames = ['Polaris-List'];
+    let cssClasses = ['Polaris-List'];
     let { listType } = this;
-    classNames.push(`Polaris-List--type${classify(listType)}`);
+    cssClasses.push(`Polaris-List--type${classify(listType)}`);
 
-    return classNames.join(' ');
+    return cssClasses.join(' ');
   }
 }

--- a/addon/components/polaris-list/item.js
+++ b/addon/components/polaris-list/item.js
@@ -1,10 +1,11 @@
 import Component from '@ember/component';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../templates/components/polaris-list/item';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 @tagName('')
 @templateLayout(layout)
-export default class Item extends Component {
+export default class Item extends Component.extend(TaglessCssDeprecation) {
   /**
    * The content to display for this list item
    *

--- a/addon/components/polaris-option-list.js
+++ b/addon/components/polaris-option-list.js
@@ -3,6 +3,7 @@ import { action, computed } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../templates/components/polaris-option-list';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 /**
  * Polaris option list component.
@@ -10,7 +11,9 @@ import layout from '../templates/components/polaris-option-list';
  */
 @tagName('')
 @templateLayout(layout)
-export default class PolarisOptionList extends Component {
+export default class PolarisOptionList extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * A unique identifier for the option list
    * Defaults to Ember's GUID for this component instance
@@ -107,7 +110,6 @@ export default class PolarisOptionList extends Component {
 
   /**
    * @type {Object[]}
-   * @private
    */
   @(computed('options.[]', 'sections.[]', 'title').readOnly())
   get normalizedOptions() {
@@ -142,19 +144,10 @@ function createNormalizedOptions(options, sections, title) {
     let section = { options: [], title };
     return sections == null ? [] : [section, ...sections];
   }
+
   if (sections == null) {
-    return [
-      {
-        title,
-        options,
-      },
-    ];
+    return [{ title, options }];
   }
-  return [
-    {
-      title,
-      options,
-    },
-    ...sections,
-  ];
+
+  return [{ title, options }, ...sections];
 }

--- a/addon/components/polaris-option-list/checkbox.js
+++ b/addon/components/polaris-option-list/checkbox.js
@@ -3,10 +3,11 @@ import { computed } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../templates/components/polaris-option-list/checkbox';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 @tagName('')
 @templateLayout(layout)
-export default class Checkbox extends Component {
+export default class Checkbox extends Component.extend(TaglessCssDeprecation) {
   /**
    * @type {Boolean}
    * @default false

--- a/addon/components/polaris-option-list/option.js
+++ b/addon/components/polaris-option-list/option.js
@@ -2,10 +2,11 @@ import { action } from '@ember/object';
 import Component from '@ember/component';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../templates/components/polaris-option-list/option';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 @tagName('')
 @templateLayout(layout)
-export default class Option extends Component {
+export default class Option extends Component.extend(TaglessCssDeprecation) {
   /**
    * @type {String}
    * @default null
@@ -93,7 +94,6 @@ export default class Option extends Component {
   /**
    * @type {Boolean}
    * @default false
-   * @private
    */
   focused = false;
 

--- a/addon/components/polaris-page-actions.js
+++ b/addon/components/polaris-page-actions.js
@@ -4,6 +4,7 @@ import { isArray } from '@ember/array';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import { invokeAction } from 'ember-invoke-action';
 import layout from '../templates/components/polaris-page-actions';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 /**
  * Polaris page actions component.
@@ -11,7 +12,9 @@ import layout from '../templates/components/polaris-page-actions';
  */
 @tagName('')
 @templateLayout(layout)
-export default class PolarisPageActions extends Component {
+export default class PolarisPageActions extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * The primary action for the page
    *

--- a/addon/components/polaris-page.js
+++ b/addon/components/polaris-page.js
@@ -1,9 +1,9 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { or } from '@ember/object/computed';
-import { deprecate } from '@ember/application/deprecations';
 import { tagName, layout } from '@ember-decorators/component';
 import template from '../templates/components/polaris-page';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 /**
  * Polaris page component.
@@ -11,7 +11,9 @@ import template from '../templates/components/polaris-page';
  */
 @tagName('')
 @layout(template)
-export default class PolarisPageComponent extends Component {
+export default class PolarisPageComponent extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * Page title, in large type
    *
@@ -156,33 +158,20 @@ export default class PolarisPageComponent extends Component {
   hasHeaderContent;
 
   @computed('fullWidth', 'singleColumn', 'class')
-  get classes() {
-    let classes = ['Polaris-Page'];
+  get cssClasses() {
+    let cssClasses = ['Polaris-Page'];
     if (this.fullWidth) {
-      classes.push('Polaris-Page--fullWidth');
+      cssClasses.push('Polaris-Page--fullWidth');
     }
 
     if (this.singleColumn) {
-      classes.push('Polaris-Page--singleColumn');
+      cssClasses.push('Polaris-Page--singleColumn');
     }
 
     if (this.class) {
-      classes.push(this.class);
+      cssClasses.push(this.class);
     }
 
-    return classes.join(' ');
-  }
-
-  init() {
-    super.init(...arguments);
-
-    deprecate(
-      `[polaris-page] Passing 'class' is deprecated! Switch to angle bracket invocation and pass an HTML attribute instead`,
-      !this.class,
-      {
-        id: 'ember-polaris.polaris-page.class-arg',
-        until: '7.0.0',
-      }
-    );
+    return cssClasses.join(' ');
   }
 }

--- a/addon/components/polaris-page/action-icon.js
+++ b/addon/components/polaris-page/action-icon.js
@@ -1,10 +1,13 @@
 import Component from '@ember/component';
 import { tagName, layout } from '@ember-decorators/component';
 import template from '../../templates/components/polaris-page/action-icon';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 @tagName('')
 @layout(template)
-export default class ActionIconComponent extends Component {
+export default class ActionIconComponent extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * The icon to display
    *

--- a/addon/components/polaris-page/action.js
+++ b/addon/components/polaris-page/action.js
@@ -4,10 +4,13 @@ import { isBlank } from '@ember/utils';
 import { tagName, layout } from '@ember-decorators/component';
 import template from '../../templates/components/polaris-page/action';
 import { handleMouseUpByBlurring } from '../../utils/focus';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 @tagName('')
 @layout(template)
-export default class ActionComponent extends Component {
+export default class ActionComponent extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * @type {String}
    * @default null
@@ -73,18 +76,22 @@ export default class ActionComponent extends Component {
     return this.icon && isBlank(this.text);
   }
 
-  @computed('isIconOnly', 'disabled')
-  get classes() {
-    let classes = ['Polaris-Header-Action'];
+  @computed('isIconOnly', 'disabled', 'class')
+  get cssClasses() {
+    let cssClasses = ['Polaris-Header-Action'];
     if (this.isIconOnly) {
-      classes.push('Polaris-Header-Action--iconOnly');
+      cssClasses.push('Polaris-Header-Action--iconOnly');
     }
 
     if (this.disabled) {
-      classes.push('Polaris-Header-Action--disabled');
+      cssClasses.push('Polaris-Header-Action--disabled');
     }
 
-    return classes.join(' ');
+    if (this.class) {
+      cssClasses.push(this.class);
+    }
+
+    return cssClasses.join(' ');
   }
 
   @action

--- a/addon/components/polaris-page/header.js
+++ b/addon/components/polaris-page/header.js
@@ -3,10 +3,13 @@ import { computed } from '@ember/object';
 import { or, gt } from '@ember/object/computed';
 import { tagName, layout } from '@ember-decorators/component';
 import template from '../../templates/components/polaris-page/header';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 @tagName('')
 @layout(template)
-export default class HeaderComponent extends Component {
+export default class HeaderComponent extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * Page title, in large type
    *
@@ -154,31 +157,36 @@ export default class HeaderComponent extends Component {
     'separator',
     'hasBreadcrumbs',
     'hasSecondaryActions',
-    'hasRollup'
+    'hasRollup',
+    'class'
   )
-  get classes() {
-    let classes = ['Polaris-Page-Header'];
+  get cssClasses() {
+    let cssClasses = ['Polaris-Page-Header'];
 
     if (this.titleHidden) {
-      classes.push('Polaris-Page-Header__Title--hidden');
+      cssClasses.push('Polaris-Page-Header__Title--hidden');
     }
 
     if (this.separator) {
-      classes.push('Polaris-Page-Header__Header--hasSeparator');
+      cssClasses.push('Polaris-Page-Header__Header--hasSeparator');
     }
 
     if (this.hasBreadcrumbs) {
-      classes.push('Polaris-Page-Header__Header--hasBreadcrumbs');
+      cssClasses.push('Polaris-Page-Header__Header--hasBreadcrumbs');
     }
 
     if (this.hasSecondaryActions) {
-      classes.push('Polaris-Page-Header__Header--hasSecondaryActions');
+      cssClasses.push('Polaris-Page-Header__Header--hasSecondaryActions');
     }
 
     if (this.hasRollup) {
-      classes.push('Polaris-Page-Header__Header--hasRollup');
+      cssClasses.push('Polaris-Page-Header__Header--hasRollup');
     }
 
-    return classes.join(' ');
+    if (this.class) {
+      cssClasses.push(this.class);
+    }
+
+    return cssClasses.join(' ');
   }
 }

--- a/addon/components/polaris-page/header/action-group.js
+++ b/addon/components/polaris-page/header/action-group.js
@@ -1,10 +1,13 @@
 import Component from '@ember/component';
 import { tagName, layout } from '@ember-decorators/component';
 import template from '../../../templates/components/polaris-page/header/action-group';
+import TaglessCssDeprecation from '../../../mixins/tagless-css-deprecation';
 
 @tagName('')
 @layout(template)
-export default class ActionGroupComponent extends Component {
+export default class ActionGroupComponent extends Component.extend(
+  TaglessCssDeprecation
+) {
   title = null;
   icon = null;
   groupActions = null;

--- a/addon/components/polaris-pagination.js
+++ b/addon/components/polaris-pagination.js
@@ -7,10 +7,13 @@ import { isEmpty } from '@ember/utils';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../templates/components/polaris-pagination';
 import { handleMouseUpByBlurring } from '../utils/focus';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 @tagName('')
 @templateLayout(layout)
-export default class PolarisPagination extends Component {
+export default class PolarisPagination extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * A more subdued control for use in headers
    *
@@ -103,18 +106,20 @@ export default class PolarisPagination extends Component {
    */
   onPrevious() {}
 
-  /** @private */
   handleMouseUpByBlurring = handleMouseUpByBlurring;
 
-  /** @private */
   @(not('hasPrevious').readOnly())
   isPreviousDisabled;
 
-  /** @private */
   @(not('hasNext').readOnly())
   isNextDisabled;
 
-  /** @private */
+  @(and('hasNext', 'hasNextKeysConfigured', 'onNext').readOnly())
+  isNextKeyListenerEnabled;
+
+  @(and('hasPrevious', 'hasPreviousKeysConfigured', 'onPrevious').readOnly())
+  isPreviousKeyListenerEnabled;
+
   @(computed('nextKeys.[]').readOnly())
   get hasNextKeysConfigured() {
     let { nextKeys } = this;
@@ -131,7 +136,6 @@ export default class PolarisPagination extends Component {
     return true;
   }
 
-  /** @private */
   @(computed('previousKeys.[]').readOnly())
   get hasPreviousKeysConfigured() {
     let { previousKeys } = this;
@@ -147,12 +151,4 @@ export default class PolarisPagination extends Component {
 
     return true;
   }
-
-  /** @private */
-  @(and('hasNext', 'hasNextKeysConfigured', 'onNext').readOnly())
-  isNextKeyListenerEnabled;
-
-  /** @private */
-  @(and('hasPrevious', 'hasPreviousKeysConfigured', 'onPrevious').readOnly())
-  isPreviousKeyListenerEnabled;
 }

--- a/addon/components/polaris-popover.js
+++ b/addon/components/polaris-popover.js
@@ -109,18 +109,12 @@ export default class PolarisPopover extends Component {
    */
   onClose() {}
 
-  /**
-   * @private
-   */
   triggerStyle = htmlSafe(`
     display: inline-block;
     overflow: inherit;
     border: none;
   `);
 
-  /**
-   * @private
-   */
   @computed('preferredPosition')
   get verticalPosition() {
     // If `preferredPosition` is set to `mostSpace`, the value
@@ -149,7 +143,6 @@ export default class PolarisPopover extends Component {
    * Checks the dropdown activator's location on
    * screen to determine which vertical direction
    * has more space to open the dropdown.
-   * @private
    */
   getMostVerticalSpace() {
     let component;

--- a/addon/components/polaris-popover/content.js
+++ b/addon/components/polaris-popover/content.js
@@ -36,7 +36,7 @@ export default class Content extends Component {
    * Content wrapper component.
    *
    * @type {Component}
-   * @default: null
+   * @default null
    * @public
    */
   contentComponent = null;
@@ -58,7 +58,7 @@ export default class Content extends Component {
    * `ember-basic-dropdown`'s generated ID, used to look up
    *
    * @type {String}
-   * @default: null
+   * @default null
    * @public
    */
   uniqueId = null;

--- a/addon/components/polaris-progress-bar.js
+++ b/addon/components/polaris-progress-bar.js
@@ -4,6 +4,7 @@ import { classify, htmlSafe } from '@ember/string';
 import { isPresent } from '@ember/utils';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../templates/components/polaris-progress-bar';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 const allowedSizes = ['small', 'medium', 'large'];
 const defaultSize = 'medium';
@@ -16,13 +17,15 @@ const defaultSize = 'medium';
  */
 @tagName('')
 @templateLayout(layout)
-export default class PolarisProgressBar extends Component {
+export default class PolarisProgressBar extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * The progression of certain tasks
    *
    * @public
    * @type {Number}
-   * @default: 0
+   * @default 0
    */
   progress = 0;
 
@@ -31,13 +34,10 @@ export default class PolarisProgressBar extends Component {
    *
    * @public
    * @type {String}
-   * @default: 'medium'
+   * @default 'medium'
    */
   size = defaultSize;
 
-  /**
-   * @private
-   */
   @(computed('size').readOnly())
   get sizeClass() {
     let { size } = this;
@@ -48,9 +48,6 @@ export default class PolarisProgressBar extends Component {
     return `Polaris-ProgressBar--size${classify(size)}`;
   }
 
-  /**
-   * @private
-   */
   @(computed('progress').readOnly())
   get parsedProgress() {
     let { progress } = this;
@@ -71,9 +68,6 @@ export default class PolarisProgressBar extends Component {
     return parsedProgress;
   }
 
-  /**
-   * @private
-   */
   @(computed('parsedProgress').readOnly())
   get progressStyle() {
     let { parsedProgress } = this;

--- a/addon/components/polaris-radio-button.js
+++ b/addon/components/polaris-radio-button.js
@@ -110,17 +110,11 @@ export default class PolarisRadioButton extends Component {
    */
   onBlur() {}
 
-  /**
-   * @private
-   */
   @(computed('inputId').readOnly())
   get _id() {
     return this.inputId || `polaris-radio-button-${guidFor(this)}`;
   }
 
-  /**
-   * @private
-   */
   @(computed('helpText', '_id').readOnly())
   get describedBy() {
     return this.helpText ? `${this._id}HelpText` : null;

--- a/addon/components/polaris-range-slider.js
+++ b/addon/components/polaris-range-slider.js
@@ -183,29 +183,27 @@ export default class PolarisRangeSlider extends Component {
    * Class names for the range wrapper div
    *
    * @type {String}
-   * @private
    */
   @(computed('error', 'disabled').readOnly())
   get rangeWrapperClassNames() {
     let { error, disabled } = this;
-    let classNames = ['Polaris-RangeSlider'];
+    let cssClasses = ['Polaris-RangeSlider'];
 
     if (error) {
-      classNames.push('Polaris-RangeSlider--error');
+      cssClasses.push('Polaris-RangeSlider--error');
     }
 
     if (disabled) {
-      classNames.push('Polaris-RangeSlider--disabled');
+      cssClasses.push('Polaris-RangeSlider--disabled');
     }
 
-    return classNames.join(' ');
+    return cssClasses.join(' ');
   }
 
   /**
    * Style for the range wrapper div
    *
    * @type {String}
-   * @private
    */
   @(computed('min', 'max', 'value', 'sliderProgress').readOnly())
   get rangeWrapperStyle() {
@@ -235,7 +233,6 @@ export default class PolarisRangeSlider extends Component {
    * Slider progress percentage
    *
    * @type {Number}
-   * @private
    */
   @(computed('min', 'max', 'value').readOnly())
   get sliderProgress() {
@@ -247,7 +244,6 @@ export default class PolarisRangeSlider extends Component {
    * Stringified boolean flag indicating whether an error is present
    *
    * @type {String}
-   * @private
    */
   @(computed('error').readOnly())
   get hasError() {
@@ -258,7 +254,6 @@ export default class PolarisRangeSlider extends Component {
    * Accessibility
    *
    * @type {Boolean}
-   * @private
    */
   @(computed('error', 'helpText', 'id').readOnly())
   get ariaDescribedBy() {
@@ -280,7 +275,6 @@ export default class PolarisRangeSlider extends Component {
    * Boolean flag indicating whether the output value should be displayed
    *
    * @type {Boolean}
-   * @private
    */
   @(computed('disabled', 'output').readOnly())
   get shouldShowOutput() {

--- a/addon/components/polaris-resource-list.js
+++ b/addon/components/polaris-resource-list.js
@@ -207,14 +207,12 @@ export default class PolarisResourceList extends Component.extend(
   /**
    * @type {Boolean}
    * @default false
-   * @private
    */
   selectMode = false;
 
   /**
    * @type {Number}
    * @default 0
-   * @private
    */
   loadingPosition = 0;
 
@@ -224,13 +222,11 @@ export default class PolarisResourceList extends Component.extend(
    *
    * @type {HTMLUListElement}
    * @default null
-   * @private
    */
   listNode = null;
 
   /**
    * @type {Object}
-   * @private
    */
   defaultResourceName = null;
 
@@ -239,7 +235,6 @@ export default class PolarisResourceList extends Component.extend(
    * `componentDidUpdate` behaviour.
    *
    * @type {Boolean}
-   * @private
    */
   previousLoading = false;
 
@@ -248,7 +243,6 @@ export default class PolarisResourceList extends Component.extend(
    * `componentWillReceiveProps` behaviour.
    *
    * @type {String|String[]}
-   * @private
    */
   previousSelectedItems = null;
 

--- a/addon/components/polaris-resource-list/bulk-actions.js
+++ b/addon/components/polaris-resource-list/bulk-actions.js
@@ -5,6 +5,7 @@ import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import ContextBoundEventListenersMixin from 'ember-lifeline/mixins/dom';
 import ContextBoundTasksMixin from 'ember-lifeline/mixins/run';
 import layout from '../../templates/components/polaris-resource-list/bulk-actions';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 const MAX_PROMOTED_ACTIONS = 2;
 
@@ -12,7 +13,8 @@ const MAX_PROMOTED_ACTIONS = 2;
 @templateLayout(layout)
 export default class BulkActions extends Component.extend(
   ContextBoundEventListenersMixin,
-  ContextBoundTasksMixin
+  ContextBoundTasksMixin,
+  TaglessCssDeprecation
 ) {
   /**
    * Visually hidden text for screen readers
@@ -258,6 +260,24 @@ export default class BulkActions extends Component.extend(
     }
 
     return combinedActions;
+  }
+
+  @computed('selectMode', 'class')
+  get cssClasses() {
+    let cssClasses = [
+      'Polaris-ResourceList-BulkActions__Group',
+      'Polaris-ResourceList-BulkActions__Group--smallScreen',
+    ];
+    if (this.selectMode) {
+      cssClasses.push('Polaris-ResourceList-BulkActions__Group--entered');
+    } else {
+      cssClasses.push('Polaris-ResourceList-BulkActions__Group--exited');
+    }
+    if (this.class) {
+      cssClasses.push(this.class);
+    }
+
+    return cssClasses.join(' ');
   }
 
   get moreActionsNode() {

--- a/addon/components/polaris-resource-list/checkable-button.js
+++ b/addon/components/polaris-resource-list/checkable-button.js
@@ -3,10 +3,13 @@ import { action, computed } from '@ember/object';
 import { not, and } from '@ember/object/computed';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../templates/components/polaris-resource-list/checkable-button';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 @tagName('')
 @templateLayout(layout)
-export default class CheckableButton extends Component {
+export default class CheckableButton extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * @type {String}
    * @default null
@@ -82,32 +85,36 @@ export default class CheckableButton extends Component {
     'plain',
     'shouldApplySelectModeClass',
     'shouldApplySelectedClass',
-    'shouldApplyMeasuringClass'
+    'shouldApplyMeasuringClass',
+    'class'
   )
-  get classes() {
-    let classes = ['Polaris-ResourceList-CheckableButton'];
+  get cssClasses() {
+    let cssClasses = ['Polaris-ResourceList-CheckableButton'];
     if (this.plain) {
-      classes.push(
+      cssClasses.push(
         'Polaris-ResourceList-CheckableButton__CheckableButton--plain'
       );
     }
     if (this.shouldApplySelectModeClass) {
-      classes.push(
+      cssClasses.push(
         'Polaris-ResourceList-CheckableButton__CheckableButton--selectMode'
       );
     }
     if (this.shouldApplySelectedClass) {
-      classes.push(
+      cssClasses.push(
         'Polaris-ResourceList-CheckableButton__CheckableButton--selected'
       );
     }
     if (this.shouldApplyMeasuringClass) {
-      classes.push(
+      cssClasses.push(
         'Polaris-ResourceList-CheckableButton__CheckableButton--measuring'
       );
     }
+    if (this.class) {
+      cssClasses.push(this.class);
+    }
 
-    return classes.join(' ');
+    return cssClasses.join(' ');
   }
 
   @action

--- a/addon/components/polaris-resource-list/filter-control.js
+++ b/addon/components/polaris-resource-list/filter-control.js
@@ -74,7 +74,6 @@ export default class FilterControl extends Component.extend(
    * even if it doesn't exist, which leads to an error.
    *
    * @type {Object}
-   * @private
    */
   @(computed(
     'additionalAction.{text,accessibilityLabel,url,external,destructive,icon,loading,onAction}',
@@ -106,7 +105,6 @@ export default class FilterControl extends Component.extend(
    * for rendering in the template
    *
    * @type {Object[]}
-   * @private
    */
   @(computed('appliedFilters.[]').readOnly())
   get appliedFiltersForRender() {

--- a/addon/components/polaris-resource-list/filter-control/date-selector.js
+++ b/addon/components/polaris-resource-list/filter-control/date-selector.js
@@ -75,21 +75,18 @@ export default class DateSelector extends Component {
   /**
    * @type {Date}
    * @default null
-   * @private
    */
   selectedDate = null;
 
   /**
    * @type {String}
    * @default null
-   * @private
    */
   userInputDate = null;
 
   /**
    * @type {String}
    * @default null
-   * @private
    */
   userInputDateError = null;
 
@@ -97,13 +94,11 @@ export default class DateSelector extends Component {
    * Month enum value, either string day of month or integer index (0 = Sunday).
    *
    * @type {String|Number}
-   * @private
    */
   datePickerMonth = null;
 
   /**
    * @type {Number}
-   * @private
    */
   datePickerYear = null;
 
@@ -112,7 +107,6 @@ export default class DateSelector extends Component {
    *
    * @type {String}
    * @default null
-   * @private
    */
   initialConsumerFilterKey = null;
 

--- a/addon/components/polaris-resource-list/filter-control/filter-creator.js
+++ b/addon/components/polaris-resource-list/filter-control/filter-creator.js
@@ -40,21 +40,18 @@ export default class FilterCreator extends Component {
   /**
    * @type {Object}
    * @default null
-   * @private
    */
   selectedFilter = null;
 
   /**
    * @type {String}
    * @default null
-   * @private
    */
   selectedFilterKey = null;
 
   /**
    * @type {String}
    * @default null
-   * @private
    */
   selectedFilterValue = null;
 

--- a/addon/components/polaris-resource-list/item.js
+++ b/addon/components/polaris-resource-list/item.js
@@ -6,10 +6,14 @@ import layout from '../../templates/components/polaris-resource-list/item';
 import { context } from '@smile-io/ember-polaris/components/polaris-resource-list';
 import { computedIdVariation } from '@smile-io/ember-polaris/utils/id';
 import { SELECT_ALL_ITEMS } from '../polaris-resource-list';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 @tagName('')
 @templateLayout(layout)
-export default class Item extends Component.extend(context.ConsumerMixin) {
+export default class Item extends Component.extend(
+  context.ConsumerMixin,
+  TaglessCssDeprecation
+) {
   /**
    * Unique identifier for the item
    *
@@ -91,14 +95,12 @@ export default class Item extends Component.extend(context.ConsumerMixin) {
   /**
    * @type {Boolean}
    * @default false
-   * @private
    */
   focused = false;
 
   /**
    * @type {Boolean}
    * @default false
-   * @private
    */
   focusedInner = false;
 
@@ -125,6 +127,42 @@ export default class Item extends Component.extend(context.ConsumerMixin) {
       ((Array.isArray(selectedItems) && selectedItems.includes(itemId)) ||
         selectedItems === SELECT_ALL_ITEMS)
     );
+  }
+
+  @computed(
+    'focused',
+    'selectable',
+    'selected',
+    'selectMode',
+    'persistActions',
+    'focusedInner',
+    'class'
+  )
+  get cssClasses() {
+    let cssClasses = ['Polaris-ResourceList-Item'];
+    if (this.focused) {
+      cssClasses.push('Polaris-ResourceList-Item--focused');
+    }
+    if (this.selectable) {
+      cssClasses.push('Polaris-ResourceList-Item--selectable');
+    }
+    if (this.selected) {
+      cssClasses.push('Polaris-ResourceList-Item--selected');
+    }
+    if (this.selectMode) {
+      cssClasses.push('Polaris-ResourceList-Item--selectMode');
+    }
+    if (this.persistActions) {
+      cssClasses.push('Polaris-ResourceList-Item--persistActions');
+    }
+    if (this.focusedInner) {
+      cssClasses.push('Polaris-ResourceList-Item--focusedInner');
+    }
+    if (this.class) {
+      cssClasses.push(this.class);
+    }
+
+    return cssClasses.join(' ');
   }
 
   @action

--- a/addon/components/polaris-select.js
+++ b/addon/components/polaris-select.js
@@ -190,17 +190,17 @@ export default class PolarisSelect extends Component {
    */
   @computed('error', 'disabled')
   get className() {
-    let classNames = ['Polaris-Select'];
+    let cssClasses = ['Polaris-Select'];
 
     if (this.error) {
-      classNames.push('Polaris-Select--error');
+      cssClasses.push('Polaris-Select--error');
     }
 
     if (this.disabled) {
-      classNames.push('Polaris-Select--disabled');
+      cssClasses.push('Polaris-Select--disabled');
     }
 
-    return classNames.join(' ');
+    return cssClasses.join(' ');
   }
 
   /**

--- a/addon/components/polaris-skeleton-body-text.js
+++ b/addon/components/polaris-skeleton-body-text.js
@@ -2,12 +2,15 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../templates/components/polaris-skeleton-body-text';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 const defaultLines = 3;
 
 @tagName('')
 @templateLayout(layout)
-export default class PolarisSkeletonBodyTextComponent extends Component {
+export default class PolarisSkeletonBodyTextComponent extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * Number of lines to display
    *

--- a/addon/components/polaris-skeleton-display-text.js
+++ b/addon/components/polaris-skeleton-display-text.js
@@ -3,13 +3,16 @@ import { computed } from '@ember/object';
 import { classify } from '@ember/string';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../templates/components/polaris-skeleton-display-text';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 const defaultSize = 'medium';
 const allowedSizes = ['small', defaultSize, 'large', 'extraLarge'];
 
 @tagName('')
 @templateLayout(layout)
-export default class PolarisSkeletonDisplayTextComponent extends Component {
+export default class PolarisSkeletonDisplayTextComponent extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * Size of the text
    *

--- a/addon/components/polaris-skeleton-page.js
+++ b/addon/components/polaris-skeleton-page.js
@@ -3,10 +3,13 @@ import { computed } from '@ember/object';
 import { notEmpty } from '@ember/object/computed';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../templates/components/polaris-skeleton-page';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 @tagName('')
 @templateLayout(layout)
-export default class PolarisSkeletonPageComponent extends Component {
+export default class PolarisSkeletonPageComponent extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * Page title, in large type
    *
@@ -121,16 +124,19 @@ export default class PolarisSkeletonPageComponent extends Component {
     return new Array(Math.max(secondaryActions, 0));
   }
 
-  @computed('fullWidth', 'singleColumn')
-  get classes() {
-    let classNames = ['Polaris-SkeletonPage__Page'];
+  @computed('fullWidth', 'singleColumn', 'class')
+  get cssClasses() {
+    let cssClasses = ['Polaris-SkeletonPage__Page'];
     if (this.fullWidth) {
-      classNames.push('Polaris-SkeletonPage--fullWidth');
+      cssClasses.push('Polaris-SkeletonPage--fullWidth');
     }
     if (this.singleColumn) {
-      classNames.push('Polaris-SkeletonPage--singleColumn');
+      cssClasses.push('Polaris-SkeletonPage--singleColumn');
+    }
+    if (this.class) {
+      cssClasses.push(this.class);
     }
 
-    return classNames.join(' ');
+    return cssClasses.join(' ');
   }
 }

--- a/addon/components/polaris-skeleton-page/action.js
+++ b/addon/components/polaris-skeleton-page/action.js
@@ -3,10 +3,13 @@ import { computed } from '@ember/object';
 import { htmlSafe } from '@ember/string';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../templates/components/polaris-skeleton-page/action';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 @tagName('')
 @templateLayout(layout)
-export default class SkeletonPageActionComponent extends Component {
+export default class SkeletonPageActionComponent extends Component.extend(
+  TaglessCssDeprecation
+) {
   @computed()
   get width() {
     return Math.round(Math.random() * 40 + 60);

--- a/addon/components/polaris-skeleton-thumbnail.js
+++ b/addon/components/polaris-skeleton-thumbnail.js
@@ -3,13 +3,16 @@ import { computed } from '@ember/object';
 import { capitalize } from '@ember/string';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../templates/components/polaris-skeleton-thumbnail';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 const defaultSize = 'medium';
 const allowedSizes = ['small', defaultSize, 'large'];
 
 @tagName('')
 @templateLayout(layout)
-export default class PolarisSkeletonThumbnailComponent extends Component {
+export default class PolarisSkeletonThumbnailComponent extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * Size of the thumbnail
    *

--- a/addon/components/polaris-stack.js
+++ b/addon/components/polaris-stack.js
@@ -3,10 +3,10 @@ import { computed, action } from '@ember/object';
 import { equal } from '@ember/object/computed';
 import { isBlank } from '@ember/utils';
 import { classify } from '@ember/string';
-import { deprecate } from '@ember/application/deprecations';
 import { layout, tagName } from '@ember-decorators/component';
 import template from '../templates/components/polaris-stack';
 import AutoWrapper from '../-private/auto-wrapper';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 /**
  * Polaris stack component.
@@ -14,7 +14,9 @@ import AutoWrapper from '../-private/auto-wrapper';
  */
 @tagName('')
 @layout(template)
-export default class PolarisStackComponent extends Component {
+export default class PolarisStackComponent extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * Elements to display inside stack
    *
@@ -110,43 +112,30 @@ export default class PolarisStackComponent extends Component {
     'noWrap',
     'class'
   )
-  get classes() {
-    let classNames = ['Polaris-Stack'];
+  get cssClasses() {
+    let cssClasses = ['Polaris-Stack'];
 
     let { spacingClassName, alignmentClassName, distributionClassName } = this;
     if (spacingClassName) {
-      classNames.push(spacingClassName);
+      cssClasses.push(spacingClassName);
     }
     if (alignmentClassName) {
-      classNames.push(alignmentClassName);
+      cssClasses.push(alignmentClassName);
     }
     if (distributionClassName) {
-      classNames.push(distributionClassName);
+      cssClasses.push(distributionClassName);
     }
     if (this.vertical) {
-      classNames.push('Polaris-Stack--vertical');
+      cssClasses.push('Polaris-Stack--vertical');
     }
     if (this.noWrap) {
-      classNames.push('Polaris-Stack--noWrap');
+      cssClasses.push('Polaris-Stack--noWrap');
     }
     if (this.class) {
-      classNames.push(this.class);
+      cssClasses.push(this.class);
     }
 
-    return classNames.join(' ');
-  }
-
-  init() {
-    super.init(...arguments);
-
-    deprecate(
-      `[polaris-stack] Passing 'class' is deprecated! Switch to angle bracket invocation and pass an HTML attribute instead`,
-      !this.class,
-      {
-        id: 'ember-polaris.polaris-stack.class-arg',
-        until: '7.0.0',
-      }
-    );
+    return cssClasses.join(' ');
   }
 
   @action

--- a/addon/components/polaris-stack/item.js
+++ b/addon/components/polaris-stack/item.js
@@ -1,12 +1,14 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { deprecate } from '@ember/application/deprecations';
 import { layout, tagName } from '@ember-decorators/component';
 import template from '../../templates/components/polaris-stack/item';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 @tagName('')
 @layout(template)
-export default class StackItemComponent extends Component {
+export default class StackItemComponent extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * Elements to display inside stack item
    *
@@ -26,28 +28,15 @@ export default class StackItemComponent extends Component {
   fill = false;
 
   @computed('fill', 'class')
-  get classes() {
-    let classNames = ['Polaris-Stack__Item'];
+  get cssClasses() {
+    let cssClasses = ['Polaris-Stack__Item'];
     if (this.fill) {
-      classNames.push('Polaris-Stack__Item--fill');
+      cssClasses.push('Polaris-Stack__Item--fill');
     }
     if (this.class) {
-      classNames.push(this.class);
+      cssClasses.push(this.class);
     }
 
-    return classNames.join(' ');
-  }
-
-  init() {
-    super.init(...arguments);
-
-    deprecate(
-      `[polaris-stack/item] Passing 'class' is deprecated! Switch to angle bracket invocation and pass an HTML attribute instead`,
-      !this.class,
-      {
-        id: 'ember-polaris.polaris-stack-item.class-arg',
-        until: '7.0.0',
-      }
-    );
+    return cssClasses.join(' ');
   }
 }

--- a/addon/components/polaris-sticky.js
+++ b/addon/components/polaris-sticky.js
@@ -5,13 +5,16 @@ import { htmlSafe } from '@ember/string';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import { getRectForNode } from '@shopify/javascript-utilities/geometry';
 import layout from '../templates/components/polaris-sticky';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 /**
  * Undocumented Polaris sticky component.
  */
 @tagName('')
 @templateLayout(layout)
-export default class PolarisSticky extends Component {
+export default class PolarisSticky extends Component.extend(
+  TaglessCssDeprecation
+) {
   @service
   stickyManager;
 

--- a/addon/components/polaris-subheading.js
+++ b/addon/components/polaris-subheading.js
@@ -3,6 +3,7 @@ import { action } from '@ember/object';
 import { deprecate } from '@ember/application/deprecations';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../templates/components/polaris-subheading';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 /**
  * Polaris subheading component.
@@ -20,7 +21,9 @@ import layout from '../templates/components/polaris-subheading';
  */
 @tagName('')
 @templateLayout(layout)
-export default class PolarisSubheadingComponent extends Component {
+export default class PolarisSubheadingComponent extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * The content to display inside the heading
    *

--- a/addon/components/polaris-tag.js
+++ b/addon/components/polaris-tag.js
@@ -3,6 +3,7 @@ import { action, computed } from '@ember/object';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../templates/components/polaris-tag';
 import { handleMouseUpByBlurring } from '../utils/focus';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 /**
  * Polaris tag component.
@@ -12,7 +13,9 @@ import { handleMouseUpByBlurring } from '../utils/focus';
  */
 @tagName('')
 @templateLayout(layout)
-export default class PolarisTag extends Component {
+export default class PolarisTag extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * The content to display inside the tag.
    *

--- a/addon/components/polaris-text-container.js
+++ b/addon/components/polaris-text-container.js
@@ -3,6 +3,7 @@ import { computed } from '@ember/object';
 import { classify } from '@ember/string';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../templates/components/polaris-text-container';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 const allowedSpacings = ['tight', 'loose'];
 
@@ -11,7 +12,9 @@ const allowedSpacings = ['tight', 'loose'];
  */
 @tagName('')
 @templateLayout(layout)
-export default class PolarisTextContainer extends Component {
+export default class PolarisTextContainer extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * The text to display.
    *

--- a/addon/components/polaris-text-field.js
+++ b/addon/components/polaris-text-field.js
@@ -373,43 +373,38 @@ export default class PolarisTextFieldComponent extends Component {
   )
   get textFieldClasses() {
     let { normalizedValue, disabled, readOnly, error, multiline, focus } = this;
-    let classes = ['Polaris-TextField'];
+    let cssClasses = ['Polaris-TextField'];
 
     if (normalizedValue) {
-      classes.push('Polaris-TextField--hasValue');
+      cssClasses.push('Polaris-TextField--hasValue');
     }
-
     if (disabled) {
-      classes.push('Polaris-TextField--disabled');
+      cssClasses.push('Polaris-TextField--disabled');
     }
-
     if (readOnly) {
-      classes.push('Polaris-TextField--readOnly');
+      cssClasses.push('Polaris-TextField--readOnly');
     }
-
     if (error) {
-      classes.push('Polaris-TextField--error');
+      cssClasses.push('Polaris-TextField--error');
     }
-
     if (multiline) {
-      classes.push('Polaris-TextField--multiline');
+      cssClasses.push('Polaris-TextField--multiline');
     }
-
     if (focus) {
-      classes.push('Polaris-TextField--focus');
+      cssClasses.push('Polaris-TextField--focus');
     }
 
-    return classes.join(' ');
+    return cssClasses.join(' ');
   }
 
   @computed('suffix')
   get inputClassName() {
-    let classes = ['Polaris-TextField__Input'];
+    let cssClasses = ['Polaris-TextField__Input'];
     if (this.suffix) {
-      classes.push('Polaris-TextField__Input--suffixed');
+      cssClasses.push('Polaris-TextField__Input--suffixed');
     }
 
-    return classes.join(' ');
+    return cssClasses.join(' ');
   }
 
   @computed('error', 'helpText', 'id')
@@ -490,13 +485,13 @@ export default class PolarisTextFieldComponent extends Component {
 
   @computed('multiline')
   get characterCountClassName() {
-    let classNames = ['Polaris-TextField__CharacterCount'];
+    let cssClasses = ['Polaris-TextField__CharacterCount'];
 
     if (this.multiline) {
-      classNames.push('Polaris-TextField__AlignFieldBottom');
+      cssClasses.push('Polaris-TextField__AlignFieldBottom');
     }
 
-    return classNames.join(' ');
+    return cssClasses.join(' ');
   }
 
   @computed('maxLength', 'characterCount')

--- a/addon/components/polaris-text-field/resizer.js
+++ b/addon/components/polaris-text-field/resizer.js
@@ -3,6 +3,7 @@ import { computed, action } from '@ember/object';
 import { htmlSafe } from '@ember/string';
 import { tagName, layout as templateLayout } from '@ember-decorators/component';
 import layout from '../../templates/components/polaris-text-field/resizer';
+import TaglessCssDeprecation from '../../mixins/tagless-css-deprecation';
 
 const REPLACE_REGEX = /[\n&<>]/g;
 
@@ -19,7 +20,9 @@ function replaceEntity(entity) {
 
 @tagName('')
 @templateLayout(layout)
-export default class PolarisTextFieldResizerComponent extends Component {
+export default class PolarisTextFieldResizerComponent extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * The value of the textarea
    *

--- a/addon/components/polaris-text-style.js
+++ b/addon/components/polaris-text-style.js
@@ -42,7 +42,7 @@ export default class PolarisTextStyle extends Component {
    * Possible values: positive, negative, strong, subdued
    *
    * @type {String}
-   * @default: null
+   * @default null
    * @public
    */
   variation = null;
@@ -55,7 +55,7 @@ export default class PolarisTextStyle extends Component {
    * instead of `text`
    *
    * @type {String}
-   * @default: null
+   * @default null
    * @public
    */
   text = null;
@@ -67,17 +67,11 @@ export default class PolarisTextStyle extends Component {
    */
   classes = '';
 
-  /**
-   * @private
-   */
   @(computed('variation').readOnly())
   get elementTagName() {
     return variationElement(this.variation);
   }
 
-  /**
-   * @private
-   */
   @(computed('variation', 'classes').readOnly())
   get textStyleClasses() {
     let { variation, classes } = this;

--- a/addon/components/polaris-thumbnail.js
+++ b/addon/components/polaris-thumbnail.js
@@ -4,6 +4,7 @@ import { classify } from '@ember/string';
 import { warn } from '@ember/debug';
 import { tagName, layout } from '@ember-decorators/component';
 import template from '../templates/components/polaris-thumbnail';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 const allowedSizes = ['small', 'medium', 'large'];
 const defaultSize = 'medium';
@@ -14,12 +15,14 @@ const defaultSize = 'medium';
  */
 @tagName('')
 @layout(template)
-export default class PolarisThumbnailComponent extends Component {
+export default class PolarisThumbnailComponent extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * Size of thumbnail
    *
    * @type {String}
-   * @default: 'medium'
+   * @default 'medium'
    * @public
    */
   size = defaultSize;
@@ -28,7 +31,7 @@ export default class PolarisThumbnailComponent extends Component {
    * URL for the image
    *
    * @type {String}
-   * @default: null
+   * @default null
    * @public
    */
   source = null;
@@ -37,7 +40,7 @@ export default class PolarisThumbnailComponent extends Component {
    * Alt text for the thumbnail image
    *
    * @type {String}
-   * @default: null
+   * @default null
    * @public
    */
   alt = null;

--- a/addon/components/polaris-unstyled-link.js
+++ b/addon/components/polaris-unstyled-link.js
@@ -3,6 +3,7 @@ import { computed, action } from '@ember/object';
 import { deprecate } from '@ember/application/deprecations';
 import { tagName, layout } from '@ember-decorators/component';
 import template from '../templates/components/polaris-unstyled-link';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 /**
  * Undocumented Polaris UnstyledLink component.
@@ -12,7 +13,9 @@ import template from '../templates/components/polaris-unstyled-link';
  */
 @tagName('')
 @layout(template)
-export default class PolarisUnstyledLinkComponent extends Component {
+export default class PolarisUnstyledLinkComponent extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * Content to display inside the link
    *
@@ -131,14 +134,6 @@ export default class PolarisUnstyledLinkComponent extends Component {
       !this.id,
       {
         id: 'ember-polaris.polaris-unstyled-link.id-arg',
-        until: '7.0.0',
-      }
-    );
-    deprecate(
-      `[polaris-unstyled-link] Passing 'class' is deprecated! Switch to angle bracket invocation and pass an HTML attribute instead`,
-      !this.class,
-      {
-        id: 'ember-polaris.polaris-unstyled-link.class-arg',
         until: '7.0.0',
       }
     );

--- a/addon/components/polaris-visually-hidden.js
+++ b/addon/components/polaris-visually-hidden.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { tagName, layout } from '@ember-decorators/component';
 import template from '../templates/components/polaris-visually-hidden';
+import TaglessCssDeprecation from '../mixins/tagless-css-deprecation';
 
 /**
  * Polaris Visually hidden component.
@@ -8,7 +9,9 @@ import template from '../templates/components/polaris-visually-hidden';
  */
 @tagName('')
 @layout(template)
-export default class PolarisVisuallyHiddenComponent extends Component {
+export default class PolarisVisuallyHiddenComponent extends Component.extend(
+  TaglessCssDeprecation
+) {
   /**
    * The content to be hidden visually
    *
@@ -17,7 +20,7 @@ export default class PolarisVisuallyHiddenComponent extends Component {
    * instead of `text`
    *
    * @type {string}
-   * @default: null
+   * @default null
    * @public
    */
   text = null;

--- a/addon/mixins/tagless-css-deprecation.js
+++ b/addon/mixins/tagless-css-deprecation.js
@@ -1,0 +1,20 @@
+import Mixin from '@ember/object/mixin';
+import { deprecate } from '@ember/application/deprecations';
+import { dasherize } from '@ember/string';
+
+// eslint-disable-next-line ember/no-new-mixins
+export default Mixin.create({
+  init() {
+    this._super(...arguments);
+
+    let componentName = this.constructor?.name;
+    deprecate(
+      `[${componentName}] Passing 'class' argument is deprecated! Switch to angle bracket invocation and pass an HTML attribute instead`,
+      !this.class,
+      {
+        id: `ember-polaris.${dasherize(componentName)}.class-arg`,
+        until: '7.0.0',
+      }
+    );
+  },
+});

--- a/addon/templates/components/polaris-banner.hbs
+++ b/addon/templates/components/polaris-banner.hbs
@@ -1,5 +1,5 @@
 <div
-  class="Polaris-Banner {{this.statusClass}} {{if this.hasDismiss "Polaris-Banner--hasDismiss"}} {{if @withinContentContainer "Polaris-Banner--withinContentContainer" "Polaris-Banner--withinPage"}}"
+  class={{this.cssClasses}}
   tabindex="0"
   aria-live="polite"
   aria-describedby={{this.contentId}}

--- a/addon/templates/components/polaris-button-group.hbs
+++ b/addon/templates/components/polaris-button-group.hbs
@@ -1,5 +1,5 @@
 <div
-  class="Polaris-ButtonGroup {{if @segmented "Polaris-ButtonGroup--segmented"}} {{if @fullWidth "Polaris-ButtonGroup--fullWidth"}} {{if @connectedTop "Polaris-ButtonGroup--connectedTop"}}"
+  class={{this.cssClasses}}
   data-test-button-group
   {{did-insert this.setupAutoWrapper}}
   {{will-destroy this.teardownAutoWrapper}}

--- a/addon/templates/components/polaris-button-group/item.hbs
+++ b/addon/templates/components/polaris-button-group/item.hbs
@@ -1,5 +1,5 @@
 <div
-  class="Polaris-ButtonGroup__Item {{if @plain "Polaris-ButtonGroup__Item--plain"}} {{if this.focused "Polaris-ButtonGroup__Item--focused"}}"
+  class={{this.cssClasses}}
   data-test-button-group-item
   role="button"
   {{on "focus" this.handleFocus}}

--- a/addon/templates/components/polaris-button.hbs
+++ b/addon/templates/components/polaris-button.hbs
@@ -18,7 +18,7 @@
       {{!-- template-lint-disable link-href-attributes --}}
       <a
         id={{this.id}}
-        class={{this.classes}}
+        class={{this.cssClasses}}
         aria-label={{@accessibilityLabel}}
         data-test-id={{@dataTestId}}
         ...attributes
@@ -33,7 +33,7 @@
       </a>
     {{else}}
       <PolarisUnstyledLink
-        class={{this.classes}}
+        class={{this.cssClasses}}
         id={{this.id}}
         @dataTestId={{@dataTestId}}
         @url={{@url}}
@@ -59,7 +59,7 @@
     <button
       id={{this.id}}
       data-test-id={{@dataTestId}}
-      class={{this.classes}}
+      class={{this.cssClasses}}
       disabled={{this.isDisabled}}
       type={{if @submit "submit" "button"}}
       role={{if @loading "alert"}}

--- a/addon/templates/components/polaris-callout-card.hbs
+++ b/addon/templates/components/polaris-callout-card.hbs
@@ -1,4 +1,4 @@
-<div class="Polaris-Card" ...attributes>
+<div class="Polaris-Card {{@class}}" ...attributes>
   <div class="Polaris-CalloutCard__Container">
     {{#if @onDismiss}}
       <div class="Polaris-CalloutCard__Dismiss">

--- a/addon/templates/components/polaris-caption.hbs
+++ b/addon/templates/components/polaris-caption.hbs
@@ -1,4 +1,4 @@
-<p class="Polaris-Caption" data-test-caption ...attributes>
+<p class="Polaris-Caption {{@class}}" data-test-caption ...attributes>
   {{#if hasBlock}}
     {{yield}}
   {{else}}

--- a/addon/templates/components/polaris-card.hbs
+++ b/addon/templates/components/polaris-card.hbs
@@ -1,5 +1,5 @@
 <div
-  class="Polaris-Card {{if @subdued "Polaris-Card--subdued"}}"
+  class="Polaris-Card {{@class}} {{if @subdued "Polaris-Card--subdued"}}"
   ...attributes
 >
   {{#if (or @title @headerActions)}}

--- a/addon/templates/components/polaris-card/section-header.hbs
+++ b/addon/templates/components/polaris-card/section-header.hbs
@@ -1,4 +1,4 @@
-<div class="Polaris-Card__SectionHeader" ...attributes>
+<div class="Polaris-Card__SectionHeader {{@class}}" ...attributes>
   {{#if @title}}
     {{#if (is-component-definition @title)}}
       {{render-content @title}}

--- a/addon/templates/components/polaris-card/section.hbs
+++ b/addon/templates/components/polaris-card/section.hbs
@@ -1,9 +1,4 @@
-<div
-  class="Polaris-Card__Section
-    {{if @subdued "Polaris-Card__Section--subdued"}}
-    {{if @fullWidth "Polaris-Card__Section--fullWidth"}}"
-  ...attributes
->
+<div class={{this.cssClasses}} ...attributes>
   {{#let (component "polaris-card/section-header") as |Header|}}
     {{#if @title}}
       <Header @title={{@title}} />

--- a/addon/templates/components/polaris-choice-list.hbs
+++ b/addon/templates/components/polaris-choice-list.hbs
@@ -2,7 +2,7 @@
   id={{this.finalName}}
   aria-invalid={{this.ariaInvalid}}
   aria-describedby={{this.ariaDescribedBy}}
-  class="Polaris-ChoiceList {{if this.titleHidden "Polaris-ChoiceList--titleHidden"}}"
+  class="Polaris-ChoiceList {{@class}} {{if this.titleHidden "Polaris-ChoiceList--titleHidden"}}"
   data-test-choice-list
   ...attributes
 >

--- a/addon/templates/components/polaris-choice/label.hbs
+++ b/addon/templates/components/polaris-choice/label.hbs
@@ -1,6 +1,6 @@
 <label
   for={{@inputId}}
-  class="Polaris-Choice {{if @labelHidden "Polaris-Choice--labelHidden"}} {{if @disabled "Polaris-Choice--disabled"}}"
+  class={{this.cssClasses}}
   data-test="choice-label"
   ...attributes
 >

--- a/addon/templates/components/polaris-color-picker.hbs
+++ b/addon/templates/components/polaris-color-picker.hbs
@@ -1,5 +1,5 @@
 <div
-  class="Polaris-ColorPicker"
+  class="Polaris-ColorPicker {{@class}}"
   {{did-insert this.setPickerSize}}
   ...attributes
 >

--- a/addon/templates/components/polaris-color-picker/alpha-picker.hbs
+++ b/addon/templates/components/polaris-color-picker/alpha-picker.hbs
@@ -1,5 +1,5 @@
 <div
-  class="Polaris-ColorPicker__AlphaPicker"
+  class="Polaris-ColorPicker__AlphaPicker {{@class}}"
   {{did-insert this.setSliderHeight}}
 >
   <div class="Polaris-ColorPicker__ColorLayer" style={{this.colorLayerStyle}} />

--- a/addon/templates/components/polaris-color-picker/hue-picker.hbs
+++ b/addon/templates/components/polaris-color-picker/hue-picker.hbs
@@ -1,5 +1,5 @@
 <div
-  class="Polaris-ColorPicker__HuePicker"
+  class="Polaris-ColorPicker__HuePicker {{@class}}"
   {{did-insert this.setSliderHeight}}
 >
   <PolarisColorPicker::Slidable

--- a/addon/templates/components/polaris-color-picker/slidable.hbs
+++ b/addon/templates/components/polaris-color-picker/slidable.hbs
@@ -1,6 +1,6 @@
 {{!-- template-lint-disable no-invalid-interactive --}}
 <div
-  class="Polaris-ColorPicker__Slidable"
+  class="Polaris-ColorPicker__Slidable {{@class}}"
   {{on "mousedown" this.startDrag}}
   {{on "touchstart" this.startDrag}}
   {{did-insert this.setElementAndTriggerHeightChanged}}

--- a/addon/templates/components/polaris-connected/item.hbs
+++ b/addon/templates/components/polaris-connected/item.hbs
@@ -1,6 +1,6 @@
 {{!-- template-lint-disable no-invalid-interactive --}}
 <div
-  class={{this.classes}}
+  class={{this.cssClasses}}
   ...attributes
   {{on "focus" this.handleFocus}}
   {{on "blur" this.handleBlur}}

--- a/addon/templates/components/polaris-data-table.hbs
+++ b/addon/templates/components/polaris-data-table.hbs
@@ -1,5 +1,5 @@
 <div
-  class={{if this.collapsed "Polaris-DataTable--collapsed"}}
+  class="{{if this.collapsed "Polaris-DataTable--collapsed"}} {{@class}}"
   {{did-insert this.insertDataTable}}
   {{did-update this.updateDataTable @footerContent @truncate}}
   ...attributes

--- a/addon/templates/components/polaris-data-table/navigation.hbs
+++ b/addon/templates/components/polaris-data-table/navigation.hbs
@@ -1,4 +1,4 @@
-<div class="Polaris-DataTable__Navigation" ...attributes>
+<div class="Polaris-DataTable__Navigation {{@class}}" ...attributes>
   <PolarisButton
     @plain={{true}}
     @icon="chevron-left"

--- a/addon/templates/components/polaris-data-table/row.hbs
+++ b/addon/templates/components/polaris-data-table/row.hbs
@@ -1,4 +1,4 @@
-<tr class="Polaris-DataTable__TableRow" data-test-data-table-row="true" ...attributes>
+<tr class="Polaris-DataTable__TableRow {{@class}}" data-test-data-table-row="true" ...attributes>
   {{#each @row as |cellText cellIndex|}}
     <PolarisDataTable::Cell
       @height={{get this.bodyCellHeights index}}

--- a/addon/templates/components/polaris-date-picker.hbs
+++ b/addon/templates/components/polaris-date-picker.hbs
@@ -1,6 +1,6 @@
 {{!-- template-lint-disable no-invalid-interactive --}}
 <div
-  class="Polaris-DatePicker"
+  class="Polaris-DatePicker {{@class}}"
   data-test-date-picker
   ...attributes
   {{did-update this.handleSelectedUpdate @selected}}

--- a/addon/templates/components/polaris-date-picker/month.hbs
+++ b/addon/templates/components/polaris-date-picker/month.hbs
@@ -1,5 +1,5 @@
 <div
-  class="Polaris-DatePicker__Month"
+  class="Polaris-DatePicker__Month {{@class}}"
   role="grid"
   data-test-date-picker-month
   ...attributes

--- a/addon/templates/components/polaris-date-picker/weekday.hbs
+++ b/addon/templates/components/polaris-date-picker/weekday.hbs
@@ -1,5 +1,5 @@
 <div
-  class="Polaris-DatePicker__Weekday {{if @current "Polaris-DatePicker__Weekday--current"}}"
+  class="Polaris-DatePicker__Weekday {{@class}} {{if @current "Polaris-DatePicker__Weekday--current"}}"
   data-test-date-picker-weekday
   ...attributes
   aria-label={{@label}}

--- a/addon/templates/components/polaris-description-list.hbs
+++ b/addon/templates/components/polaris-description-list.hbs
@@ -1,4 +1,4 @@
-<dl class="Polaris-DescriptionList">
+<dl class="Polaris-DescriptionList {{@class}}" ...attributes>
   {{#each @items as |item|}}
     <dt class="Polaris-DescriptionList__Term">
       {{render-content item.term}}

--- a/addon/templates/components/polaris-display-text.hbs
+++ b/addon/templates/components/polaris-display-text.hbs
@@ -1,6 +1,6 @@
 {{#let (element (or @htmlTag @tagName "p")) as |DisplayText|}}
   <DisplayText
-    class="Polaris-DisplayText {{this.sizeClassName}}"
+    class="Polaris-DisplayText {{this.sizeClassName}} {{@class}}"
     data-test-display-text
     ...attributes
   >

--- a/addon/templates/components/polaris-drop-zone/file-upload.hbs
+++ b/addon/templates/components/polaris-drop-zone/file-upload.hbs
@@ -1,4 +1,4 @@
-<div class="Polaris-DropZone-FileUpload">
+<div class="Polaris-DropZone-FileUpload {{@class}}" ...attributes>
   {{#if (eq this.size "small")}}
     <PolarisStack @vertical={{true}} @spacing="tight">
       <PolarisIcon

--- a/addon/templates/components/polaris-empty-state.hbs
+++ b/addon/templates/components/polaris-empty-state.hbs
@@ -1,5 +1,5 @@
 <div
-  class="Polaris-EmptyState {{if @imageContained "Polaris-EmptyState--imageContained"}}"
+  class="Polaris-EmptyState {{@class}} {{if @imageContained "Polaris-EmptyState--imageContained"}}"
   data-test-empty-state
   ...attributes
 >

--- a/addon/templates/components/polaris-empty-state/details.hbs
+++ b/addon/templates/components/polaris-empty-state/details.hbs
@@ -1,6 +1,7 @@
 <div
-  class="Polaris-EmptyState__Details"
+  class="Polaris-EmptyState__Details {{@class}}"
   data-test-empty-state-details
+  ...attributes
 >
   <PolarisTextContainer>
     <PolarisDisplayText data-test-empty-state-heading @size="medium" @text={{@heading}} />

--- a/addon/templates/components/polaris-footer-help.hbs
+++ b/addon/templates/components/polaris-footer-help.hbs
@@ -1,4 +1,4 @@
-<div class="Polaris-FooterHelp" ...attributes>
+<div class="Polaris-FooterHelp {{@class}}" ...attributes>
   <div class="Polaris-FooterHelp__Content">
     <div class="Polaris-FooterHelp__Icon">
       <PolarisIcon @source="help" @color="teal" @backdrop={{true}} />

--- a/addon/templates/components/polaris-form-layout.hbs
+++ b/addon/templates/components/polaris-form-layout.hbs
@@ -1,5 +1,5 @@
 <div
-  class="Polaris-FormLayout"
+  class="Polaris-FormLayout {{@class}}"
   data-test-form-layout
   ...attributes
   {{did-insert this.setupAutoWrapper}}

--- a/addon/templates/components/polaris-form-layout/group.hbs
+++ b/addon/templates/components/polaris-form-layout/group.hbs
@@ -1,5 +1,5 @@
 <div
-  class={{if @condensed "Polaris-FormLayout--condensed" "Polaris-FormLayout--grouped"}}
+  class="{{@class}} {{if @condensed "Polaris-FormLayout--condensed" "Polaris-FormLayout--grouped"}}"
   data-test-form-layout-group
   aria-labelledby={{this.titleID}}
   aria-describedby={{this.helpTextID}}

--- a/addon/templates/components/polaris-form-layout/item.hbs
+++ b/addon/templates/components/polaris-form-layout/item.hbs
@@ -1,5 +1,5 @@
 <div
-  class="Polaris-FormLayout__Item"
+  class="Polaris-FormLayout__Item {{@class}}"
   data-test-form-layout-item
   ...attributes
 >

--- a/addon/templates/components/polaris-form.hbs
+++ b/addon/templates/components/polaris-form.hbs
@@ -1,5 +1,6 @@
 <form
   data-test-form
+  class={{@class}}
   ...attributes
   acceptCharset={{@acceptCharset}}
   action={{@action}}

--- a/addon/templates/components/polaris-heading.hbs
+++ b/addon/templates/components/polaris-heading.hbs
@@ -1,6 +1,6 @@
 {{#let (element (or @htmlTag @tagName "h2")) as |Heading|}}
   <Heading
-    class="Polaris-Heading"
+    class="Polaris-Heading {{@class}}"
     data-test-polaris-heading
     ...attributes
   >

--- a/addon/templates/components/polaris-icon.hbs
+++ b/addon/templates/components/polaris-icon.hbs
@@ -1,5 +1,5 @@
 <span
-  class={{this.classes}}
+  class={{this.cssClasses}}
   data-test-icon
   ...attributes
   aria-label={{@accessibilityLabel}}

--- a/addon/templates/components/polaris-layout.hbs
+++ b/addon/templates/components/polaris-layout.hbs
@@ -1,4 +1,4 @@
-<div class="Polaris-Layout" ...attributes>
+<div class="Polaris-Layout {{@class}}" ...attributes>
   {{#if this.sectioned}}
     <PolarisLayout::Section>
       {{#if hasBlock}}

--- a/addon/templates/components/polaris-layout/annotated-section.hbs
+++ b/addon/templates/components/polaris-layout/annotated-section.hbs
@@ -1,4 +1,4 @@
-<div class="Polaris-Layout__AnnotatedSection" ...attributes>
+<div class="Polaris-Layout__AnnotatedSection {{@class}}" ...attributes>
   <div class="Polaris-Layout__AnnotationWrapper">
     <PolarisLayout::Annotation @title={{@title}} @description={{@description}} />
 

--- a/addon/templates/components/polaris-layout/annotation-content.hbs
+++ b/addon/templates/components/polaris-layout/annotation-content.hbs
@@ -1,4 +1,4 @@
-<div class="Polaris-Layout__AnnotationContent" ...attributes>
+<div class="Polaris-Layout__AnnotationContent {{@class}}" ...attributes>
   {{#if hasBlock}}
     {{yield}}
   {{else}}

--- a/addon/templates/components/polaris-layout/annotation.hbs
+++ b/addon/templates/components/polaris-layout/annotation.hbs
@@ -1,4 +1,4 @@
-<div class="Polaris-Layout__Annotation" ...attributes>
+<div class="Polaris-Layout__Annotation {{@class}}" ...attributes>
   <PolarisTextContainer>
     <PolarisHeading @text={{@title}} />
 

--- a/addon/templates/components/polaris-layout/section.hbs
+++ b/addon/templates/components/polaris-layout/section.hbs
@@ -1,4 +1,4 @@
-<div class={{this.classes}} ...attributes>
+<div class={{this.cssClasses}} ...attributes>
   {{#if hasBlock}}
     {{yield}}
   {{else}}

--- a/addon/templates/components/polaris-list/item.hbs
+++ b/addon/templates/components/polaris-list/item.hbs
@@ -1,7 +1,7 @@
-<li class="Polaris-List__Item" ...attributes>
+<li class="Polaris-List__Item {{@class}}" ...attributes>
   {{#if hasBlock}}
     {{yield}}
   {{else}}
-    {{text}}
+    {{@text}}
   {{/if}}
 </li>

--- a/addon/templates/components/polaris-option-list.hbs
+++ b/addon/templates/components/polaris-option-list.hbs
@@ -1,4 +1,4 @@
-<ul role={{@role}} class="Polaris-OptionList" ...attributes>
+<ul role={{@role}} class="Polaris-OptionList {{@class}}" ...attributes>
   {{#each this.normalizedOptions as |normalizedOption sectionIndex|}}
     <li>
       {{#if normalizedOption.title}}

--- a/addon/templates/components/polaris-option-list/checkbox.hbs
+++ b/addon/templates/components/polaris-option-list/checkbox.hbs
@@ -1,4 +1,7 @@
-<div class="Polaris-OptionList-Checkbox {{if @active "Polaris-OptionList-Checkbox--active"}}" ...attributes>
+<div
+  class="Polaris-OptionList-Checkbox {{@class}} {{if @active "Polaris-OptionList-Checkbox--active"}}"
+  ...attributes
+>
   <input
     id={{or @checkboxId this.checkboxId}}
     name={{@name}}

--- a/addon/templates/components/polaris-option-list/option.hbs
+++ b/addon/templates/components/polaris-option-list/option.hbs
@@ -2,7 +2,7 @@
   tabIndex={{this.tabIndex}}
   aria-selected={{@active}}
   role={{@role}}
-  class="Polaris-OptionList-Option"
+  class="Polaris-OptionList-Option {{@class}}"
   ...attributes
 >
   {{!-- TODO: add Scrollable.ScrollTo here when available --}}

--- a/addon/templates/components/polaris-page-actions.hbs
+++ b/addon/templates/components/polaris-page-actions.hbs
@@ -1,4 +1,4 @@
-<div class="Polaris-PageActions" ...attributes>
+<div class="Polaris-PageActions {{@class}}" ...attributes>
   <PolarisStack
     @spacing="tight"
     @distribution={{if this.showSecondaryActions "equalSpacing" "trailing"}}

--- a/addon/templates/components/polaris-page.hbs
+++ b/addon/templates/components/polaris-page.hbs
@@ -1,7 +1,4 @@
-<div
-  class={{this.classes}}
-  ...attributes
->
+<div class={{this.cssClasses}} ...attributes>
   {{#if this.hasHeaderContent}}
     <PolarisPage::Header
       @title={{@title}}

--- a/addon/templates/components/polaris-page/action-icon.hbs
+++ b/addon/templates/components/polaris-page/action-icon.hbs
@@ -1,3 +1,3 @@
-<span class="Polaris-Header-Action__ActionIcon">
+<span class="Polaris-Header-Action__ActionIcon {{@class}}" ...attributes>
   <PolarisIcon @source={{@icon}} />
 </span>

--- a/addon/templates/components/polaris-page/action.hbs
+++ b/addon/templates/components/polaris-page/action.hbs
@@ -1,11 +1,12 @@
 {{! TODO: support url }}
 <button
   type="button"
-  class={{this.classes}}
+  class={{this.cssClasses}}
   aria-label={{@accessibilityLabel}}
   disabled={{@disabled}}
   {{on "click" (stop-propagation this.handleClick)}}
   {{on "mouseup" this.handleMouseUpByBlurring}}
+  ...attributes
 >
   {{#if (or @icon @disclosure)}}
     <span class="Polaris-Header-Action__ActionContent">

--- a/addon/templates/components/polaris-page/header.hbs
+++ b/addon/templates/components/polaris-page/header.hbs
@@ -1,4 +1,4 @@
-<div class={{this.classes}}>
+<div class={{this.cssClasses}} ...attributes>
   {{#let
     (component
       "polaris-page/header/rollup"

--- a/addon/templates/components/polaris-page/header/action-group.hbs
+++ b/addon/templates/components/polaris-page/header/action-group.hbs
@@ -1,4 +1,4 @@
-<div class="Polaris-Header-ActionGroup">
+<div class="Polaris-Header-ActionGroup {{@class}}" ...attributes>
   <PolarisPopover as |popover|>
     <popover.activator>
       <PolarisPage::Action

--- a/addon/templates/components/polaris-pagination.hbs
+++ b/addon/templates/components/polaris-pagination.hbs
@@ -1,6 +1,6 @@
 <nav
   aria-label={{this.accessibilityLabel}}
-  class="Polaris-Pagination {{if @plain "Polaris-Pagination--plain"}}"
+  class="Polaris-Pagination {{@class}} {{if @plain "Polaris-Pagination--plain"}}"
   ...attributes
 >
   <button

--- a/addon/templates/components/polaris-progress-bar.hbs
+++ b/addon/templates/components/polaris-progress-bar.hbs
@@ -1,4 +1,8 @@
-<div data-test-progress-bar class="Polaris-ProgressBar {{this.sizeClass}}" ...attributes>
+<div
+  data-test-progress-bar
+  class="Polaris-ProgressBar {{@class}} {{this.sizeClass}}"
+  ...attributes
+>
   <progress
     data-test-progress-bar-progress
     class="Polaris-ProgressBar__Progress"

--- a/addon/templates/components/polaris-resource-list/bulk-actions.hbs
+++ b/addon/templates/components/polaris-resource-list/bulk-actions.hbs
@@ -1,13 +1,8 @@
 <div
   data-test-bulk-actions="true"
-  class="Polaris-ResourceList-BulkActions__Group
-    Polaris-ResourceList-BulkActions__Group--smallScreen
-    {{if @selectMode
-      "Polaris-ResourceList-BulkActions__Group--entered"
-      "Polaris-ResourceList-BulkActions__Group--exited"
-    }}
-  "
+  class={{this.cssClasses}}
   {{did-insert this.insertBulkActions}}
+  ...attributes
 >
   <div class="Polaris-ResourceList-BulkActions__ButtonGroup">
     <PolarisResourceList::CheckableButton

--- a/addon/templates/components/polaris-resource-list/checkable-button.hbs
+++ b/addon/templates/components/polaris-resource-list/checkable-button.hbs
@@ -1,6 +1,6 @@
 {{!-- template-lint-disable no-invalid-interactive --}}
 <div
-  class={{this.classes}}
+  class={{this.cssClasses}}
   {{on "click" this.toggleAll}}
   ...attributes
 >

--- a/addon/templates/components/polaris-resource-list/item.hbs
+++ b/addon/templates/components/polaris-resource-list/item.hbs
@@ -2,14 +2,7 @@
 <div
   data-test-id="item-wrapper"
   data-href={{@url}}
-  class="Polaris-ResourceList-Item
-    {{if this.focused "Polaris-ResourceList-Item--focused"}}
-    {{if this.selectable "Polaris-ResourceList-Item--selectable"}}
-    {{if this.selected "Polaris-ResourceList-Item--selected"}}
-    {{if this.selectMode "Polaris-ResourceList-Item--selectMode"}}
-    {{if @persistActions "Polaris-ResourceList-Item--persistActions"}}
-    {{if this.focusedInner "Polaris-ResourceList-Item--focusedInner"}}
-  "
+  class={{this.cssClasses}}
   {{on "click" this.handleClick}}
   {{on "focusin" this.handleFocus}}
   {{on "focusout" this.handleBlur}}

--- a/addon/templates/components/polaris-skeleton-body-text.hbs
+++ b/addon/templates/components/polaris-skeleton-body-text.hbs
@@ -1,4 +1,4 @@
-<div class="Polaris-SkeletonBodyText__SkeletonBodyTextContainer" ...attributes>
+<div class="Polaris-SkeletonBodyText__SkeletonBodyTextContainer {{@class}} " ...attributes>
   {{#each this.dummyLines}}
     <div class="Polaris-SkeletonBodyText"></div>
   {{/each}}

--- a/addon/templates/components/polaris-skeleton-display-text.hbs
+++ b/addon/templates/components/polaris-skeleton-display-text.hbs
@@ -1,5 +1,5 @@
 <div
-  class="Polaris-SkeletonDisplayText__DisplayText {{this.sizeClass}}"
+  class="Polaris-SkeletonDisplayText__DisplayText {{@class}} {{this.sizeClass}}"
   ...attributes
 >
 </div>

--- a/addon/templates/components/polaris-skeleton-page.hbs
+++ b/addon/templates/components/polaris-skeleton-page.hbs
@@ -1,5 +1,5 @@
 <div
-  class={{this.classes}}
+  class={{this.cssClasses}}
   aria-label={{this.ariaLabel}}
   role={{this.role}}
   data-test-skeleton-page

--- a/addon/templates/components/polaris-skeleton-page/action.hbs
+++ b/addon/templates/components/polaris-skeleton-page/action.hbs
@@ -1,4 +1,4 @@
-<div class="Polaris-SkeletonPage__Action" style={{this.style}} ...attributes>
+<div class="Polaris-SkeletonPage__Action {{@class}}" style={{this.style}} ...attributes>
   <PolarisSkeletonBodyText
     @lines={{1}}
     data-test-skeleton-page-action-text={{true}}

--- a/addon/templates/components/polaris-skeleton-thumbnail.hbs
+++ b/addon/templates/components/polaris-skeleton-thumbnail.hbs
@@ -1,1 +1,1 @@
-<div class="Polaris-SkeletonThumbnail {{this.sizeClass}}" ...attributes></div>
+<div class="Polaris-SkeletonThumbnail {{@class}} {{this.sizeClass}}" ...attributes></div>

--- a/addon/templates/components/polaris-stack.hbs
+++ b/addon/templates/components/polaris-stack.hbs
@@ -1,6 +1,6 @@
 <div
   data-test-stack={{true}}
-  class={{this.classes}}
+  class={{this.cssClasses}}
   {{did-insert this.setupAutoWrapper}}
   {{will-destroy this.teardownAutoWrapper}}
   ...attributes

--- a/addon/templates/components/polaris-stack/item.hbs
+++ b/addon/templates/components/polaris-stack/item.hbs
@@ -1,6 +1,6 @@
 <div
   data-test-stack-item={{true}}
-  class={{this.classes}}
+  class={{this.cssClasses}}
   ...attributes
 >
   {{#if hasBlock}}

--- a/addon/templates/components/polaris-sticky.hbs
+++ b/addon/templates/components/polaris-sticky.hbs
@@ -1,4 +1,4 @@
-<div ...attributes {{did-insert this.registerStickyItem}}>
+<div class={{@class}} ...attributes {{did-insert this.registerStickyItem}}>
   <div {{did-insert this.setPlaceHolderNode}}></div>
   <div {{did-insert this.setStickyNode}} style={{this.style}}>
     {{yield (hash

--- a/addon/templates/components/polaris-subheading.hbs
+++ b/addon/templates/components/polaris-subheading.hbs
@@ -1,6 +1,6 @@
 {{#let (element (or @htmlTag @tagName "h3")) as |Subheading|}}
   <Subheading
-    class="Polaris-Subheading"
+    class="Polaris-Subheading {{@class}}"
     aria-label={{this.ariaLabel}}
     {{did-insert this.setAriaLabel}}
     ...attributes

--- a/addon/templates/components/polaris-tag.hbs
+++ b/addon/templates/components/polaris-tag.hbs
@@ -1,5 +1,5 @@
 <span
-  class="Polaris-Tag {{if @disabled "Polaris-Tag--disabled"}}"
+  class="Polaris-Tag {{@class}} {{if @disabled "Polaris-Tag--disabled"}}"
   data-test-tag={{true}}
   ...attributes
   {{did-insert this.setTagText}}

--- a/addon/templates/components/polaris-text-container.hbs
+++ b/addon/templates/components/polaris-text-container.hbs
@@ -1,4 +1,4 @@
-<div class="Polaris-TextContainer {{this.spacingClass}}" ...attributes>
+<div class="Polaris-TextContainer {{@class}} {{this.spacingClass}}" ...attributes>
   {{#if hasBlock}}
     {{yield}}
   {{else}}

--- a/addon/templates/components/polaris-text-field/resizer.hbs
+++ b/addon/templates/components/polaris-text-field/resizer.hbs
@@ -7,7 +7,7 @@
 --}}
 {{!-- template-lint-disable no-invalid-interactive --}}
 <div
-  class="Polaris-TextField__Resizer"
+  class="Polaris-TextField__Resizer {{@class}}"
   aria-hidden="true"
   data-test-text-field-resizer
   ...attributes

--- a/addon/templates/components/polaris-thumbnail.hbs
+++ b/addon/templates/components/polaris-thumbnail.hbs
@@ -1,4 +1,4 @@
-<span class="Polaris-Thumbnail {{this.sizeClass}}" ...attributes>
+<span class="Polaris-Thumbnail {{@class}} {{this.sizeClass}}" ...attributes>
   <img
     class="Polaris-Thumbnail__Image"
     src={{@source}}

--- a/addon/templates/components/polaris-visually-hidden.hbs
+++ b/addon/templates/components/polaris-visually-hidden.hbs
@@ -1,4 +1,4 @@
-<span class="Polaris-VisuallyHidden" ...attributes>
+<span class="Polaris-VisuallyHidden {{@class}}" ...attributes>
   {{#if hasBlock}}
     {{yield}}
   {{else}}


### PR DESCRIPTION
Adds backwards compatibiltiy to using `class` as an argument for curly brackets
syntax invocation to all the components that were previously non-tagless.
Also adds deprecation to all of these.