### PR TITLE
Fix PolarisButton click propagation

### DIFF
--- a/addon/templates/components/polaris-button.hbs
+++ b/addon/templates/components/polaris-button.hbs
@@ -68,7 +68,7 @@
       aria-controls={{@ariaControls}}
       aria-expanded={{if @ariaExpanded "true"}}
       aria-pressed={{if @ariaPressed "true"}}
-      {{on "click" (stop-propagation this.handleClick)}}
+      {{on "click" this.handleClick}}
       {{on "focus" this.onFocus}}
       {{on "blur" this.onBlur}}
       {{on "keydown" this.onKeyDown}}

--- a/tests/integration/components/polaris-button-test.js
+++ b/tests/integration/components/polaris-button-test.js
@@ -234,8 +234,7 @@ module('Integration | Component | polaris-button', function(hooks) {
 
     module('onClick()', function() {
       test('is called when the button is clicked', async function(assert) {
-        this.handleWrapperClick = () =>
-          assert.notOk(true, "click event doesn't bubble");
+        this.handleWrapperClick = () => assert.ok(true, 'click event bubbles');
         this.handleClick = (event) => {
           assert.ok(true, 'triggers @onClick handler');
           assert.notOk(event, 'does not curry click event to @onClick');


### PR DESCRIPTION
This fixes the issue we've been seeing in our testing with the DropZone
click handling not working correctly.