### PR TITLE
Explicitly pass action to polaris page action

### DIFF
--- a/addon/templates/components/polaris-page/header/action-group.hbs
+++ b/addon/templates/components/polaris-page/header/action-group.hbs
@@ -5,6 +5,7 @@
         @disclosure={{true}}
         @icon={{@icon}}
         @text={{@title}}
+        @onAction={{action popover.toggle}}
       />
     </popover.activator>
 


### PR DESCRIPTION
The polaris action group didn't pass an `onAction` to the underlying `PolarisPage::Action` component and was relying on event bubbling for the popover's activator to work. With some recent changes to stop event propagation in that component, this stopped working. So this PR adds an implicit `onAction` parameter so that we don't run into any surprises in the future.

Testing: verified that the functionality was broken on master by looking at the dummy app & validated that it works as expected with this change.