### PR TITLE
Add changelog generator note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,12 @@ Contributing
 
 See the [Contributing](CONTRIBUTING.md) guide for details.
 
+Release preparation
+------------------------------------------------------------------------------
+
+`ember-polaris` has an automated changelog generator when preparing releases.
+Run `yarn changelog-generator` to generate changelog for the current branch.
+
 
 License
 ------------------------------------------------------------------------------


### PR DESCRIPTION
This info about changelog generation was buried deep in our Slack and seemed worth adding to the README before it gets "expired".