### PR TITLE
Upgrade ember-keyboard to v6

### DIFF
--- a/addon/components/key-event-listener.js
+++ b/addon/components/key-event-listener.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { assert } from '@ember/debug';
+import { assert, deprecate } from '@ember/debug';
 import { isPresent } from '@ember/utils';
 import {
   EKMixin,
@@ -61,6 +61,16 @@ export default Component.extend(EKMixin, EKOnInsertMixin, {
 
   init() {
     this._super(...arguments);
+
+    deprecate(
+      `[KeyEventListener] This component is deprecated! Please use ember-keyboard modifiers instead!`,
+      false,
+      {
+        id: 'ember-polaris.key-event-listener',
+        until: '7.0.0',
+      }
+    );
+
     assert(
       'ember-polaris::key-event-listener `key` should be passed',
       isPresent(this.key)

--- a/addon/components/polaris-pagination.js
+++ b/addon/components/polaris-pagination.js
@@ -91,17 +91,19 @@ export default class PolarisPagination extends Component {
    * Callback when next button is clicked
    *
    * @type {function}
+   * @default no-op
    * @public
    */
-  onNext;
+  onNext() {}
 
   /**
    * Callback when previous button is clicked
    *
    * @type {function}
+   * @default no-op
    * @public
    */
-  onPrevious;
+  onPrevious() {}
 
   handleMouseUpByBlurring = handleMouseUpByBlurring;
 

--- a/addon/components/polaris-pagination.js
+++ b/addon/components/polaris-pagination.js
@@ -91,19 +91,17 @@ export default class PolarisPagination extends Component {
    * Callback when next button is clicked
    *
    * @type {function}
-   * @default no-op
    * @public
    */
-  onNext() {}
+  onNext;
 
   /**
    * Callback when previous button is clicked
    *
    * @type {function}
-   * @default no-op
    * @public
    */
-  onPrevious() {}
+  onPrevious;
 
   handleMouseUpByBlurring = handleMouseUpByBlurring;
 

--- a/addon/templates/components/polaris-choice-list.hbs
+++ b/addon/templates/components/polaris-choice-list.hbs
@@ -15,7 +15,7 @@
   <ul data-test-choice-list-choices class="Polaris-ChoiceList__Choices">
     {{#each this.checkedChoices as |choice|}}
       <li data-test-choice-list-item>
-        {{#let this.controlComponent as |Control|}}
+        {{#let (component this.controlComponent) as |Control|}}
           <Control
             @label={{choice.label}}
             @value={{choice.value}}

--- a/addon/templates/components/polaris-pagination.hbs
+++ b/addon/templates/components/polaris-pagination.hbs
@@ -9,7 +9,7 @@
     aria-label="Previous"
     type="button"
     disabled={{this.isPreviousDisabled}}
-    {{on "click" (or @onPrevious this.onPrevious)}}
+    {{on "click" @onPrevious}}
     {{on "mouseup" this.handleMouseUpByBlurring}}
   >
     <PolarisIcon @source="arrow-left" />
@@ -21,7 +21,7 @@
     aria-label="Next"
     type="button"
     disabled={{this.isNextDisabled}}
-    {{on "click" (or @onNext this.onNext)}}
+    {{on "click" @onNext}}
     {{on "mouseup" this.handleMouseUpByBlurring}}
   >
     <PolarisIcon @source="arrow-right" />
@@ -29,13 +29,13 @@
 
   {{#if this.isPreviousKeyListenerEnabled}}
     {{#each @previousKeys as |key|}}
-      <KeyEventListener @key={{key}} @onKeyUp={{fn (or @onPrevious this.onPrevious)}} />
+      {{on-key key @onPrevious event="keyup"}}
     {{/each}}
   {{/if}}
 
   {{#if this.isNextKeyListenerEnabled}}
     {{#each @nextKeys as |key|}}
-      <KeyEventListener @key={{key}} @onKeyUp={{fn (or @onNext this.onNext)}} />
+      {{on-key key @onNext event="keyup"}}
     {{/each}}
   {{/if}}
 </nav>

--- a/addon/templates/components/polaris-pagination.hbs
+++ b/addon/templates/components/polaris-pagination.hbs
@@ -9,7 +9,7 @@
     aria-label="Previous"
     type="button"
     disabled={{this.isPreviousDisabled}}
-    {{on "click" @onPrevious}}
+    {{on "click" (or @onPrevious this.onPrevious)}}
     {{on "mouseup" this.handleMouseUpByBlurring}}
   >
     <PolarisIcon @source="arrow-left" />
@@ -21,7 +21,7 @@
     aria-label="Next"
     type="button"
     disabled={{this.isNextDisabled}}
-    {{on "click" @onNext}}
+    {{on "click" (or @onNext this.onNext)}}
     {{on "mouseup" this.handleMouseUpByBlurring}}
   >
     <PolarisIcon @source="arrow-right" />

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "ember-element-helper": "^0.3.1",
     "ember-event-helpers": "^0.1.0",
     "ember-invoke-action": "^1.5.1",
-    "ember-keyboard": "^5.0.0",
+    "ember-keyboard": "^6.0.1",
     "ember-lifeline": "^4.1.5",
     "ember-render-detector": "^1.0.0",
     "ember-svg-jar": "^2.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -161,7 +161,7 @@
     "@babel/helper-replace-supers" "^7.10.1"
     "@babel/helper-split-export-declaration" "^7.10.1"
 
-"@babel/helper-create-class-features-plugin@^7.10.4", "@babel/helper-create-class-features-plugin@^7.10.5":
+"@babel/helper-create-class-features-plugin@^7.10.4", "@babel/helper-create-class-features-plugin@^7.10.5", "@babel/helper-create-class-features-plugin@^7.8.3":
   version "7.10.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.5.tgz#9f61446ba80e8240b0a5c85c6fdac8459d6f259d"
   integrity sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==
@@ -626,7 +626,7 @@
     "@babel/helper-plugin-utils" "^7.10.1"
     "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
 
-"@babel/plugin-proposal-nullish-coalescing-operator@^7.10.4":
+"@babel/plugin-proposal-nullish-coalescing-operator@^7.10.4", "@babel/plugin-proposal-nullish-coalescing-operator@^7.4.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.10.4.tgz#02a7e961fc32e6d5b2db0649e01bf80ddee7e04a"
   integrity sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==
@@ -650,7 +650,7 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-numeric-separator" "^7.10.4"
 
-"@babel/plugin-proposal-object-rest-spread@^7.10.1", "@babel/plugin-proposal-object-rest-spread@^7.3.1":
+"@babel/plugin-proposal-object-rest-spread@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.10.1.tgz#cba44908ac9f142650b4a65b8aa06bf3478d5fb6"
   integrity sha512-Z+Qri55KiQkHh7Fc4BW6o+QBuTagbOp9txE+4U1i79u9oWlf2npkiDx+Rf3iK3lbcHBuNy9UOkwuR5wOMH3LIQ==
@@ -692,7 +692,7 @@
     "@babel/helper-plugin-utils" "^7.10.1"
     "@babel/plugin-syntax-optional-chaining" "^7.8.0"
 
-"@babel/plugin-proposal-optional-chaining@^7.11.0":
+"@babel/plugin-proposal-optional-chaining@^7.11.0", "@babel/plugin-proposal-optional-chaining@^7.6.0":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.11.0.tgz#de5866d0646f6afdaab8a566382fe3a221755076"
   integrity sha512-v9fZIu3Y8562RRwhm1BbMRxtqZNFmFA2EG+pT2diuU8PT3H6T/KXoZ54KgYisfOFZHV6PfvAiBIZ9Rcz+/JCxA==
@@ -859,7 +859,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.1"
 
-"@babel/plugin-syntax-typescript@^7.10.4":
+"@babel/plugin-syntax-typescript@^7.10.4", "@babel/plugin-syntax-typescript@^7.8.3":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.10.4.tgz#2f55e770d3501e83af217d782cb7517d7bb34d25"
   integrity sha512-oSAEz1YkBCAKr5Yiq8/BNtvSAPwkp/IyUnwZogd8p+F0RuYQQrLeRUzIQhueQTTBy/F+a40uS7OFKxnkRvmvFQ==
@@ -1399,6 +1399,15 @@
     "@babel/helper-create-class-features-plugin" "^7.5.5"
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-typescript" "^7.2.0"
+
+"@babel/plugin-transform-typescript@~7.8.0":
+  version "7.8.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.8.7.tgz#48bccff331108a7b3a28c3a4adc89e036dc3efda"
+  integrity sha512-7O0UsPQVNKqpHeHLpfvOG4uXmlw+MOxYvUv6Otc9uH5SYMIxvF6eBdjkWvC3f9G+VXe0RsNExyAQBeTRug/wqQ==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.8.3"
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-syntax-typescript" "^7.8.3"
 
 "@babel/plugin-transform-unicode-escapes@^7.10.1":
   version "7.10.1"
@@ -6072,7 +6081,7 @@ ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.16.0, ember-cli-babel@^6.6.0, 
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.11.0, ember-cli-babel@^7.11.1, ember-cli-babel@^7.12.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.17.2, ember-cli-babel@^7.19.0, ember-cli-babel@^7.2.0, ember-cli-babel@^7.4.1, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.11.0, ember-cli-babel@^7.11.1, ember-cli-babel@^7.12.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.17.2, ember-cli-babel@^7.19.0, ember-cli-babel@^7.2.0, ember-cli-babel@^7.7.3:
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.21.0.tgz#c79e888876aee87dfc3260aee7cb580b74264bbc"
   integrity sha512-jHVi9melAibo0DrAG3GAxid+29xEyjBoU53652B4qcu3Xp58feZGTH/JGXovH7TjvbeNn65zgNyoV3bk1onULw==
@@ -6413,6 +6422,26 @@ ember-cli-typescript@^2.0.0, ember-cli-typescript@^2.0.2:
     stagehand "^1.0.0"
     walk-sync "^1.0.0"
 
+ember-cli-typescript@^3.1.3:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-3.1.4.tgz#21d6ccd670d1f2e34c9cce68c6e32c442f46806b"
+  integrity sha512-HJ73kL45OGRmIkPhBNFt31I1SGUvdZND+LCH21+qpq3pPlFpJG8GORyXpP+2ze8PbnITNLzwe5AwUrpyuRswdQ==
+  dependencies:
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.4.4"
+    "@babel/plugin-proposal-optional-chaining" "^7.6.0"
+    "@babel/plugin-transform-typescript" "~7.8.0"
+    ansi-to-html "^0.6.6"
+    broccoli-stew "^3.0.0"
+    debug "^4.0.0"
+    ember-cli-babel-plugin-helpers "^1.0.0"
+    execa "^3.0.0"
+    fs-extra "^8.0.0"
+    resolve "^1.5.0"
+    rsvp "^4.8.1"
+    semver "^6.3.0"
+    stagehand "^1.0.0"
+    walk-sync "^2.0.0"
+
 ember-cli-uglify@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-uglify/-/ember-cli-uglify-3.0.0.tgz#8819665b2cc5fe70e3ba9fe7a94645209bc42fd6"
@@ -6592,6 +6621,15 @@ ember-decorators@^6.1.1:
     "@ember-decorators/object" "^6.1.1"
     ember-cli-babel "^7.7.3"
 
+ember-destroyable-polyfill@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/ember-destroyable-polyfill/-/ember-destroyable-polyfill-2.0.2.tgz#2cc7532bd3c00e351b4da9b7fc683f4daff79671"
+  integrity sha512-9t+ya+9c+FkNM5IAyJIv6ETG8jfZQaUnFCO5SeLlV0wkSw7TOexyb61jh5GVee0KmknfRhrRGGAyT4Y0TwkZ+w==
+  dependencies:
+    ember-cli-babel "^7.22.1"
+    ember-cli-version-checker "^5.1.1"
+    ember-compatibility-helpers "^1.2.1"
+
 ember-disable-prototype-extensions@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz#1969135217654b5e278f9fe2d9d4e49b5720329e"
@@ -6625,13 +6663,15 @@ ember-invoke-action@^1.5.1:
   dependencies:
     ember-cli-babel "^6.6.0"
 
-ember-keyboard@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/ember-keyboard/-/ember-keyboard-5.0.0.tgz#a8ffd949c392b854d094f756116c063070e3ce63"
-  integrity sha512-ahWioA5ek1MU8JayyzowCiRQWRGXfqYTJPFOpxJsTDQmjpUm3HpQHVXmqZXy6wEPnRnhyngRpPbU5/K8cW0CMg==
+ember-keyboard@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/ember-keyboard/-/ember-keyboard-6.0.1.tgz#2e806c92f36ec9a8a85064ca246e23eb11245dae"
+  integrity sha512-PXWwulXbRHxKOvNCuDmFqX7UEiVrCFKKIcxz+Wxv05GYs2pbvbrW97bKzesRjwrSuNYxSYV9+KnDFpeWahYYKg==
   dependencies:
-    "@babel/plugin-proposal-object-rest-spread" "^7.3.1"
-    ember-cli-babel "^7.4.1"
+    ember-cli-babel "^7.19.0"
+    ember-cli-htmlbars "^5.3.1"
+    ember-compatibility-helpers "^1.2.1"
+    ember-modifier "^2.1.0"
 
 ember-lifeline@^4.1.5:
   version "4.1.5"
@@ -6666,7 +6706,7 @@ ember-maybe-in-element@^0.2.0:
   dependencies:
     ember-cli-babel "^7.1.0"
 
-ember-modifier-manager-polyfill@^1.1.0:
+ember-modifier-manager-polyfill@^1.1.0, ember-modifier-manager-polyfill@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz#cf4444e11a42ac84f5c8badd85e635df57565dda"
   integrity sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==
@@ -6674,6 +6714,18 @@ ember-modifier-manager-polyfill@^1.1.0:
     ember-cli-babel "^7.10.0"
     ember-cli-version-checker "^2.1.2"
     ember-compatibility-helpers "^1.2.0"
+
+ember-modifier@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ember-modifier/-/ember-modifier-2.1.1.tgz#aa3a12e2d6cf1622f774f3f1eab4880982a43fa9"
+  integrity sha512-g9mcpFWgw5lgNU40YNf0USNWqoGTJ+EqjDQKjm7556gaRNDeGnLylFKqx9O3opwLHEt6ZODnRDy9U0S5YEMREg==
+  dependencies:
+    ember-cli-babel "^7.22.1"
+    ember-cli-normalize-entity-name "^1.0.0"
+    ember-cli-string-utils "^1.1.0"
+    ember-cli-typescript "^3.1.3"
+    ember-destroyable-polyfill "^2.0.2"
+    ember-modifier-manager-polyfill "^1.2.0"
 
 ember-qunit@4.6.0:
   version "4.6.0"
@@ -7337,6 +7389,22 @@ execa@^2.0.0:
     is-stream "^2.0.0"
     merge-stream "^2.0.0"
     npm-run-path "^3.0.0"
+    onetime "^5.1.0"
+    p-finally "^2.0.0"
+    signal-exit "^3.0.2"
+    strip-final-newline "^2.0.0"
+
+execa@^3.0.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-3.4.0.tgz#c08ed4550ef65d858fac269ffc8572446f37eb89"
+  integrity sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==
+  dependencies:
+    cross-spawn "^7.0.0"
+    get-stream "^5.0.0"
+    human-signals "^1.1.1"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.0"
     onetime "^5.1.0"
     p-finally "^2.0.0"
     signal-exit "^3.0.2"


### PR DESCRIPTION
This fixes failing tests on `ember-beta`/`ember-canary`. This is a major
upgrade for `ember-keyboard` because it drops support for Ember pre `3.8`, but we are compatible with
`3.12+`, so not a major for us.

There are still some deprecations, we'll fix these later on.