### PR TITLE
Update is-component-definition for ember update

### DIFF
--- a/addon/helpers/is-component-definition.js
+++ b/addon/helpers/is-component-definition.js
@@ -12,9 +12,15 @@ export function isComponentDefinition(content) {
   if (symbolPropKeys?.length) {
     let isGlimmerComponentDefinition = symbolPropKeys.some((symbolPropKey) => {
       let propValue = content[symbolPropKey];
+      // The check for `__container__` is due to an update in Ember 3.25.1 where ComponentClass
+      // is no longer a key in the INNER symbol. As far as I can tell the combination of Symbols
+      // and having a `__container__` key is specific only to components. Passing other objects
+      // such as JS objects, Ember objects, hashes, or services, etc, do not share these traits.
       return (
         propValue &&
-        Object.keys(propValue).some((key) => key === 'ComponentClass')
+        Object.keys(propValue).some(
+          (key) => key === 'ComponentClass' || key === '__container__'
+        )
       );
     });
 


### PR DESCRIPTION
This is the result of a conversation [here](https://github.com/smile-io/ember-polaris/pull/704/files#r585980715) where I fixed failing tests for `ember try:one ember-release` for Ember 3.25.1 in a renovate bot PR. We decided to PR this fix separately so it was easier to track.