### PR TITLE
Add support for new design language

### DIFF
--- a/addon/components/polaris-action-list.hbs
+++ b/addon/components/polaris-action-list.hbs
@@ -1,6 +1,9 @@
 {{#let (element (if this.hasMultipleSections "ul" "div")) as |ActionList|}}
-  {{!-- TODO #polaris-v5-newDesignLanguage add newDesignLanguage styles --}}
-  <ActionList data-test-action-list class="Polaris-ActionList" ...attributes>
+  <ActionList
+    data-test-action-list
+    class="Polaris-ActionList {{if this.polaris.features.newDesignLanguage "Polaris-ActionList--newDesignLanguage"}}"
+    ...attributes
+  >
     {{#each this.finalSections as |section|}}
       <PolarisActionList::Section
         @section={{section}}

--- a/addon/components/polaris-action-list.js
+++ b/addon/components/polaris-action-list.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { gt } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
 
 /**
  * Polaris action list component.
@@ -8,6 +9,8 @@ import { gt } from '@ember/object/computed';
  * @version 5.6.0
  */
 export default class PolarisActionListComponent extends Component {
+  @service('polaris-app-provider') polaris;
+
   /**
    * Collection of actions for list
    * @type {Array}

--- a/addon/components/polaris-action-list/item.js
+++ b/addon/components/polaris-action-list/item.js
@@ -1,7 +1,10 @@
 import Component from '@glimmer/component';
 import { htmlSafe } from '@ember/string';
+import { inject as service } from '@ember/service';
 
 export default class PolarisActionListItem extends Component {
+  @service('polaris-app-provider') polaris;
+
   /**
    * Visually hidden text for screen readers
    * @type: {String}
@@ -115,8 +118,9 @@ export default class PolarisActionListItem extends Component {
     if (active) {
       cssClasses.push('Polaris-ActionList--active');
     }
-    // TODO #polaris-v5-newDesignLanguage add newDesignLanguage styles
-
+    if (this.polaris.features.newDesignLanguage) {
+      cssClasses.push('Polaris-ActionList--newDesignLanguage');
+    }
     return cssClasses.join(' ');
   }
 

--- a/addon/components/polaris-action-list/section.hbs
+++ b/addon/components/polaris-action-list/section.hbs
@@ -10,8 +10,11 @@
         </p>
       {{/if}}
 
-      {{!-- TODO #polaris-v5-newDesignLanguage add newDesignLanguage styles --}}
-      <ul class="Polaris-ActionList__Actions" data-test-action-list-section-actions role={{this.sectionRole}}>
+      <ul
+        class="Polaris-ActionList__Actions {{if this.polaris.features.newDesignLanguage "Polaris-ActionList--newDesignLanguage"}}"
+        data-test-action-list-section-actions
+        role={{this.sectionRole}}
+      >
         {{#each @section.items as |item|}}
           <PolarisActionList::Item
             {{!-- TODO we should be able to match React impl and use `content` here  --}}

--- a/addon/components/polaris-action-list/section.js
+++ b/addon/components/polaris-action-list/section.js
@@ -1,7 +1,10 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default class PolarisActionListSection extends Component {
+  @service('polaris-app-provider') polaris;
+
   /**
    * Section action item
    *

--- a/addon/components/polaris-icon.js
+++ b/addon/components/polaris-icon.js
@@ -1,6 +1,8 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { classify } from '@ember/string';
+import { inject as service } from '@ember/service';
+import { isNewDesignLanguageColor } from '@smile-io/ember-polaris/utils/color-new-design-language';
 
 const COLORS_WITH_BACKDROPS = [
   'blueDark',
@@ -14,6 +16,8 @@ const COLORS_WITH_BACKDROPS = [
 ];
 
 export default class PolarisIconComponent extends Component {
+  @service('polaris-app-provider') polaris;
+
   /**
    * The SVG contents to display in the icon
    * If the source doesn't have a slash in the name, it will look for Polaris
@@ -64,7 +68,9 @@ export default class PolarisIconComponent extends Component {
     if (this.args.backdrop) {
       cssClasses.push('Polaris-Icon--hasBackdrop');
     }
-    // TODO #polaris-v5-newDesignLanguage add newDesignLanguage styles
+    if (this.polaris.features.newDesignLanguage) {
+      cssClasses.push('Polaris-Icon--newDesignLanguage');
+    }
 
     return cssClasses.join(' ');
   }
@@ -96,22 +102,22 @@ export default class PolarisIconComponent extends Component {
       );
     }
 
-    // TODO #polaris-v5-newDesignLanguage
-    // if (color && !newDesignLanguage && isNewDesignLanguageColor(color)) {
-    //   console.warn(
-    //     '[PolarisIcon] You have selected a color meant to be used in the new design language but new design language is not enabled.'
-    //   );
-    // }
+    const { newDesignLanguage } = this.polaris.features;
+    if (color && !newDesignLanguage && isNewDesignLanguageColor(color)) {
+      console.warn(
+        '[PolarisIcon] You have selected a color meant to be used in the new design language but new design language is not enabled.'
+      );
+    }
 
-    // if (
-    //   color &&
-    //   this.sourceType === 'external' &&
-    //   newDesignLanguage === true &&
-    //   isNewDesignLanguageColor(color)
-    // ) {
-    //   console.warn(
-    //     '[PolarisIcon] Recoloring external SVGs is not supported with colors in the new design language. Set the intended color on your SVG instead.'
-    //   );
-    // }
+    if (
+      color &&
+      this.sourceType === 'external' &&
+      newDesignLanguage === true &&
+      isNewDesignLanguageColor(color)
+    ) {
+      console.warn(
+        '[PolarisIcon] Recoloring external SVGs is not supported with colors in the new design language. Set the intended color on your SVG instead.'
+      );
+    }
   }
 }

--- a/addon/services/polaris-app-provider.js
+++ b/addon/services/polaris-app-provider.js
@@ -1,0 +1,15 @@
+import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class PolarisAppProviderService extends Service {
+  @tracked _features = { newDesignLanguage: false };
+
+  get features() {
+    console.log(this._features, 'get features');
+    return this._features;
+  }
+  set features(features = {}) {
+    console.log('setting features');
+    this._features = { ...this._features, ...features };
+  }
+}

--- a/addon/services/polaris-app-provider.js
+++ b/addon/services/polaris-app-provider.js
@@ -5,11 +5,9 @@ export default class PolarisAppProviderService extends Service {
   @tracked _features = { newDesignLanguage: false };
 
   get features() {
-    console.log(this._features, 'get features');
     return this._features;
   }
   set features(features = {}) {
-    console.log('setting features');
     this._features = { ...this._features, ...features };
   }
 }

--- a/addon/utils/color-new-design-language.js
+++ b/addon/utils/color-new-design-language.js
@@ -1,0 +1,13 @@
+var NEW_DESIGN_LANGUAGE_COLORS = [
+  'base',
+  'subdued',
+  'critical',
+  'warning',
+  'highlight',
+  'success',
+  'primary',
+];
+
+export function isNewDesignLanguageColor(color) {
+  return NEW_DESIGN_LANGUAGE_COLORS.includes(color);
+}

--- a/app/services/polaris-app-provider.js
+++ b/app/services/polaris-app-provider.js
@@ -1,0 +1,1 @@
+export { default } from '@smile-io/ember-polaris/services/polaris-app-provider';

--- a/app/utils/color-new-design-language.js
+++ b/app/utils/color-new-design-language.js
@@ -1,0 +1,1 @@
+export { default } from '@smile-io/ember-polaris/utils/color-new-design-language';

--- a/tests/integration/components/polaris-action-list-test.js
+++ b/tests/integration/components/polaris-action-list-test.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, render } from '@ember/test-helpers';
+import { click, render, settled } from '@ember/test-helpers';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 import { capitalize } from '@ember/string';
 import { matchesIcon } from '../../helpers/matches-icon';
@@ -428,6 +428,61 @@ module('Integration | Component | polaris action list', function (hooks) {
       });
 
       await click(actionListItemLinkSelector);
+    });
+
+    module('newDesignLanguage', function () {
+      test('it supports newDesignLanguage', async function (assert) {
+        await render(
+          hbs`<PolarisActionList
+            @items={{array (hash text="Add discount")}}
+            @sections={{array (hash items=(array (hash text="Section")))}}
+          />`
+        );
+
+        assert
+          .dom(actionListSelector)
+          .doesNotHaveClass(
+            'Polaris-ActionList--newDesignLanguage',
+            'when newDesignLanguage is false does not add --newDesignLanguage class'
+          );
+        assert
+          .dom(actionListItemButtonSelector)
+          .doesNotHaveClass(
+            'Polaris-ActionList--newDesignLanguage',
+            'when newDesignLanguage is false does not add --newDesignLanguage class'
+          );
+        assert
+          .dom(actionListSectionActionsSelector)
+          .doesNotHaveClass(
+            'Polaris-ActionList--newDesignLanguage',
+            'when newDesignLanguage is false does not add --newDesignLanguage class'
+          );
+
+        this.appProviderService = this.owner.lookup(
+          'service:polaris-app-provider'
+        );
+        this.appProviderService.features = { newDesignLanguage: true };
+
+        await settled();
+        assert
+          .dom(actionListSelector)
+          .hasClass(
+            'Polaris-ActionList--newDesignLanguage',
+            'when newDesignLanguage is true adds --newDesignLanguage class'
+          );
+        assert
+          .dom(actionListItemButtonSelector)
+          .hasClass(
+            'Polaris-ActionList--newDesignLanguage',
+            'when newDesignLanguage is true adds --newDesignLanguage class'
+          );
+        assert
+          .dom(actionListSectionActionsSelector)
+          .hasClass(
+            'Polaris-ActionList--newDesignLanguage',
+            'when newDesignLanguage is true adds --newDesignLanguage class'
+          );
+      });
     });
   });
 

--- a/tests/integration/components/polaris-icon-test.js
+++ b/tests/integration/components/polaris-icon-test.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, settled } from '@ember/test-helpers';
 import { classify } from '@ember/string';
 import buildNestedSelector from '../../helpers/build-nested-selector';
 import { matchesIcon } from '../../helpers/matches-icon';
@@ -27,25 +27,47 @@ module('Integration | Component | polaris icon', function (hooks) {
       <PolarisIcon @source="placeholder" />
     `);
 
-    assert.dom(iconSelector).exists('renders the icon');
     assert
       .dom(iconSelector)
+      .exists('renders the icon')
       .doesNotHaveClass(
         'Polaris-Icon--isColored',
         'without @color has no isColored class'
-      );
-    assert
-      .dom(iconSelector)
+      )
       .doesNotHaveClass(
         /Polaris-Icon--color/,
         'without @color has no color class'
-      );
-    assert
-      .dom(iconSelector)
+      )
       .doesNotHaveClass(
         'Polaris-Icon--hasBackdrop',
         'without @backdrop has no hasBackdrop class'
       );
+  });
+
+  module('newDesignLanguage', function () {
+    test('it supports newDesignLanguage', async function (assert) {
+      await render(hbs`<PolarisIcon @source="placeholder" />`);
+
+      assert
+        .dom(iconSelector)
+        .doesNotHaveClass(
+          'Polaris-Icon--newDesignLanguage',
+          'when newDesignLanguage is false does not add --newDesignLanguage class'
+        );
+
+      this.appProviderService = this.owner.lookup(
+        'service:polaris-app-provider'
+      );
+      this.appProviderService.features = { newDesignLanguage: true };
+
+      await settled();
+      assert
+        .dom(iconSelector)
+        .hasClass(
+          'Polaris-Icon--newDesignLanguage',
+          'when newDesignLanguage is true adds --newDesignLanguage class'
+        );
+    });
   });
 
   module('@source', function () {
@@ -57,45 +79,39 @@ module('Integration | Component | polaris icon', function (hooks) {
     test('when set to an svg-jar ID', async function (assert) {
       await render(hbs`<PolarisIcon @source="NoteMinor" />`);
 
-      assert.dom(svgSelector).exists('it renders as a SVG element');
-      assert.ok(matchesIcon(iconSelector, 'NoteMinor'), 'renders correct icon');
       assert
         .dom(svgSelector)
+        .exists('it renders as a SVG element')
         .hasAttribute(
           'focusable',
           'false',
           'applies focusable:false to the SVG element'
-        );
-      assert
-        .dom(svgSelector)
+        )
         .hasAttribute(
           'aria-hidden',
           'true',
           'applies aria-hidden to the SVG element'
         );
+      assert.ok(matchesIcon(iconSelector, 'NoteMinor'), 'renders correct icon');
     });
 
     test('when set to an untrusted SVG element string', async function (assert) {
       this.svg = svg;
       await render(hbs`<PolarisIcon @source={{this.svg}} />`);
 
-      assert.dom(imageSelector).exists('it renders the SVG as an image');
       assert
         .dom(imageSelector)
+        .exists('it renders the SVG as an image')
         .hasAttribute(
           'src',
           `data:image/svg+xml;utf8,${this.svg}`,
           'sets `src` correctly on the SVG image'
-        );
-      assert
-        .dom(imageSelector)
+        )
         .hasAttribute(
           'aria-hidden',
           'true',
           'sets `aria-hidden` on the SVG image'
-        );
-      assert
-        .dom(imageSelector)
+        )
         .hasAttribute('alt', '', 'sets `alt` on the SVG image');
     });
   });
@@ -110,9 +126,7 @@ module('Integration | Component | polaris icon', function (hooks) {
       .doesNotHaveClass(
         'Polaris-Icon--isColored',
         'without @color has no isColored class'
-      );
-    assert
-      .dom(iconSelector)
+      )
       .doesNotHaveClass(
         'Polaris-Icon--hasBackdrop',
         'without @backdrop has no hasBackdrop class'
@@ -121,9 +135,7 @@ module('Integration | Component | polaris icon', function (hooks) {
     this.set('color', 'blue');
     assert
       .dom(iconSelector)
-      .hasClass('Polaris-Icon--isColored', 'with @color adds isColored class');
-    assert
-      .dom(iconSelector)
+      .hasClass('Polaris-Icon--isColored', 'with @color adds isColored class')
       .hasClass(
         `Polaris-Icon--color${classify(this.color)}`,
         'with @color adds color-specific class'


### PR DESCRIPTION
Adds `polaris-app-provider` service that we use to have support for the
`newDesignLanguage`. Kind of equivalent to `polaris-react`'s `AppProvider`
component, but minimal implementation for features only for now.

**NOTE** It's just a plain service for now, likely we'll want to allow setting this by the consuming app through config to make life easier, but we can do that later