### PR TITLE
Fix broken Glimmer component detection

### DIFF
--- a/addon/helpers/is-component-definition.js
+++ b/addon/helpers/is-component-definition.js
@@ -7,10 +7,23 @@ export function isComponentDefinition(content) {
     return false;
   }
 
+  // Glimmer now uses Symbol keys in its component definitions so we check those first.
+  let symbolPropKeys = Object.getOwnPropertySymbols?.(content);
+  if (symbolPropKeys?.length) {
+    let isGlimmerComponentDefinition = symbolPropKeys.some((symbolPropKey) => {
+      let propValue = content[symbolPropKey];
+      return (
+        propValue &&
+        Object.keys(propValue).some((key) => key === 'ComponentClass')
+      );
+    });
+
+    if (isGlimmerComponentDefinition) {
+      return true;
+    }
+  }
+
   let contentPropNames = Object.keys(content);
-  // This stopped working in Ember 3.17 when it was switched to use a Symbol instead
-  // See https://github.com/glimmerjs/glimmer-vm/blob/master/CHANGELOG.md#v0450-2019-12-18 and
-  // https://github.com/glimmerjs/glimmer-vm/pull/993 for more
   let isPreOctaneComponentDefinition = contentPropNames.some(
     (propName) => propName.indexOf('COMPONENT DEFINITION') > -1
   );

--- a/tests/integration/helpers/is-component-definition-test.js
+++ b/tests/integration/helpers/is-component-definition-test.js
@@ -3,23 +3,49 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 
+function createMockGlimmerComponentDefinition() {
+  return {
+    [Symbol('INNER')]: {
+      name: 'mock-component',
+      ComponentClass: {},
+      template: {},
+      manager: {},
+      state: {},
+    },
+  };
+}
+
 module('Integration | Helper | is-component-definition', function (hooks) {
   setupRenderingTest(hooks);
 
-  // Replace this with your real tests.
-  test('it renders', async function (assert) {
-    this.set('inputValue', '1234');
-
-    await render(hbs`{{if (is-component-definition inputValue) "yes" "no"}}`);
+  test('it detects component definitions correctly', async function (assert) {
+    await render(hbs`{{if (is-component-definition "1234") "yes" "no"}}`);
     assert
       .dom(this.element)
-      .hasText('no', "returns false when it's not a component definition");
+      .hasText(
+        'no',
+        'returns false when passed something other than a component definition'
+      );
 
     await render(
       hbs`{{if (is-component-definition (component "polaris-heading" text="Text")) "yes" "no"}}`
     );
     assert
       .dom(this.element)
-      .hasText('yes', "returns true when it's a component definition");
+      .hasText('yes', 'returns true when passed a component definition');
+
+    this.set(
+      'glimmerComponentDefinition',
+      createMockGlimmerComponentDefinition()
+    );
+    await render(
+      hbs`{{if (is-component-definition this.glimmerComponentDefinition) "yes" "no"}}`
+    );
+    assert
+      .dom(this.element)
+      .hasText(
+        'yes',
+        'returns true when passed a Glimmer component definition'
+      );
   });
 });


### PR DESCRIPTION
At some point, component definitions in production switched to using Symbol keys instead of string keys. This broke our `is-component-definition` helper, which resulted in some breakages elsewhere. This PR adds a rudimentary check for these new-style component definitions.

This is at least the second time that this helper has broken as a result of Ember/Glimmer updates. I'm aware that we should be trying to figure out a way to remove it or make it less brittle/dependent on internals, but for the time being I think this workaround will have to do 😅 

Demo of something now working after this change that was previously broken (the strong part of the help text was previously not updating because it was not receiving updates due to `is-component-definition` returning a false negative):
![prod-1868-fix-component-definition-detection](https://user-images.githubusercontent.com/5737342/104302245-40621580-54d1-11eb-9913-2a1042d10d24.gif)
