### PR TITLE
Fix yielded section in sectioned card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+
+## [v6.0.0](https://github.com/smile-io/ember-polaris/tree/v6.0.0)
+
+[Full Changelog](https://github.com/smile-io/ember-polaris/compare/v6.0.0-beta.0...v6.0.0)
+
+:bug: Bugfixes
+
+- Fix yielded `section` on sectioned `PolarisCard` [\#642](https://github.com/smile-io/ember-polaris/pull/642) ([andrewpye](https://github.com/andrewpye))
+
+
+
 ## [v6.0.0-beta.0](https://github.com/smile-io/ember-polaris/tree/v6.0.0-beta.0)
 
 [Full Changelog](https://github.com/smile-io/ember-polaris/compare/v5.2.1...v6.0.0-beta.0)

--- a/addon/templates/components/polaris-card.hbs
+++ b/addon/templates/components/polaris-card.hbs
@@ -44,7 +44,7 @@
     {{#if @sectioned}}
       <Section>
         {{#if hasBlock}}
-          {{yield (hash section=section)}}
+          {{yield (hash section=Section Section=Section)}}
         {{else}}
           {{text}}
         {{/if}}


### PR DESCRIPTION
Found this morning that when using a `PolarisCard` with `@sectioned={{true}}` in block mode, the yielded hash looks like `{section: undefined}` 😬 This change makes sure `section` is populated correctly, and also adds a `Section` property as a parallel to the yielded hash when `PolarisCard` is used without `@sectioned={{true}}`.