### PR TITLE
Pass rows attribute to did-update modifier in PolarisDataTable

### DIFF
--- a/addon/components/polaris-data-table.js
+++ b/addon/components/polaris-data-table.js
@@ -349,11 +349,11 @@ export default class PolarisDataTable extends Component.extend(
     this.addEventHandlers();
   }
 
-  // footerContent and truncate are passed in via template
+  // footerContent, truncate, and rows are passed in via template
   // in order to re-trigger the `did-update` modifier to run
   // when these attributes change.
   @action
-  updateDataTable(/**footerContent, truncate */) {
+  updateDataTable(/**footerContent, truncate, rows */) {
     if (isEqual(this.get('oldAttrs'), this.get('attrs'))) {
       return;
     }

--- a/addon/templates/components/polaris-data-table.hbs
+++ b/addon/templates/components/polaris-data-table.hbs
@@ -1,7 +1,7 @@
 <div
   class="{{if this.collapsed "Polaris-DataTable--collapsed"}} {{@class}}"
   {{did-insert this.insertDataTable}}
-  {{did-update this.updateDataTable @footerContent @truncate}}
+  {{did-update this.updateDataTable @footerContent @truncate @rows}}
   ...attributes
 >
   <PolarisDataTable::Navigation


### PR DESCRIPTION
Cell heights aren't getting recalculated once the `cellText` (which comes from `@rows` data) gets rendered inside the cell, so its resulting in broken cells where they're are all the initial default height regardless of how much content is rendered inside of them.