### PR TITLE
Rename master to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
       - 'v*'
   pull_request:
   schedule:

--- a/docs/resource-list.md
+++ b/docs/resource-list.md
@@ -81,4 +81,4 @@ then use that component with `polaris-resource-list` to render items (using [emb
 }}
 ```
 
-For additional examples, refer to the source code for the [`resource-list` page](https://github.com/smile-io/ember-polaris/blob/master/tests/dummy/app/templates/resource-list.hbs) and associated [components](https://github.com/smile-io/ember-polaris/blob/master/tests/dummy/app/components/resource-list) in the dummy app.
+For additional examples, refer to the source code for the [`resource-list` page](https://github.com/smile-io/ember-polaris/blob/main/tests/dummy/app/templates/resource-list.hbs) and associated [components](https://github.com/smile-io/ember-polaris/blob/main/tests/dummy/app/components/resource-list) in the dummy app.


### PR DESCRIPTION
# Rename master to main

According to [this issue](https://github.com/smile-io/engineering/issues/10), this pull request removes the master branch reference from the config file and updates the URLs of repositories that are already using main.