### PR TITLE
Use ember-cli-htmlbars in tests

### DIFF
--- a/tests/integration/components/key-event-listener-test.js
+++ b/tests/integration/components/key-event-listener-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import {
   initialize,
   triggerKeyDown,

--- a/tests/integration/components/polaris-action-list-test.js
+++ b/tests/integration/components/polaris-action-list-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { findAll, click, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 import MockSvgJarComponent from '../../mocks/components/svg-jar';
 

--- a/tests/integration/components/polaris-avatar-test.js
+++ b/tests/integration/components/polaris-avatar-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, triggerEvent } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | polaris-avatar', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/polaris-badge-test.js
+++ b/tests/integration/components/polaris-badge-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, find } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
 module('Integration | Component | polaris badge', function (hooks) {

--- a/tests/integration/components/polaris-banner-test.js
+++ b/tests/integration/components/polaris-banner-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { click, render } from '@ember/test-helpers';
 import { setupRenderingTest } from 'ember-qunit';
-import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
 import MockSvgJarComponent from '../../mocks/components/svg-jar';
 

--- a/tests/integration/components/polaris-breadcrumbs-test.js
+++ b/tests/integration/components/polaris-breadcrumbs-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 const content = 'Content value';
 

--- a/tests/integration/components/polaris-button-group-test.js
+++ b/tests/integration/components/polaris-button-group-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { findAll, render, triggerEvent } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
 const buttonGroupSelector = '[data-test-button-group]';

--- a/tests/integration/components/polaris-button-test.js
+++ b/tests/integration/components/polaris-button-test.js
@@ -1,3 +1,4 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import {
@@ -7,7 +8,6 @@ import {
   blur,
   triggerKeyEvent,
 } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import MockSvgJarComponent from '../../mocks/components/svg-jar';
 
 module('Integration | Component | polaris-button', function (hooks) {

--- a/tests/integration/components/polaris-callout-card-test.js
+++ b/tests/integration/components/polaris-callout-card-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { click, findAll, render } from '@ember/test-helpers';
 import { setupRenderingTest } from 'ember-qunit';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
 module('Integration | Component | polaris callout card', function (hooks) {

--- a/tests/integration/components/polaris-caption-test.js
+++ b/tests/integration/components/polaris-caption-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { render } from '@ember/test-helpers';
 import { setupRenderingTest } from 'ember-qunit';
-import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | polaris caption', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/polaris-card-test.js
+++ b/tests/integration/components/polaris-card-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, findAll, click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
 module('Integration | Component | polaris card', function (hooks) {

--- a/tests/integration/components/polaris-checkbox-test.js
+++ b/tests/integration/components/polaris-checkbox-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, click, focus, blur, find } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | polaris-checkbox', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/polaris-choice-list-test.js
+++ b/tests/integration/components/polaris-choice-list-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, findAll, click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 import MockSvgJarComponent from '../../mocks/components/svg-jar';
 import Component from '@ember/component';

--- a/tests/integration/components/polaris-choice-test.js
+++ b/tests/integration/components/polaris-choice-test.js
@@ -1,8 +1,8 @@
+import { hbs } from 'ember-cli-htmlbars';
 import Component from '@ember/component';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 import MockSvgJarComponent from '../../mocks/components/svg-jar';
 

--- a/tests/integration/components/polaris-color-picker-test.js
+++ b/tests/integration/components/polaris-color-picker-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, skip, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, find, findAll, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
 module('Integration | Component | polaris color picker', function (hooks) {

--- a/tests/integration/components/polaris-connected-test.js
+++ b/tests/integration/components/polaris-connected-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
 const leftContent = 'left content';

--- a/tests/integration/components/polaris-data-table-test.js
+++ b/tests/integration/components/polaris-data-table-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, findAll, find } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 const sortable = [false, true, false, false, true, false];
 const columnContentTypes = ['text', 'numeric', 'numeric', 'numeric', 'numeric'];

--- a/tests/integration/components/polaris-date-picker-test.js
+++ b/tests/integration/components/polaris-date-picker-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 import MockSvgJarComponent from '../../mocks/components/svg-jar';
 

--- a/tests/integration/components/polaris-description-list-test.js
+++ b/tests/integration/components/polaris-description-list-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 import Component from '@ember/component';
 

--- a/tests/integration/components/polaris-display-text-test.js
+++ b/tests/integration/components/polaris-display-text-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | polaris display text', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/polaris-drop-zone-test.js
+++ b/tests/integration/components/polaris-drop-zone-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, triggerEvent, settled } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import { capitalize, htmlSafe } from '@ember/string';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 import MockSvgJarComponent from '../../mocks/components/svg-jar';

--- a/tests/integration/components/polaris-empty-search-result-test.js
+++ b/tests/integration/components/polaris-empty-search-result-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 const titleSelector = '.Polaris-DisplayText';
 const descriptionSelector = '.Polaris-TextStyle--variationSubdued';

--- a/tests/integration/components/polaris-empty-state-test.js
+++ b/tests/integration/components/polaris-empty-state-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
 module('Integration | Component | polaris empty state', function (hooks) {

--- a/tests/integration/components/polaris-footer-help-test.js
+++ b/tests/integration/components/polaris-footer-help-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 import MockSvgJarComponent from '../../mocks/components/svg-jar';
 

--- a/tests/integration/components/polaris-form-layout-test.js
+++ b/tests/integration/components/polaris-form-layout-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
 module('Integration | Component | polaris form layout', function (hooks) {

--- a/tests/integration/components/polaris-form-test.js
+++ b/tests/integration/components/polaris-form-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, triggerEvent } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 const name = 'form-name';
 const noValidate = true;

--- a/tests/integration/components/polaris-heading-test.js
+++ b/tests/integration/components/polaris-heading-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 const headingSelector = '[data-test-polaris-heading]';
 

--- a/tests/integration/components/polaris-icon-test.js
+++ b/tests/integration/components/polaris-icon-test.js
@@ -1,8 +1,8 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { classify } from '@ember/string';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 import MockSvgJarComponent from '../../mocks/components/svg-jar';
 

--- a/tests/integration/components/polaris-inline-error-test.js
+++ b/tests/integration/components/polaris-inline-error-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | polaris-inline-error', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/polaris-label-test.js
+++ b/tests/integration/components/polaris-label-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | polaris-label', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/polaris-labelled-test.js
+++ b/tests/integration/components/polaris-labelled-test.js
@@ -1,8 +1,8 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, click } from '@ember/test-helpers';
 import Component from '@ember/component';
-import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | polaris-labelled', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/polaris-layout-test.js
+++ b/tests/integration/components/polaris-layout-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { findAll, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
 const layoutSelector = 'div.Polaris-Layout';

--- a/tests/integration/components/polaris-link-test.js
+++ b/tests/integration/components/polaris-link-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | polaris link', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/polaris-list-test.js
+++ b/tests/integration/components/polaris-list-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { findAll, find, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
 module('Integration | Component | polaris list', function (hooks) {

--- a/tests/integration/components/polaris-option-list-test.js
+++ b/tests/integration/components/polaris-option-list-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, click, triggerEvent } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 const defaultProps = {
   id: 'recommended-products',

--- a/tests/integration/components/polaris-option-list/checkbox-test.js
+++ b/tests/integration/components/polaris-option-list/checkbox-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, triggerEvent } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 const defaultProps = {
   checked: true,

--- a/tests/integration/components/polaris-option-list/option-test.js
+++ b/tests/integration/components/polaris-option-list/option-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, click, triggerEvent } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 const defaultProps = {
   id: 'itemId',

--- a/tests/integration/components/polaris-page-actions-test.js
+++ b/tests/integration/components/polaris-page-actions-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { click, find, findAll, render } from '@ember/test-helpers';
 import { setupRenderingTest } from 'ember-qunit';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 import MockSvgJarComponent from '../../mocks/components/svg-jar';
 

--- a/tests/integration/components/polaris-page-test.js
+++ b/tests/integration/components/polaris-page-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, findAll, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 import stubRouting from '../../helpers/stub-routing';
 import MockSvgJarComponent from '../../mocks/components/svg-jar';

--- a/tests/integration/components/polaris-pagination-test.js
+++ b/tests/integration/components/polaris-pagination-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import { initialize } from 'ember-keyboard';
 import { keyUp } from 'ember-keyboard/test-support/test-helpers';
 import MockSvgJarComponent from '../../mocks/components/svg-jar';

--- a/tests/integration/components/polaris-popover-test.js
+++ b/tests/integration/components/polaris-popover-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { findAll, click, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
 module('Integration | Component | polaris popover', function (hooks) {

--- a/tests/integration/components/polaris-progress-bar-test.js
+++ b/tests/integration/components/polaris-progress-bar-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
 module('Integration | Component | polaris progress bar', function (hooks) {

--- a/tests/integration/components/polaris-radio-button-test.js
+++ b/tests/integration/components/polaris-radio-button-test.js
@@ -1,8 +1,8 @@
+import { hbs } from 'ember-cli-htmlbars';
 import Component from '@ember/component';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { focus, click, blur, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import MockSvgJarComponent from '../../mocks/components/svg-jar';
 
 // Mock the polaris-choice component to simplify testing what gets rendered.

--- a/tests/integration/components/polaris-range-slider-test.js
+++ b/tests/integration/components/polaris-range-slider-test.js
@@ -1,8 +1,8 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, find, triggerEvent, fillIn } from '@ember/test-helpers';
 import Component from '@ember/component';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
 module('Integration | Component | polaris-range-slider', function (hooks) {

--- a/tests/integration/components/polaris-resource-list-test.js
+++ b/tests/integration/components/polaris-resource-list-test.js
@@ -1,9 +1,9 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, click, find, triggerEvent } from '@ember/test-helpers';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import hbs from 'htmlbars-inline-precompile';
 import BulkActionsComponent from '@smile-io/ember-polaris/components/polaris-resource-list/bulk-actions';
 import SelectComponent from '@smile-io/ember-polaris/components/polaris-select';
 import { setUpAttributeCaptureOnComponent } from '../../helpers/component-attribute-capture';

--- a/tests/integration/components/polaris-resource-list/bulk-actions-test.js
+++ b/tests/integration/components/polaris-resource-list/bulk-actions-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, findAll, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 const actionsCollection = [
   {

--- a/tests/integration/components/polaris-resource-list/checkable-button-test.js
+++ b/tests/integration/components/polaris-resource-list/checkable-button-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 const label = 'Test-Label';
 const accessibilityLabel = 'Accessibility-Label';

--- a/tests/integration/components/polaris-resource-list/filter-control-test.js
+++ b/tests/integration/components/polaris-resource-list/filter-control-test.js
@@ -1,3 +1,4 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import {
@@ -9,7 +10,6 @@ import {
   focus,
   blur,
 } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import FilterCreatorComponent from '@smile-io/ember-polaris/components/polaris-resource-list/filter-control/filter-creator';
 import { FilterType } from '@smile-io/ember-polaris/components/polaris-resource-list/filter-control/filter-value-selector';
 import { DateFilterOption } from '@smile-io/ember-polaris/components/polaris-resource-list/filter-control/date-selector';

--- a/tests/integration/components/polaris-resource-list/filter-control/date-selector-test.js
+++ b/tests/integration/components/polaris-resource-list/filter-control/date-selector-test.js
@@ -1,3 +1,4 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import {
@@ -9,7 +10,6 @@ import {
   blur,
   waitUntil,
 } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import { DateFilterOption } from '@smile-io/ember-polaris/components/polaris-resource-list/filter-control/date-selector';
 import DatePickerComponent from '@smile-io/ember-polaris/components/polaris-date-picker';
 import { setUpAttributeCaptureOnComponent } from '../../../../helpers/component-attribute-capture';

--- a/tests/integration/components/polaris-resource-list/filter-control/filter-creator-test.js
+++ b/tests/integration/components/polaris-resource-list/filter-control/filter-creator-test.js
@@ -1,3 +1,4 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import {
@@ -7,7 +8,6 @@ import {
   findAll,
   triggerEvent,
 } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import FilterValueSelectorComponent, {
   FilterType,
 } from '@smile-io/ember-polaris/components/polaris-resource-list/filter-control/filter-value-selector';

--- a/tests/integration/components/polaris-resource-list/filter-control/filter-value-selector-test.js
+++ b/tests/integration/components/polaris-resource-list/filter-control/filter-value-selector-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, findAll, find, triggerEvent } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import { FilterType } from '@smile-io/ember-polaris/components/polaris-resource-list/filter-control/filter-value-selector';
 import DateSelectorComponent, {
   DateFilterOption,

--- a/tests/integration/components/polaris-resource-list/item-test.js
+++ b/tests/integration/components/polaris-resource-list/item-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 const mockDefaultContext = {
   selectMode: false,

--- a/tests/integration/components/polaris-select-test.js
+++ b/tests/integration/components/polaris-select-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, find, findAll, triggerEvent } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | polaris-select', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/polaris-setting-toggle-test.js
+++ b/tests/integration/components/polaris-setting-toggle-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
 module('Integration | Component | polaris setting toggle', function (hooks) {

--- a/tests/integration/components/polaris-skeleton-body-text-test.js
+++ b/tests/integration/components/polaris-skeleton-body-text-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
 module('Integration | Component | polaris skeleton body text', function (

--- a/tests/integration/components/polaris-skeleton-display-text-test.js
+++ b/tests/integration/components/polaris-skeleton-display-text-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | polaris skeleton display text', function (
   hooks

--- a/tests/integration/components/polaris-skeleton-page-test.js
+++ b/tests/integration/components/polaris-skeleton-page-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
 module('Integration | Component | polaris skeleton page', function (hooks) {

--- a/tests/integration/components/polaris-skeleton-thumbnail-test.js
+++ b/tests/integration/components/polaris-skeleton-thumbnail-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | polaris skeleton thumbnail', function (
   hooks

--- a/tests/integration/components/polaris-spinner-test.js
+++ b/tests/integration/components/polaris-spinner-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 const spinnerSelector = '[data-test-spinner]';
 

--- a/tests/integration/components/polaris-stack-test.js
+++ b/tests/integration/components/polaris-stack-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { findAll, find, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | polaris stack', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/polaris-sticky-test.js
+++ b/tests/integration/components/polaris-sticky-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | polaris-sticky', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/polaris-subheading-test.js
+++ b/tests/integration/components/polaris-subheading-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | polaris subheading', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/polaris-tag-test.js
+++ b/tests/integration/components/polaris-tag-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 import MockSvgJarComponent from '../../mocks/components/svg-jar';
 

--- a/tests/integration/components/polaris-text-container-test.js
+++ b/tests/integration/components/polaris-text-container-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | polaris text container', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/polaris-text-field-test.js
+++ b/tests/integration/components/polaris-text-field-test.js
@@ -1,3 +1,4 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import {
@@ -8,7 +9,6 @@ import {
   blur,
   click,
 } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
 const label = 'Text field label';

--- a/tests/integration/components/polaris-text-style-test.js
+++ b/tests/integration/components/polaris-text-style-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, find } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | polaris text style', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/polaris-thumbnail-test.js
+++ b/tests/integration/components/polaris-thumbnail-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 
 module('Integration | Component | polaris thumbnail', function (hooks) {

--- a/tests/integration/components/polaris-unstyled-link-test.js
+++ b/tests/integration/components/polaris-unstyled-link-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | polaris-unstyled-link', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/polaris-visually-hidden-test.js
+++ b/tests/integration/components/polaris-visually-hidden-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | polaris visually hidden', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/render-content-test.js
+++ b/tests/integration/components/render-content-test.js
@@ -1,8 +1,8 @@
+import { hbs } from 'ember-cli-htmlbars';
 import Component from '@ember/component';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | render-content', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/wrapper-element-test.js
+++ b/tests/integration/components/wrapper-element-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | wrapper-element', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/helpers/is-component-definition-test.js
+++ b/tests/integration/helpers/is-component-definition-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Helper | is-component-definition', function (hooks) {
   setupRenderingTest(hooks);


### PR DESCRIPTION
Starts using `ember-cli-htmlbars` instead of the deprecated
`htmlbars-inline-precompile`.  Changes are the result of running the
[codemod](https://github.com/ember-codemods/ember-cli-htmlbars-inline-precompile-codemod)