### PR TITLE
Reduce CI scenarios to Ember latest LTS, release, and beta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,12 +74,9 @@ jobs:
       fail-fast: true
       matrix:
         ember-try-scenario:
-          - ember-lts-3.20
           - ember-lts-3.24
           - ember-release
           - ember-beta
-          - ember-canary
-          - ember-classic
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Removes failing `ember-try` scenarios caused by dependency version issues to make CI green again 🤞 