### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @smile-io/merchant-squad-reviewers
+* @smile-io/activation-squad-reviewers


### PR DESCRIPTION
Updating CODEOWNERS as part of the squad iterations rename. I'm going to open a bunch of PRs and then merge them all at the same time when I actually change the GH team names to avoid any "downtime" with automatic PR mapping & review assignment.