### PR TITLE
Remove usage of deprecated getCode function from ember-keyboard

### DIFF
--- a/addon/components/polaris-text-field.js
+++ b/addon/components/polaris-text-field.js
@@ -6,7 +6,6 @@ import { htmlSafe } from '@ember/string';
 import { typeOf, isPresent } from '@ember/utils';
 import { deprecate } from '@ember/application/deprecations';
 import { tagName, layout } from '@ember-decorators/component';
-import { getCode } from 'ember-keyboard';
 import { runTask, cancelTask } from 'ember-lifeline';
 import template from '../templates/components/polaris-text-field';
 import { normalizeAutoCompleteProperty } from '../utils/normalize-auto-complete';
@@ -623,13 +622,13 @@ export default class PolarisTextField extends Component {
 
   @action
   handleKeyPress(event) {
-    let { key } = event;
+    let { key, which } = event;
     let numbersSpec = /[\d.eE+-]$/;
 
     if (
       this.type !== 'number' ||
-      getCode(event) === 'Enter' ||
-      key.match(numbersSpec)
+      which === 13 /* Enter key */ ||
+      numbersSpec.test(key)
     ) {
       return;
     }


### PR DESCRIPTION
Removes our previous usage of `getCode` from `ember-keyboard` in the `PolarisTextField` component to prevent an error being thrown when typing values into numeric text fields.